### PR TITLE
Remove default values from structs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-- [Fork](https://github.com/jacklund/kafka_ex/fork), then clone the repo: `git clone git@github.com:your-username/kafka_ex.git`
+- [Fork](https://github.com/kafkaex/kafka_ex/fork), then clone the repo: `git clone git@github.com:your-username/kafka_ex.git`
 - Create a feature branch: `git checkout -b feature_branch`
 - Make your changes
 - Make sure the unit tests pass: `mix test --no-start`

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,4 +5,4 @@ use Mix.Config
       {"localhost", 9093},
       {"localhost", 9094},
     ],
-    consumer_group: false
+    consumer_group: "kafka_ex_dev"

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -31,10 +31,10 @@ defmodule KafkaEx do
   def create_worker(name, worker_init \\ [])
 
   def create_worker(name, worker_init) do
-    worker_init = case worker_init do
-      [] -> [uris: Application.get_env(:kafka_ex, :brokers)]
-      _   -> worker_init
-    end
+    defaults = [uris: Application.get_env(:kafka_ex, :brokers),
+                consumer_group: Application.get_env(:kafka_ex, :consumer_group)]
+
+    worker_init = Keyword.merge(defaults, worker_init)
 
     Supervisor.start_child(KafkaEx.Supervisor, [worker_init, name])
   end

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -272,7 +272,7 @@ defmodule KafkaEx do
   def start(_type, _args) do
     {:ok, pid}     = KafkaEx.Supervisor.start_link
     uris           = Application.get_env(:kafka_ex, :brokers)
-    consumer_group = Application.get_env(:kafka_ex, :consumer_group)
+    consumer_group = Application.get_env(:kafka_ex, :consumer_group, "kafka_ex")
     worker_init    = case consumer_group do
       nil            -> [uris: uris]
       consumer_group -> [uris: uris, consumer_group: consumer_group]

--- a/lib/kafka_ex/protocol/consumer_metadata.ex
+++ b/lib/kafka_ex/protocol/consumer_metadata.ex
@@ -1,6 +1,6 @@
 defmodule KafkaEx.Protocol.ConsumerMetadata do
   defmodule Response do
-    defstruct coordinator_id: 0, coordinator_host: "", coordinator_port: 0, error_code: 0
+    defstruct coordinator_id: nil, coordinator_host: nil, coordinator_port: nil, error_code: 0
     @type t :: %Response{coordinator_id: integer, coordinator_host: binary, coordinator_port: 0..65535, error_code: integer}
 
     def broker_for_consumer_group(brokers, consumer_group_metadata) do
@@ -9,7 +9,10 @@ defmodule KafkaEx.Protocol.ConsumerMetadata do
   end
 
   @spec create_request(integer, binary, binary) :: binary
-  def create_request(correlation_id, client_id, consumer_group \\ "kafka_ex") do
+  def create_request(correlation_id, client_id, consumer_group)
+  when is_integer(correlation_id) and correlation_id >= 0
+  and is_binary(client_id) and byte_size(client_id) > 0
+  and is_binary(consumer_group) and byte_size(consumer_group) > 0 do
     KafkaEx.Protocol.create_request(:consumer_metadata, correlation_id, client_id) <> << byte_size(consumer_group) :: 16-signed, consumer_group :: binary >>
   end
 

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -1,11 +1,6 @@
 defmodule KafkaEx.Protocol.Fetch do
-  defmodule Request do
-    defstruct replica_id: -1, max_wait_time: 0, min_bytes: 0, topic_name: "", partition: 0, fetch_offset: 0, max_bytes: 0
-    @type t :: %Request{replica_id: integer, max_wait_time: integer, topic_name: binary, partition: integer, fetch_offset: integer, max_bytes: integer}
-  end
-
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list} 
   end
 

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -39,7 +39,7 @@ defmodule KafkaEx.Protocol.Metadata do
   end
 
   defmodule PartitionMetadata do
-    defstruct error_code: 0, partition_id: 0, leader: -1, replicas: [], isrs: []
+    defstruct error_code: 0, partition_id: nil, leader: -1, replicas: [], isrs: []
   end
 
   def create_request(correlation_id, client_id, ""), do: KafkaEx.Protocol.create_request(:metadata, correlation_id, client_id) <> << 0 :: 32-signed >>

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -1,6 +1,6 @@
 defmodule KafkaEx.Protocol.Metadata do
   defmodule Request do
