### PR TITLE
Allow topic deletes in server.properties

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -51,6 +51,8 @@ socket.receive.buffer.bytes=102400
 # The maximum size of a request that the socket server will accept (protection against OOM)
 socket.request.max.bytes=104857600
 
+# allow deleting topics
+delete.topic.enable=true
 
 ############################# Log Basics #############################
 


### PR DESCRIPTION
It's handy to be able to delete topics when testing.  This setting makes it possible to run `kafka-topics.sh --delete` (with versions that support that).