### PR TITLE
Use Application.get_env instead of Mix.Config.read

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,17 +3,13 @@ ExUnit.start()
 ExUnit.configure exclude: [integration: true, consumer_group: true]
 
 defmodule TestHelper do
-  def get_bootstrap_hosts do
-    Mix.Config.read!("config/config.exs") |> hd |> elem(1) |> hd |> elem(1)
-  end
-
   def generate_random_string(string_length \\ 20) do
     :random.seed(:os.timestamp)
     Enum.map(1..string_length, fn _ -> (:random.uniform * 25 + 65) |> round end) |> to_string
   end
 
   def uris do
-    Mix.Config.read!("config/config.exs") |> hd |> elem(1) |> hd |> elem(1)
+    Application.get_env(:kafka_ex, :brokers)
   end
 
   def utc_time do


### PR DESCRIPTION
This returns the same value and is The OTP Way to do it.

Also removed the `TestHelper.get_bootstrap_hosts` function that no longer appears to be used.