-    defstruct topic: ""
+    defstruct topic: nil
     @type t :: %Request{topic: binary}
   end
 
@@ -31,11 +31,11 @@ defmodule KafkaEx.Protocol.Metadata do
   end
 
   defmodule Broker do
-    defstruct node_id: 0, host: "", port: 0, socket: nil
+    defstruct node_id: 0, host: nil, port: 0, socket: nil
   end
 
   defmodule TopicMetadata do
-    defstruct error_code: 0, topic: "", partition_metadatas: []
+    defstruct error_code: 0, topic: nil, partition_metadatas: []
   end
 
   defmodule PartitionMetadata do

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -1,11 +1,11 @@
 defmodule KafkaEx.Protocol.Offset do
   defmodule Request do
-    defstruct replica_id: -1, topic_name: "", partition: 0, time: -1, max_number_of_offsets: 1
+    defstruct replica_id: -1, topic_name: nil, partition: 0, time: -1, max_number_of_offsets: 1
     @type t :: %Request{replica_id: integer, topic_name: binary, partition: integer, time: integer, max_number_of_offsets: integer}
   end
 
   defmodule Response do
-    defstruct topic: "", partition_offsets: []
+    defstruct topic: nil, partition_offsets: []
     @type t :: %Response{topic: binary, partition_offsets: list}
   end
 

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -20,10 +20,11 @@ defmodule KafkaEx.Protocol.OffsetCommit do
                        offset: offset})
   when is_binary(topic) and byte_size(topic) > 0
   and is_binary(consumer_group) and byte_size(consumer_group) > 0
-  and is_binary(metadata)
   and is_integer(partition) and partition >= 0
   and is_integer(offset) and offset >= 0 do
-    KafkaEx.Protocol.create_request(:offset_commit, correlation_id, client_id) <> << byte_size(consumer_group) :: 16-signed, offset_commit_request.consumer_group :: binary, 1 :: 32-signed, byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, offset :: 64, byte_size(offset_commit_request.metadata) :: 16-signed, offset_commit_request.metadata :: binary >>
+    # metadata for a commit request is optional - we pass an empty string to omit it
+    metadata = metadata || ""
+    KafkaEx.Protocol.create_request(:offset_commit, correlation_id, client_id) <> << byte_size(consumer_group) :: 16-signed, offset_commit_request.consumer_group :: binary, 1 :: 32-signed, byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, offset :: 64, byte_size(metadata) :: 16-signed, metadata :: binary >>
   end
 
   @spec parse_response(binary) :: [] | [Response.t]

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -1,7 +1,7 @@
 defmodule KafkaEx.Protocol.OffsetCommit do
   defmodule Request do
     defstruct consumer_group: nil, topic: nil, partition: nil, offset: nil, metadata: nil
-    @type t :: %Request{consumer_group: binary, topic: binary, partition: integer, offset: integer}
+    @type t :: %Request{consumer_group: binary, topic: binary, partition: integer, offset: integer, metadata: binary}
   end
 
   defmodule Response do
@@ -16,12 +16,14 @@ defmodule KafkaEx.Protocol.OffsetCommit do
                        topic: topic,
                        partition: partition,
                        consumer_group: consumer_group,
+                       metadata: metadata,
                        offset: offset})
   when is_binary(topic) and byte_size(topic) > 0
   and is_binary(consumer_group) and byte_size(consumer_group) > 0
+  and is_binary(metadata)
   and is_integer(partition) and partition >= 0
   and is_integer(offset) and offset >= 0 do
-    KafkaEx.Protocol.create_request(:offset_commit, correlation_id, client_id) <> << byte_size(offset_commit_request.consumer_group) :: 16-signed, offset_commit_request.consumer_group :: binary, 1 :: 32-signed, byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, offset :: 64, byte_size(offset_commit_request.metadata) :: 16-signed, offset_commit_request.metadata :: binary >>
+    KafkaEx.Protocol.create_request(:offset_commit, correlation_id, client_id) <> << byte_size(consumer_group) :: 16-signed, offset_commit_request.consumer_group :: binary, 1 :: 32-signed, byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, offset :: 64, byte_size(offset_commit_request.metadata) :: 16-signed, offset_commit_request.metadata :: binary >>
   end
 
   @spec parse_response(binary) :: [] | [Response.t]

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -15,8 +15,10 @@ defmodule KafkaEx.Protocol.OffsetCommit do
                      offset_commit_request = %Request{
                        topic: topic,
                        partition: partition,
+                       consumer_group: consumer_group,
                        offset: offset})
   when is_binary(topic) and byte_size(topic) > 0
+  and is_binary(consumer_group) and byte_size(consumer_group) > 0
   and is_integer(partition) and partition >= 0
   and is_integer(offset) and offset >= 0 do
     KafkaEx.Protocol.create_request(:offset_commit, correlation_id, client_id) <> << byte_size(offset_commit_request.consumer_group) :: 16-signed, offset_commit_request.consumer_group :: binary, 1 :: 32-signed, byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, offset :: 64, byte_size(offset_commit_request.metadata) :: 16-signed, offset_commit_request.metadata :: binary >>

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -28,8 +28,10 @@ defmodule KafkaEx.Protocol.OffsetFetch do
                      client_id,
                      offset_fetch_request = %Request{
                        topic: topic,
+                       consumer_group: consumer_group,
                        partition: partition})
   when is_binary(topic) and byte_size(topic) > 0
+  and is_binary(consumer_group) and byte_size(consumer_group) > 0
   and is_integer(partition) and partition >= 0 do
     KafkaEx.Protocol.create_request(:offset_fetch, correlation_id, client_id) <> << byte_size(offset_fetch_request.consumer_group) :: 16-signed, offset_fetch_request.consumer_group :: binary, 1 :: 32-signed, byte_size(offset_fetch_request.topic) :: 16-signed, offset_fetch_request.topic :: binary, 1 :: 32-signed, offset_fetch_request.partition :: 32 >>
   end

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -1,11 +1,11 @@
 defmodule KafkaEx.Protocol.OffsetFetch do
   defmodule Request do
-    defstruct consumer_group: "kafka_ex", topic: "", partition: 0
+    defstruct consumer_group: nil, topic: nil, partition: nil
     @type t :: %Request{consumer_group: binary, topic: binary, partition: integer}
   end
 
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list}
 
     def last_offset(:topic_not_found) do
@@ -24,7 +24,13 @@ defmodule KafkaEx.Protocol.OffsetFetch do
     end
   end
 
-  def create_request(correlation_id, client_id, offset_fetch_request) do
+  def create_request(correlation_id,
+                     client_id,
+                     offset_fetch_request = %Request{
+                       topic: topic,
+                       partition: partition})
+  when is_binary(topic) and byte_size(topic) > 0
+  and is_integer(partition) and partition >= 0 do
     KafkaEx.Protocol.create_request(:offset_fetch, correlation_id, client_id) <> << byte_size(offset_fetch_request.consumer_group) :: 16-signed, offset_fetch_request.consumer_group :: binary, 1 :: 32-signed, byte_size(offset_fetch_request.topic) :: 16-signed, offset_fetch_request.topic :: binary, 1 :: 32-signed, offset_fetch_request.partition :: 32 >>
   end
 

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.Produce do
     - require_acks: indicates how many acknowledgements the servers should receive before responding to the request. If it is 0 the server will not send any response (this is the only case where the server will not reply to a request). If it is 1, the server will wait the data is written to the local log before sending a response. If it is -1 the server will block until the message is committed by all in sync replicas before sending a response. For any number > 1 the server will block waiting for this number of acknowledgements to occur (but the server will never wait for more acknowledgements than there are in-sync replicas), default is 0
     - timeout: provides a maximum time in milliseconds the server can await the receipt of the number of acknowledgements in RequiredAcks, default is 100 milliseconds
     """
-    defstruct topic: nil, partition: 0, required_acks: 0, timeout: 0, compression: :none, messages: []
+    defstruct topic: nil, partition: nil, required_acks: 0, timeout: 0, compression: :none, messages: []
     @type t :: %Request{topic: binary, partition: integer, required_acks: binary, timeout: integer, compression: atom, messages: list}
   end
 

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.Produce do
     - require_acks: indicates how many acknowledgements the servers should receive before responding to the request. If it is 0 the server will not send any response (this is the only case where the server will not reply to a request). If it is 1, the server will wait the data is written to the local log before sending a response. If it is -1 the server will block until the message is committed by all in sync replicas before sending a response. For any number > 1 the server will block waiting for this number of acknowledgements to occur (but the server will never wait for more acknowledgements than there are in-sync replicas), default is 0
     - timeout: provides a maximum time in milliseconds the server can await the receipt of the number of acknowledgements in RequiredAcks, default is 100 milliseconds
     """
-    defstruct topic: "", partition: 0, required_acks: 0, timeout: 0, compression: :none, messages: []
+    defstruct topic: nil, partition: 0, required_acks: 0, timeout: 0, compression: :none, messages: []
     @type t :: %Request{topic: binary, partition: integer, required_acks: binary, timeout: integer, compression: atom, messages: list}
   end
 
@@ -18,7 +18,7 @@ defmodule KafkaEx.Protocol.Produce do
   end
 
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list}
   end
 

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -324,7 +324,7 @@ defmodule KafkaEx.Server do
 
   defp consumer_offset(nil, topic, partition, state) do
     request = %Proto.OffsetFetch.Request{topic: topic,
-                                            partition: partition}
+                                         partition: partition}
 
     {offset_response, state} = consumer_offset_fetch(request, state)
 

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -362,5 +362,5 @@ defmodule KafkaEx.Server do
   end
 
   defp ensure_valid_offset(offset) when offset <= 0, do: 0
-  defp ensure_valid_offset(offset), do: offset
+  defp ensure_valid_offset(offset), do: offset + 1
 end

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -8,7 +8,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "consumer_group_metadata works" do
     random_string = generate_random_string
     pid = Process.whereis(KafkaEx.Server)
-    KafkaEx.produce(%Proto.Produce.Request{topic: "food", required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: "food", partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
     KafkaEx.fetch("food", 0, offset: 0)
     metadata = KafkaEx.consumer_group_metadata(KafkaEx.Server, random_string)
     consumer_group_metadata = :sys.get_state(pid).consumer_metadata
@@ -105,7 +105,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
     topic = generate_random_string
     worker_name = :fetch_no_auto_commit_worker
     KafkaEx.create_worker(worker_name)
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: topic, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: worker_name) end)
+    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: topic, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: worker_name) end)
     offset = KafkaEx.fetch(topic, 0, offset: 0, worker: worker_name, auto_commit: false) |> hd |> Map.get(:partitions) |> hd |> Map.get(:message_set) |> Enum.reverse |> hd |> Map.get(:offset)
     offset_fetch_response = KafkaEx.offset_fetch(worker_name, %Proto.OffsetFetch.Request{topic: topic, partition: 0}) |> hd
     offset_fetch_response_offset = offset_fetch_response.partitions |> hd |> Map.get(:offset)
@@ -117,7 +117,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "offset_commit commits an offset and offset_fetch retrieves the committed offset" do
     random_string = generate_random_string
     consumer_group = "offset_management"
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
+    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
     assert KafkaEx.offset_commit(KafkaEx.Server, %Proto.OffsetCommit.Request{topic: random_string, offset: 9, consumer_group: consumer_group, partition: 0}) ==
       [%Proto.OffsetCommit.Response{partitions: [0], topic: random_string}]
     assert KafkaEx.offset_fetch(KafkaEx.Server, %Proto.OffsetFetch.Request{topic: random_string, consumer_group: consumer_group, partition: 0}) ==
@@ -128,7 +128,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "stream auto_commits offset by default" do
     random_string = generate_random_string
     KafkaEx.create_worker(:stream_auto_commit, uris: uris, consumer_group: "stream_auto_commit")
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "hey"},
         %Proto.Produce.Message{value: "hi"},
       ]
@@ -152,7 +152,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
     worker_name = :stream_last_committed_offset
     consumer_group = "stream_next_offset"
     KafkaEx.create_worker(worker_name, uris: uris, consumer_group: consumer_group)
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: worker_name) end)
+    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: worker_name) end)
     KafkaEx.offset_commit(worker_name, %Proto.OffsetCommit.Request{topic: random_string, offset: 3, partition: 0, consumer_group: consumer_group})
     stream = KafkaEx.stream(random_string, 0, worker_name: worker_name)
     :timer.sleep(500)
@@ -168,7 +168,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "stream does not commit offset with auto_commit is set to false" do
     random_string = generate_random_string
     KafkaEx.create_worker(:stream_no_auto_commit, uris: uris, consumer_group: "stream_no_autocommit")
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
+    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
     KafkaEx.stream(random_string, 0, worker_name: :stream_no_auto_commit, auto_commit: false, offset: 0)
 
     offset_fetch_response = KafkaEx.offset_fetch(:stream_no_auto_commit, %Proto.OffsetFetch.Request{topic: random_string, partition: 0}) |> hd

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -49,7 +49,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
                           uris: Application.get_env(:kafka_ex, :brokers),
                           consumer_group: consumer_group)
 
-    offset_before = TestHelper.latest_offset_number(topic, 0, worker_name)
+    offset_before = TestHelper.latest_offset_number(topic, 0, worker_name) || 0
     Enum.each(1..10, fn _ ->
       msg = %Proto.Produce.Message{value: "hey #{inspect :os.timestamp}"}
       KafkaEx.produce(%Proto.Produce.Request{topic: topic,

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -49,13 +49,6 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group_update_interval == 30000
   end
 
-  test "create_worker provides a default consumer_group of 'kafka_ex'" do
-    {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
-    consumer_group = :sys.get_state(pid).consumer_group
-
-    assert consumer_group == "kafka_ex"
-  end
-
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])
     consumer_group = :sys.get_state(pid).consumer_group

--- a/test/protocol/offset_commit_test.exs
+++ b/test/protocol/offset_commit_test.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.OffsetCommit.Test do
   test "create_request creates a valid offset commit message" do
     corr_id = 3
     client_id = "kafka_ex"
-    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{offset: 10, topic: "foo", consumer_group: "bar", metadata: "baz"}
+    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{offset: 10, partition: 0, topic: "foo", consumer_group: "bar", metadata: "baz"}
     good_request = << 8 :: 16, 0 :: 16, corr_id :: 32, byte_size(client_id) :: 16, client_id :: binary, 3 :: 16, "bar", 1 :: 32, 3 :: 16, "foo", 1 :: 32, 0 :: 32, 10 :: 64, 3 :: 16, "baz" >>
     request = KafkaEx.Protocol.OffsetCommit.create_request(corr_id, client_id, offset_commit_request)
     assert request == good_request

--- a/test/protocol/offset_fetch_test.exs
+++ b/test/protocol/offset_fetch_test.exs
@@ -4,9 +4,11 @@ defmodule KafkaEx.Protocol.OffsetFetch.Test do
   test "create_request creates a valid offset commit message" do
     corr_id = 3
     client_id = "kafka_ex"
-    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{topic: "foo", consumer_group: "bar"}
+    offset_fetch_request = %KafkaEx.Protocol.OffsetFetch.Request{topic: "foo",
+                                                                 consumer_group: "bar",
+                                                                 partition: 0}
     good_request = << 9 :: 16, 0 :: 16, 3 :: 32, 8 :: 16, "kafka_ex" :: binary, 3 :: 16, "bar" :: binary, 1 :: 32, 3 :: 16, "foo" :: binary, 1 :: 32, 0 :: 32 >>
-    request = KafkaEx.Protocol.OffsetFetch.create_request(corr_id, client_id, offset_commit_request)
+    request = KafkaEx.Protocol.OffsetFetch.create_request(corr_id, client_id, offset_fetch_request)
     assert request == good_request
   end
 


### PR DESCRIPTION
This is a lead up to #68 but does not implement that feature.  I think that this will potentially solve a number of bugs, as well.  The default value of "kafka_ex" for the consumer group in many places was causing unset values to be missed.  Generally speaking, I don't think structs should have default values unless those default values mean something specific (error codes, specific unset values, empty arrays, etc.).  Empty strings as defaults, for example, can mask a bug where a value is not being set properly.

Unfortunately, I didn't write a failing test before I started this, but I know that it has solved at least one bug I was experiencing when using a custom worker with a custom consumer group.

Summary of changes:
- Fix root repo in CONTRIBUTING.md
- Remove 'false' consumer group (it's not well defined what this even means)
- Shift offset fetch into Server.ex - this reduces some repeated code and should be more performant
- Add a worker_consumer_group helper function
- Remove default values from many structs, fix a couple bugs that that uncovered
- Remove KafkaEx.Protocol.Fetch.Request struct, which was not used by any other code
- Give the Server.ex module a State substruct, which makes pattern matching easier
- Add guards to several functions - these could theoretically be removed, but they were very helpful in working out bugs.

Sorry for the big PR; all of the tests still pass and I have not introduced any new dialyzer warnings.