### PR TITLE
Allow creating unnamed server workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ iex> KafkaEx.create_worker(:pr, [uris: uris, consumer_group: "kafka_ex", consume
 {:ok, #PID<0.172.0>}
 ```
 
+### Create KafkaEx worker
+
+You may find you want to create many workers, say in conjunction with
+a `poolboy` pool. In this scenario you usually won't want to name these worker processes.
+
+To create an unnamed worked with `create_worker`:
+```elixir
+iex> KafkaEx.create_worker(:no_name) # indicates to the server process not to name the process
+{:ok, #PID<0.171.0>}
+```
+
+To create an unnamed worker directly with the `KafkaEx.Supervisor`:
+```elixir
+iex> worker_init = [] # whatever options you want
+iex> Supervisor.start_child(KafkaEx.Supervisor, [worker_init, :no_name]) # indicates to the server process not to name the process
+{:ok, #PID<0.171.0>}
+```
+
 ### Retrieve kafka metadata
 For all metadata
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ iex> KafkaEx.create_worker(:pr, [uris: uris, consumer_group: "kafka_ex", consume
 {:ok, #PID<0.172.0>}
 ```
 
-### Create KafkaEx worker
+### Create an unnamed KafkaEx worker
 
 You may find you want to create many workers, say in conjunction with
 a `poolboy` pool. In this scenario you usually won't want to name these worker processes.

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -13,8 +13,16 @@ defmodule KafkaEx.Server do
 
   def start_link(args, name \\ __MODULE__)
 
+  def start_link(args, :no_name) do
+    GenServer.start_link(__MODULE__, [args])
+  end
+
   def start_link(args, name) do
     GenServer.start_link(__MODULE__, [args, name], [name: name])
+  end
+
+  def init([args]) do
+    init([args, self])
   end
 
   def init([args, name]) do


### PR DESCRIPTION
Creating named workers is useful but falls down if I want to create a
large group of workers to work with (for instance) a poolboy pool.

This is a very naive attempt at changing as little code as possible to
introduce an atom `:no_name` which will cause the
`KafkaEx.Server.start_link` method to not register any name for the
started process.

I wrote a simple description in the README as well. I'm happy to update
the description or change the implementation per your guidance.

Thanks for the library!