### PR TITLE
Fix parameter merging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -5,4 +5,4 @@ use Mix.Config
       {"localhost", 9093},
       {"localhost", 9094},
     ],
-    consumer_group: false
+    consumer_group: "kafka_ex"

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -7,7 +7,8 @@ defmodule KafkaEx do
   create_worker creates KafkaEx workers
 
   Optional arguments(KeywordList)
-  - consumer_group: Name of the group of consumers, `false` should be passed for Kafka < 0.8.2, default is "kafka_ex"
+  - consumer_group: Name of the group of consumers, `false` should be passed for Kafka < 0.8.2, defaults to `Application.get_env(:kafka_ex, :consumer_group)`
+  - uris: List of brokers in `{"host", port}` form, defaults to `Application.get_env(:kafka_ex, :brokers)`
   - metadata_update_interval: How often `kafka_ex` would update the Kafka cluster metadata information in milliseconds, default is 30000
   - consumer_group_update_interval: How often `kafka_ex` would update the Kafka cluster consumer_groups information in milliseconds, default is 30000
   - sync_timeout: Timeout for synchronous requests to kafka in milliseconds, default is 1000
@@ -29,11 +30,9 @@ defmodule KafkaEx do
   def create_worker(name, worker_init \\ [])
 
   def create_worker(name, worker_init) do
-    worker_init = case worker_init do
-      [] -> [uris: Application.get_env(:kafka_ex, :brokers)]
-      _   -> worker_init
-    end
-
+    defaults = [uris: Application.get_env(:kafka_ex, :brokers),
+                consumer_group: Application.get_env(:kafka_ex, :consumer_group)]
+    worker_init = Keyword.merge(defaults, worker_init)
     Supervisor.start_child(KafkaEx.Supervisor, [worker_init, name])
   end
 

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -295,9 +295,13 @@ defmodule KafkaEx do
     end
   end
 
-  defp valid_consumer_group?(:no_consumer_group), do: true
-  defp valid_consumer_group?(b) when is_binary(b) and byte_size(b) > 0, do: true
-  defp valid_consumer_group?(_), do: false
+  @doc """
+  Returns true if the input is a valid consumer group or :no_consumer_group
+  """
+  @spec valid_consumer_group?(any) :: boolean
+  def valid_consumer_group?(:no_consumer_group), do: true
+  def valid_consumer_group?(b) when is_binary(b), do: byte_size(b) > 0
+  def valid_consumer_group?(_), do: false
 
 #OTP API
   def start(_type, _args) do

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -1,7 +1,12 @@
 defmodule KafkaEx do
   use Application
   @type uri() :: [{binary|char_list, number}]
