### PR TITLE
Remove defaults for topic and partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ messages = [message1, message2]
 #snappy
 produce_request = %KafkaEx.Protocol.Produce.Request{
   topic: "test_topic",
+  partition: 0,
   required_acks: 1,
   compression: :snappy,
   messages: messages}
@@ -210,6 +211,7 @@ KafkaEx.produce(produce_request)
 #gzip
 produce_request = %KafkaEx.Protocol.Produce.Request{
   topic: "test_topic",
+  partition: 0,
   required_acks: 1,
   compression: :gzip,
   messages: messages}

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -178,9 +178,9 @@ defmodule KafkaEx do
   ## Example
 
   ```elixir
-  iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]})
+  iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", partition: 0, required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]})
   :ok
-  iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]}, worker_name: :pr)
+  iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", partition: 0, required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]}, worker_name: :pr)
   [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
   ```
   """

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -1,6 +1,6 @@
 defmodule KafkaEx.Protocol.Fetch do
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list} 
   end
 

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -1,6 +1,6 @@
 defmodule KafkaEx.Protocol.Metadata do
   defmodule Request do
-    defstruct topic: ""
+    defstruct topic: nil
     @type t :: %Request{topic: binary}
   end
 
@@ -35,11 +35,11 @@ defmodule KafkaEx.Protocol.Metadata do
   end
 
   defmodule TopicMetadata do
-    defstruct error_code: 0, topic: "", partition_metadatas: []
+    defstruct error_code: 0, topic: nil, partition_metadatas: []
   end
 
   defmodule PartitionMetadata do
-    defstruct error_code: 0, partition_id: 0, leader: -1, replicas: [], isrs: []
+    defstruct error_code: 0, partition_id: nil, leader: -1, replicas: [], isrs: []
   end
 
   def create_request(correlation_id, client_id, ""), do: KafkaEx.Protocol.create_request(:metadata, correlation_id, client_id) <> << 0 :: 32-signed >>

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -1,11 +1,11 @@
 defmodule KafkaEx.Protocol.Offset do
   defmodule Request do
-    defstruct replica_id: -1, topic_name: "", partition: 0, time: -1, max_number_of_offsets: 1
+    defstruct replica_id: -1, topic_name: nil, partition: nil, time: -1, max_number_of_offsets: 1
     @type t :: %Request{replica_id: integer, topic_name: binary, partition: integer, time: integer, max_number_of_offsets: integer}
   end
 
   defmodule Response do
-    defstruct topic: "", partition_offsets: []
+    defstruct topic: nil, partition_offsets: []
     @type t :: %Response{topic: binary, partition_offsets: list}
   end
 

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -1,11 +1,11 @@
 defmodule KafkaEx.Protocol.OffsetCommit do
   defmodule Request do
-    defstruct consumer_group: "kafka_ex", topic: "", partition: 0, offset: 0, metadata: ""
+    defstruct consumer_group: "kafka_ex", topic: nil, partition: nil, offset: nil, metadata: ""
     @type t :: %Request{consumer_group: binary, topic: binary, partition: integer, offset: integer}
   end
 
   defmodule Response do
-    defstruct partitions: [], topic: ""
+    defstruct partitions: [], topic: nil
     @type t :: %Response{partitions: [] | [integer], topic: binary}
   end
 

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -1,11 +1,11 @@
 defmodule KafkaEx.Protocol.OffsetFetch do
   defmodule Request do
-    defstruct consumer_group: "kafka_ex", topic: "", partition: 0
+    defstruct consumer_group: "kafka_ex", topic: nil, partition: nil
     @type t :: %Request{consumer_group: binary, topic: binary, partition: integer}
   end
 
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list}
 
     def last_offset(:topic_not_found) do

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.Produce do
     - require_acks: indicates how many acknowledgements the servers should receive before responding to the request. If it is 0 the server will not send any response (this is the only case where the server will not reply to a request). If it is 1, the server will wait the data is written to the local log before sending a response. If it is -1 the server will block until the message is committed by all in sync replicas before sending a response. For any number > 1 the server will block waiting for this number of acknowledgements to occur (but the server will never wait for more acknowledgements than there are in-sync replicas), default is 0
     - timeout: provides a maximum time in milliseconds the server can await the receipt of the number of acknowledgements in RequiredAcks, default is 100 milliseconds
     """
-    defstruct topic: "", partition: 0, required_acks: 0, timeout: 0, compression: :none, messages: []
+    defstruct topic: nil, partition: nil, required_acks: 0, timeout: 0, compression: :none, messages: []
     @type t :: %Request{topic: binary, partition: integer, required_acks: binary, timeout: integer, compression: atom, messages: list}
   end
 
@@ -18,7 +18,7 @@ defmodule KafkaEx.Protocol.Produce do
   end
 
   defmodule Response do
-    defstruct topic: "", partitions: []
+    defstruct topic: nil, partitions: []
     @type t :: %Response{topic: binary, partitions: list}
   end
 

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -304,6 +304,7 @@ defmodule KafkaEx.Server do
                 offset_commit_request = %Proto.OffsetCommit.Request{
                   topic: topic,
                   offset: last_offset,
+                  partition: partition,
                   consumer_group: consumer_group(state)}
                 {_, state} = offset_commit(state, offset_commit_request)
                 {response, state}

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -49,6 +49,13 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group_update_interval == 30000
   end
 
+  test "create_worker provides a default consumer_group of 'kafka_ex'" do
+    {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
+    consumer_group = :sys.get_state(pid).consumer_group
+    
+    assert consumer_group == "kafka_ex"
+  end
+
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])
     consumer_group = :sys.get_state(pid).consumer_group

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -49,13 +49,6 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group_update_interval == 30000
   end
 
-  test "create_worker provides a default consumer_group of 'kafka_ex'" do
-    {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
-    consumer_group = :sys.get_state(pid).consumer_group
-
-    assert consumer_group == "kafka_ex"
-  end
-
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])
     consumer_group = :sys.get_state(pid).consumer_group
@@ -102,7 +95,7 @@ defmodule KafkaEx.Integration.Test do
     random_string = generate_random_string
     KafkaEx.create_worker(:update_metadata, [uris: uris, consumer_group: "foo", metadata_update_interval: 100])
     previous_metadata = KafkaEx.metadata(worker_name: :update_metadata)
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 0, messages: [%Proto.Produce.Message{value: "hey"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 0, messages: [%Proto.Produce.Message{value: "hey"}]})
     :timer.sleep(105)
     new_metadata = KafkaEx.metadata(worker_name: :update_metadata)
 
@@ -137,11 +130,11 @@ defmodule KafkaEx.Integration.Test do
   end
 
   test "produce without an acq required returns :ok" do
-    assert KafkaEx.produce(%Proto.Produce.Request{topic: "food", required_acks: 0, messages: [%Proto.Produce.Message{value: "hey"}]}) == :ok
+    assert KafkaEx.produce(%Proto.Produce.Request{topic: "food", partition: 0, required_acks: 0, messages: [%Proto.Produce.Message{value: "hey"}]}) == :ok
   end
 
   test "produce with ack required returns an ack" do
-    produce_response = KafkaEx.produce(%Proto.Produce.Request{topic: "food", required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) |> hd
+    produce_response = KafkaEx.produce(%Proto.Produce.Request{topic: "food", partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) |> hd
     offset = produce_response.partitions |> hd |> Map.get(:offset)
 
     refute offset == nil
@@ -154,7 +147,7 @@ defmodule KafkaEx.Integration.Test do
 
     assert empty_metadata.brokers == []
 
-    KafkaEx.produce(%Proto.Produce.Request{topic: "food", required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: :update_metadata_test)
+    KafkaEx.produce(%Proto.Produce.Request{topic: "food", partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}, worker_name: :update_metadata_test)
     metadata = :sys.get_state(pid).metadata
 
     refute metadata == empty_metadata
@@ -163,7 +156,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "produce creates log for a non-existing topic" do
     random_string = generate_random_string
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
     pid = Process.whereis(KafkaEx.Server)
     metadata = :sys.get_state(pid).metadata
 
@@ -173,7 +166,7 @@ defmodule KafkaEx.Integration.Test do
   #metadata
   test "metadata works" do
     random_string = generate_random_string
-    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
+    Enum.each(1..10, fn _ -> KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) end)
 
     refute Enum.empty?(Enum.flat_map(KafkaEx.metadata.topic_metadatas, fn(metadata) -> metadata.partition_metadatas end))
   end
@@ -217,7 +210,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "fetch works" do
     random_string = generate_random_string
-    produce_response =  KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey foo"}]}) |> hd
+    produce_response =  KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey foo"}]}) |> hd
     offset = produce_response.partitions |> hd |> Map.get(:offset)
     fetch_response = KafkaEx.fetch(random_string, 0, offset: 0, auto_commit: false) |>  hd
     message = fetch_response.partitions |> hd |> Map.get(:message_set) |> hd
@@ -239,7 +232,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "offset retrieves most recent offset by time specification" do
     random_string = generate_random_string
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
     offset_response = KafkaEx.offset(random_string, 0, utc_time) |> hd
     offset = offset_response.partition_offsets |> hd |> Map.get(:offset) |> hd
 
@@ -248,7 +241,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "earliest_offset retrieves offset of 0" do
     random_string = generate_random_string
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})
     offset_response = KafkaEx.earliest_offset(random_string, 0) |> hd
     offset = offset_response.partition_offsets |> hd |> Map.get(:offset) |> hd
 
@@ -257,7 +250,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "latest_offset retrieves offset of 0 for non-existing topic" do
     random_string = generate_random_string
-    produce_offset = KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) |> hd |> Map.get(:partitions) |> hd |> Map.get(:offset)
+    produce_offset = KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]}) |> hd |> Map.get(:partitions) |> hd |> Map.get(:offset)
     :timer.sleep(300)
     offset_response = KafkaEx.latest_offset(random_string, 0) |> hd
     offset = offset_response.partition_offsets |> hd |> Map.get(:offset) |> hd
@@ -267,7 +260,7 @@ defmodule KafkaEx.Integration.Test do
 
   test "latest_offset retrieves a non-zero offset for a topic published to" do
     random_string = generate_random_string
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [%Proto.Produce.Message{value: "foo"}]})
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "foo"}]})
     offset_response = KafkaEx.latest_offset(random_string, 0) |> hd
     offset = offset_response.partition_offsets |> hd |> Map.get(:offset) |> hd
 
@@ -284,6 +277,7 @@ defmodule KafkaEx.Integration.Test do
 
     produce_request = %Proto.Produce.Request{
       topic: random_string,
+      partition: 0,
       required_acks: 1,
       compression: :gzip,
       messages: messages}
@@ -310,6 +304,7 @@ defmodule KafkaEx.Integration.Test do
 
     produce_request = %Proto.Produce.Request{
       topic: random_string,
+      partition: 0,
       required_acks: 1,
       compression: :snappy,
       messages: messages}
@@ -334,7 +329,7 @@ defmodule KafkaEx.Integration.Test do
     # 10 chars * 1024 repeats ~= 10kb
     message_value = String.duplicate("ABCDEFGHIJ", 1024)
     messages = [%Proto.Produce.Message{key: nil, value: message_value}]
-    produce_request = %Proto.Produce.Request{topic: topic, required_acks: 1, messages: messages}
+    produce_request = %Proto.Produce.Request{topic: topic, partition: 0, required_acks: 1, messages: messages}
 
     produce_response = KafkaEx.produce(produce_request) |> hd
     offset = produce_response.partitions |> hd |> Map.get(:offset)
@@ -352,7 +347,7 @@ defmodule KafkaEx.Integration.Test do
     # 10 chars * 1024 repeats ~= 10kb
     message_value = String.duplicate("ABCDEFGHIJ", 100)
     messages = [%Proto.Produce.Message{key: nil, value: message_value}]
-    produce_request = %Proto.Produce.Request{topic: topic, compression: :gzip, required_acks: 1, messages: messages}
+    produce_request = %Proto.Produce.Request{topic: topic, partition: 0, compression: :gzip, required_acks: 1, messages: messages}
 
     produce_response = KafkaEx.produce(produce_request) |> hd
     offset = produce_response.partitions |> hd |> Map.get(:offset)
@@ -370,7 +365,7 @@ defmodule KafkaEx.Integration.Test do
     # 10 chars * 1024 repeats ~= 10kb
     message_value = String.duplicate("ABCDEFGHIJ", 100)
     messages = [%Proto.Produce.Message{key: nil, value: message_value}]
-    produce_request = %Proto.Produce.Request{topic: topic, compression: :snappy, required_acks: 1, messages: messages}
+    produce_request = %Proto.Produce.Request{topic: topic, partition: 0, compression: :snappy, required_acks: 1, messages: messages}
 
     produce_response = KafkaEx.produce(produce_request) |> hd
     offset = produce_response.partitions |> hd |> Map.get(:offset)
@@ -386,7 +381,7 @@ defmodule KafkaEx.Integration.Test do
   test "streams kafka logs" do
     random_string = generate_random_string
     KafkaEx.create_worker(:stream, uris: uris)
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "hey"},
         %Proto.Produce.Message{value: "hi"},
       ]
@@ -414,7 +409,7 @@ defmodule KafkaEx.Integration.Test do
     stream = KafkaEx.stream(random_string, 0, worker_name: :stream2, offset: 0, auto_commit: false)
 
     KafkaEx.create_worker(:producer, uris: uris)
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "one"},
         %Proto.Produce.Message{value: "two"},
       ]
@@ -427,7 +422,7 @@ defmodule KafkaEx.Integration.Test do
 
     KafkaEx.stop_streaming(worker_name: :stream2)
     :timer.sleep(1000)
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "three"},
         %Proto.Produce.Message{value: "four"},
       ]
@@ -437,7 +432,7 @@ defmodule KafkaEx.Integration.Test do
     log = GenEvent.call(stream.manager, KafkaExHandler, :messages)
     assert length(log) == 0
 
-    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "five"},
         %Proto.Produce.Message{value: "six"},
       ]
@@ -450,7 +445,7 @@ defmodule KafkaEx.Integration.Test do
   test "streams kafka logs with custom handler and initial state" do
     random_string = generate_random_string
     KafkaEx.create_worker(:stream3, uris: uris)
-    produce_response = KafkaEx.produce(%Proto.Produce.Request{topic: random_string, required_acks: 1, messages: [
+    produce_response = KafkaEx.produce(%Proto.Produce.Request{topic: random_string, partition: 0, required_acks: 1, messages: [
         %Proto.Produce.Message{value: "hey"},
         %Proto.Produce.Message{value: "hi"},
       ]

--- a/test/protocol/offset_commit_test.exs
+++ b/test/protocol/offset_commit_test.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.OffsetCommit.Test do
   test "create_request creates a valid offset commit message" do
     corr_id = 3
     client_id = "kafka_ex"
-    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{offset: 10, topic: "foo", consumer_group: "bar", metadata: "baz"}
+    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{offset: 10, partition: 0, topic: "foo", consumer_group: "bar", metadata: "baz"}
     good_request = << 8 :: 16, 0 :: 16, corr_id :: 32, byte_size(client_id) :: 16, client_id :: binary, 3 :: 16, "bar", 1 :: 32, 3 :: 16, "foo", 1 :: 32, 0 :: 32, 10 :: 64, 3 :: 16, "baz" >>
     request = KafkaEx.Protocol.OffsetCommit.create_request(corr_id, client_id, offset_commit_request)
     assert request == good_request

--- a/test/protocol/offset_fetch_test.exs
+++ b/test/protocol/offset_fetch_test.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.OffsetFetch.Test do
   test "create_request creates a valid offset commit message" do
     corr_id = 3
     client_id = "kafka_ex"
-    offset_commit_request = %KafkaEx.Protocol.OffsetCommit.Request{topic: "foo", consumer_group: "bar"}
+    offset_commit_request = %KafkaEx.Protocol.OffsetFetch.Request{topic: "foo", consumer_group: "bar", partition: 0}
     good_request = << 9 :: 16, 0 :: 16, 3 :: 32, 8 :: 16, "kafka_ex" :: binary, 3 :: 16, "bar" :: binary, 1 :: 32, 3 :: 16, "foo" :: binary, 1 :: 32, 0 :: 32 >>
     request = KafkaEx.Protocol.OffsetFetch.create_request(corr_id, client_id, offset_commit_request)
     assert request == good_request


### PR DESCRIPTION
This was masking at least one bug - the partition was not being passed through to the offset commit request in Server.fetch, which would probably cause offset commits to always be commit to partition 0.

This looks like a lot of changes, but most of the changes are either removing the default values from structs or updating the tests where they were previously relying on the defaults.  I also tried to update documentation wherever it was missing values for partition or topic.

I would like to do a similar PR for the default "kafka_ex" consumer group, which I believe is masking similar bugs as per #69.  I'll wait until #71 is resolved for that.