### PR TITLE
Config timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ In your config/config.exs add the list of kafka brokers as below:
 ```elixir
 config :kafka_ex,
   brokers: [{HOST, PORT}],
-  consumer_group: consumer_group #if no consumer_group is specified "kafka_ex" would be used as the default
+  consumer_group: consumer_group, #if no consumer_group is specified "kafka_ex" would be used as the default
+  sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.
 ```
 
 Alternatively from iex:

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -1,7 +1,7 @@
 defmodule KafkaEx do
   use Application
   @type uri() :: [{binary|char_list, number}]
-  @type worker_init :: [{:uris, uri}, {:consumer_group, binary|false}]
+  @type worker_init :: [{:uris, uri}, {:consumer_group, binary|false}, {:sync_timeout, non_neg_integer}]
 
   @doc """
   create_worker creates KafkaEx workers
@@ -10,6 +10,7 @@ defmodule KafkaEx do
   - consumer_group: Name of the group of consumers, `false` should be passed for Kafka < 0.8.2, default is "kafka_ex"
   - metadata_update_interval: How often `kafka_ex` would update the Kafka cluster metadata information in milliseconds, default is 30000
   - consumer_group_update_interval: How often `kafka_ex` would update the Kafka cluster consumer_groups information in milliseconds, default is 30000
+  - sync_timeout: Timeout for synchronous requests to kafka in milliseconds, default is 1000
 
   ## Example
 
@@ -19,6 +20,8 @@ defmodule KafkaEx do
   iex> KafkaEx.create_worker(:pr, uris: [{"localhost", 9092}])
   {:ok, #PID<0.172.0>}
   iex> KafkaEx.create_worker(:pr, [uris: [{"localhost", 9092}], consumer_group: "foo"])
+  {:ok, #PID<0.173.0>}
+  iex> KafkaEx.create_worker(:pr, [uris: [{"localhost", 9092}], consumer_group: "foo", sync_timeout: 2000])
   {:ok, #PID<0.173.0>}
   ```
   """

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -25,7 +25,7 @@ defmodule KafkaEx.NetworkClient do
     end
   end
 
-  def send_sync_request(broker, data, timeout \\ 1000) do
+  def send_sync_request(broker, data, timeout) do
     socket = broker.socket
     :ok = :inet.setopts(socket, [:binary, {:packet, 4}, {:active, false}])
     response = case :gen_tcp.send(socket, data) do

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -63,6 +63,40 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group == "foo"
   end
 
+  test "create_worker provides a default sync_timeout of 1000" do
+    {:ok, pid} = KafkaEx.create_worker(:bif, uris: uris)
+    sync_timeout = :sys.get_state(pid).sync_timeout
+
+    assert sync_timeout == 1000
+  end
+
+  test "create_worker takes a sync_timeout option and sets that as the sync_timeout of the worker" do
+    {:ok, pid} = KafkaEx.create_worker(:babar, [uris: uris, sync_timeout: 2000])
+    sync_timeout = :sys.get_state(pid).sync_timeout
+
+    assert sync_timeout == 2000
+  end
+
+  test "create_worker uses sync_timeout default from config if set" do
+    Application.put_env(:kafka_ex, :sync_timeout, 3000)
+
+    {:ok, pid} = KafkaEx.create_worker(:eve, [uris: uris])
+    sync_timeout = :sys.get_state(pid).sync_timeout
+
+    Application.delete_env(:kafka_ex, :sync_timeout)
+    assert sync_timeout == 3000
+  end
+
+  test "create_worker uses explicit sync_timeout even if set in config" do
+    Application.put_env(:kafka_ex, :sync_timeout, 3000)
+
+    {:ok, pid} = KafkaEx.create_worker(:alice, [uris: uris, sync_timeout: 2000])
+    sync_timeout = :sys.get_state(pid).sync_timeout
+
+    Application.delete_env(:kafka_ex, :sync_timeout)
+    assert sync_timeout == 2000
+  end
+
   #update_metadata
   test "worker updates metadata after specified interval" do
     random_string = generate_random_string


### PR DESCRIPTION
Add a sync_timeout configuration. Defaults to 1000ms which is what it was before. Can be set in the environment config or directly in the worker spec. Worker spec takes precedence over environment. 