-  @type worker_init :: [{:uris, uri}, {:consumer_group, binary|false}, {:sync_timeout, non_neg_integer}]
+  @type worker_init :: [worker_setting]
+  @type worker_setting :: {:uris, uri}  |
+                          {:consumer_group, binary | false} |
+                          {:sync_timeout, non_neg_integer} |
+                          {:metadata_update_interval, non_neg_integer} |
+                          {:consumer_group_update_interval, non_neg_integer}
 
   @doc """
   create_worker creates KafkaEx workers

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -3,7 +3,6 @@ defmodule KafkaEx.Server do
 
   alias KafkaEx.Protocol, as: Proto
   @client_id                      "kafka_ex"
-  @consumer_group                 "kafka_ex"
   @metadata_update_interval       30_000
   @consumer_group_update_interval 30_000
   @sync_timeout                   1_000
@@ -31,7 +30,7 @@ defmodule KafkaEx.Server do
     uris = Keyword.get(args, :uris, [])
     metadata_update_interval = Keyword.get(args, :metadata_update_interval, @metadata_update_interval)
     consumer_group_update_interval = Keyword.get(args, :consumer_group_update_interval, @consumer_group_update_interval)
-    consumer_group = Keyword.get(args, :consumer_group, @consumer_group)
+    consumer_group = Keyword.get(args, :consumer_group)
     brokers = Enum.map(uris, fn({host, port}) -> %Proto.Metadata.Broker{host: host, port: port, socket: KafkaEx.NetworkClient.create_socket(host, port)} end)
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))
     {correlation_id, metadata} = metadata(brokers, 0, sync_timeout)
@@ -317,7 +316,8 @@ defmodule KafkaEx.Server do
 
   defp consumer_group(state) do
     if state.consumer_group == false do
-      @consumer_group
+      # TODO it appears we're relying on this when it shouldn't be set
+      "kafka_ex"
     else
       state.consumer_group
     end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -116,6 +116,7 @@ defmodule KafkaEx.Server do
   end
 
   def handle_call({:offset_fetch, offset_fetch}, _from, state) do
+    true = consumer_group?(state)
     {broker, state} = case Proto.ConsumerMetadata.Response.broker_for_consumer_group(state.brokers, state.consumer_metadata) do
       nil -> {_, state} = update_consumer_metadata(state, offset_fetch.consumer_group)
         {Proto.ConsumerMetadata.Response.broker_for_consumer_group(state.brokers, state.consumer_metadata), state}
@@ -144,6 +145,7 @@ defmodule KafkaEx.Server do
   end
 
   def handle_call({:consumer_group_metadata, consumer_group}, _from, state) do
+    true = consumer_group?(state)
     {consumer_metadata, state} = update_consumer_metadata(state, consumer_group)
     {:reply, consumer_metadata, state}
   end
@@ -201,6 +203,7 @@ defmodule KafkaEx.Server do
   end
 
   def handle_info(:update_consumer_metadata, state) do
+    true = consumer_group?(state)
     {:noreply, update_consumer_metadata(state, state.consumer_group) |> elem(1)}
   end
 

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -124,7 +124,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   #stream
   test "stream auto_commits offset by default" do
     random_string = generate_random_string
-    KafkaEx.create_worker(:stream_auto_commit, uris: uris)
+    KafkaEx.create_worker(:stream_auto_commit, uris: uris, consumer_group: "kafka_ex")
     KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "hey"},
         %Proto.Produce.Message{value: "hi"},
@@ -147,7 +147,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "stream starts consuming from the next offset" do
     random_string = generate_random_string
     worker_name = :stream_last_committed_offset
-    KafkaEx.create_worker(worker_name, uris: uris)
+    KafkaEx.create_worker(worker_name, uris: uris, consumer_group: "kafka_ex")
     Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: worker_name) end)
     KafkaEx.offset_commit(worker_name, %Proto.OffsetCommit.Request{topic: random_string, offset: 3})
     stream = KafkaEx.stream(random_string, 0, worker_name: worker_name)

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -30,8 +30,8 @@ defmodule KafkaEx.ConsumerGroup.Test do
     refute new_consumer_metadata == consumer_metadata
   end
 
-  test "worker does not update metadata when consumer_group is false" do
-    {:ok, pid} = KafkaEx.create_worker(:no_consumer_metadata_update, [uris: uris, consumer_group: false, consumer_group_update_interval: 100])
+  test "worker does not update metadata when consumer_group is disabled" do
+    {:ok, pid} = KafkaEx.create_worker(:no_consumer_metadata_update, [uris: uris, consumer_group: :no_consumer_group, consumer_group_update_interval: 100])
     consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
     :sys.replace_state(pid, fn(state) -> %{state | consumer_metadata: consumer_metadata} end)
     :timer.sleep(105)

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -49,12 +49,20 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group_update_interval == 30000
   end
 
-  test "create_worker provides a default consumer_group of 'kafka_ex'" do
+  test "create_worker provides a default consumer_group of false" do
     {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
     consumer_group = :sys.get_state(pid).consumer_group
 
-    assert consumer_group == "kafka_ex"
+    assert consumer_group == false
   end
+
+  test "create_worker allows us to provide a consumer group" do
+    {:ok, pid} = KafkaEx.create_worker(:bah, consumer_group: "my_consumer_group")
+    consumer_group = :sys.get_state(pid).consumer_group
+
+    assert consumer_group == "my_consumer_group"
+  end
+
 
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -49,11 +49,11 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group_update_interval == 30000
   end
 
-  test "create_worker provides a default consumer_group of false" do
+  test "create_worker provides a default consumer_group of 'kafka_ex'" do
     {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
     consumer_group = :sys.get_state(pid).consumer_group
 
-    assert consumer_group == false
+    assert consumer_group == "kafka_ex"
   end
 
   test "create_worker allows us to provide a consumer group" do
@@ -63,12 +63,22 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group == "my_consumer_group"
   end
 
-
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])
     consumer_group = :sys.get_state(pid).consumer_group
 
     assert consumer_group == "foo"
+  end
+
+  test "create_worker returns an error when an invalid consumer group is provided" do
+    assert {:error, :invalid_consumer_group} == KafkaEx.create_worker(:francine, consumer_group: 0)
+  end
+
+  test "create_worker allows us to disable the consumer group" do
+    {:ok, pid} = KafkaEx.create_worker(:barney, consumer_group: :no_consumer_group)
+    
+    consumer_group = :sys.get_state(pid).consumer_group
+    assert consumer_group == :no_consumer_group
   end
 
   test "create_worker provides a default sync_timeout of 1000" do


### PR DESCRIPTION
Another breakout from #69 

Fixes default parameter merging as we discussed.  This means that the `@consumer_group` module attribute within server.ex should no longer be relevant.  However, I found that in some of the integration tests, using `false` as the consumer group by default would cause a failure.  Upon further inspection, it appears that this is due to `auto_commit` defaulting to true in `KafkaEx.fetch`.

So, should we also set `auto_commit` to default to false?  Or include logic within server.ex to not allow offset commits unless the consumer group name is set?  I'm not familiar with Kafka < 0.8.2, but AFAIU it doesn't make sense to attempt to commit an offset unless one is using consumer groups (the docs don't appear to show support for that https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetCommitRequest).