### PR TITLE
Fix consumer group offset commit

### DIFF
--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -7,6 +7,21 @@ defmodule KafkaEx.Protocol.Offset do
   defmodule Response do
     defstruct topic: "", partition_offsets: []
     @type t :: %Response{topic: binary, partition_offsets: list}
+
+    @doc """
+    Returns the numeric offset of the first partition in the response,
+    or nil if the topic is not found.
+
+    This is a convenience for the most typical case.
+    """
+    @spec first_partition_offset(atom | t) :: number | nil
+    def first_partition_offset(:topic_not_found) do
+      nil
+    end
+    def first_partition_offset([%Response{partition_offsets: partition_offsets}]) do
+      first_partition = hd(partition_offsets)
+      first_partition.offset |> hd
+    end
   end
 
   def create_request(correlation_id, client_id, topic, partition, time) do

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -7,21 +7,6 @@ defmodule KafkaEx.Protocol.Offset do
   defmodule Response do
     defstruct topic: "", partition_offsets: []
     @type t :: %Response{topic: binary, partition_offsets: list}
-
-    @doc """
-    Returns the numeric offset of the first partition in the response,
-    or nil if the topic is not found.
-
-    This is a convenience for the most typical case.
-    """
-    @spec first_partition_offset(atom | t) :: number | nil
-    def first_partition_offset(:topic_not_found) do
-      nil
-    end
-    def first_partition_offset([%Response{partition_offsets: partition_offsets}]) do
-      first_partition = hd(partition_offsets)
-      first_partition.offset |> hd
-    end
   end
 
   def create_request(correlation_id, client_id, topic, partition, time) do

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -289,7 +289,6 @@ defmodule KafkaEx.Server do
   end
 
   defp offset_commit(state, offset_commit_request) do
-    IO.puts(inspect offset_commit_request)
     {broker, state} = case Proto.ConsumerMetadata.Response.broker_for_consumer_group(state.brokers, state.consumer_metadata) do
       nil -> {_, state} = update_consumer_metadata(state, offset_commit_request.consumer_group)
         {Proto.ConsumerMetadata.Response.broker_for_consumer_group(state.brokers, state.consumer_metadata) || hd(state.brokers), state}
@@ -298,14 +297,13 @@ defmodule KafkaEx.Server do
 
     offset_commit_request_payload = Proto.OffsetCommit.create_request(state.correlation_id, @client_id, offset_commit_request)
     response = KafkaEx.NetworkClient.send_sync_request(broker, offset_commit_request_payload) |> Proto.OffsetCommit.parse_response
-    IO.puts(inspect response)
 
     {response, %{state | correlation_id: state.correlation_id+1}}
   end
 
   defp consumer_group(state) do
     if state.consumer_group == false do
-      "kafka_ex"
+      @consumer_group
     else
       state.consumer_group
     end

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -42,17 +42,45 @@ defmodule KafkaEx.ConsumerGroup.Test do
 
   #fetch
   test "fetch auto_commits offset by default" do
-    random_string = generate_random_string
-    KafkaEx.create_worker(:fetch_test_worker)
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
-    offset = KafkaEx.fetch(random_string, 0, offset: 0, worker: :fetch_test_worker) |> hd |> Map.get(:partitions) |> hd |> Map.get(:message_set) |> Enum.reverse |> hd |> Map.get(:offset)
+    worker = :fetch_test_worker
+    topic = "kafka_ex_consumer_group_test"
+    consumer_group = "auto_commit_consumer_group"
+    KafkaEx.create_worker(worker,
+                          uris: Application.get_env(:kafka_ex, :brokers),
+                          consumer_group: consumer_group)
 
-    offset_fetch_response = KafkaEx.offset_fetch(:fetch_test_worker, %Proto.OffsetFetch.Request{topic: random_string}) |> hd
-    error_code = offset_fetch_response.partitions |> hd |> Map.get(:error_code)
-    offset_fetch_response_offset = offset_fetch_response.partitions |> hd |> Map.get(:offset)
+    offset_before = TestHelper.latest_offset_number(topic, 0, worker)
+    Enum.each(1..10, fn _ ->
+      msg = %Proto.Produce.Message{value: "hey #{inspect :os.timestamp}"}
+      KafkaEx.produce(%Proto.Produce.Request{topic: topic,
+                                             partition: 0,
+                                             required_acks: 1,
+                                             messages: [msg]},
+                      worker_name: worker)
+    end)
+
+    offset_after = TestHelper.latest_offset_number(topic, 0, worker)
+    assert offset_after == offset_before + 10
+
+    [logs] = KafkaEx.fetch(topic, 0, offset: offset_before, worker: worker)
+    [partition] = logs.partitions
+    message_set = partition.message_set
+    assert 10 == length(message_set)
+
+    last_message = List.last(message_set)
+    offset_of_last_message = last_message.offset
+
+    offset_request = %Proto.OffsetFetch.Request{topic: topic,
+                                                partition: 0,
+                                                consumer_group: consumer_group}
+
+    [offset_fetch_response] = KafkaEx.offset_fetch(worker, offset_request)
+    [partition] = offset_fetch_response.partitions
+    error_code = partition.error_code
+    offset_fetch_response_offset = partition.offset
 
     assert error_code == 0
-    assert offset == offset_fetch_response_offset
+    assert offset_of_last_message == offset_fetch_response_offset
   end
 
   test "fetch starts consuming from last committed offset" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,4 +16,9 @@ defmodule TestHelper do
     {x, {a,b,c}} = :calendar.local_time |> :calendar.local_time_to_universal_time_dst |> hd
     {x, {a,b,c + 60}}
   end
+
+  def latest_offset_number(topic, partition_id, worker \\ KafkaEx.Server) do
+    KafkaEx.latest_offset(topic, partition_id, worker)
+    |> KafkaEx.Protocol.Offset.Response.first_partition_offset
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,7 +25,9 @@ defmodule TestHelper do
   defp first_partition_offset(:topic_not_found) do
     nil
   end
-  defp first_partition_offset([%Response{partition_offsets: partition_offsets}]) do
+  defp first_partition_offset(response) do
+    [%KafkaEx.Protocol.Offset.Response{partition_offsets: partition_offsets}] =
+      response
     first_partition = hd(partition_offsets)
     first_partition.offset |> hd
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,17 +3,13 @@ ExUnit.start()
 ExUnit.configure exclude: [integration: true, consumer_group: true]
 
 defmodule TestHelper do
-  def get_bootstrap_hosts do
-    Mix.Config.read!("config/config.exs") |> hd |> elem(1) |> hd |> elem(1)
-  end
-
   def generate_random_string(string_length \\ 20) do
     :random.seed(:os.timestamp)
     Enum.map(1..string_length, fn _ -> (:random.uniform * 25 + 65) |> round end) |> to_string
   end
 
   def uris do
-    Mix.Config.read!("config/config.exs") |> hd |> elem(1) |> hd |> elem(1)
+    Application.get_env(:kafka_ex, :brokers)
   end
 
   def utc_time do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,6 +19,14 @@ defmodule TestHelper do
 
   def latest_offset_number(topic, partition_id, worker \\ KafkaEx.Server) do
     KafkaEx.latest_offset(topic, partition_id, worker)
-    |> KafkaEx.Protocol.Offset.Response.first_partition_offset
+    |> first_partition_offset
+  end
+
+  defp first_partition_offset(:topic_not_found) do
+    nil
+  end
+  defp first_partition_offset([%Response{partition_offsets: partition_offsets}]) do
+    first_partition = hd(partition_offsets)
+    first_partition.offset |> hd
   end
 end


### PR DESCRIPTION
This should fix #45 

I changed this one specific test not to use a randomly generated topic name.  I think this is better.  Given time I'd update all of the tests.

I still get one test failing on consumer groups but it was failing before.

```
  1) test fetch does not commit offset with auto_commit is set to false (KafkaEx.ConsumerGroup.Test)
     test/integration/consumer_group_test.exs:102
     ** (ArgumentError) argument error
     stacktrace:
       :erlang.hd([])
       test/integration/consumer_group_test.exs:105
```