### PR TITLE
Allow disabling the default worker, update README and document config.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,12 @@ end
 
 ### Configuration
 
-In your config/config.exs add the list of kafka brokers as below:
-```elixir
-config :kafka_ex,
-  brokers: [{HOST, PORT}],
-  consumer_group: consumer_group, #if no consumer_group is specified "kafka_ex" would be used as the default
-  sync_timeout: 1000 #Timeout used synchronous requests from kafka. Defaults to 1000ms.
-```
-
-Alternatively from iex:
-```elixir
-iex> Application.put_env(:kafka_ex, :brokers, [uris: [{"localhost", 9092}, {"localhost", 9093}], consumer_group: "kafka_ex"])
-:ok
-```
+See [config/config.exs](config/config.exs) for a description of
+configuration variables, including the Kafka broker list and default
+consumer group.  See
+http://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html#application-environment-and-configuration
+for general info if you are unfamiliar with OTP application
+environments.
 
 You can also override options when creating a worker, see below.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,8 +1,20 @@
 use Mix.Config
-  config :kafka_ex,
-    brokers: [
-      {"localhost", 9092},
-      {"localhost", 9093},
-      {"localhost", 9094},
-    ],
-    consumer_group: "kafka_ex"
+
+config :kafka_ex,
+  # a list of brokers to connect to in {"HOST", port} format
+  brokers: [
+    {"localhost", 9092},
+    {"localhost", 9093},
+    {"localhost", 9094},
+  ],
+  # the default consumer group for worker processes, must be a binary (string)
+  #    NOTE if you are on Kafka < 0.8.2 or if you want to disable the use of
+  #    consumer groups, set this to :no_consumer_group (this is the
+  #    only exception to the requirement that this value be a binary)
+  consumer_group: "kafka_ex",
+  # Set this value to true if you do not want the default
+  # `KafkaEx.Server` worker to start during application start-up -
+  # i.e., if you want to start your own set of named workers
+  disable_default_worker: false,
+  # Timeout value, in msec, for synchronous operations (e.g., network calls)
+  sync_timeout: 3000

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -307,9 +307,13 @@ defmodule KafkaEx do
   def start(_type, _args) do
     {:ok, pid}     = KafkaEx.Supervisor.start_link
 
-    case KafkaEx.create_worker(KafkaEx.Server, []) do
-      {:error, reason} -> {:error, reason}
-      {:ok, _}         -> {:ok, pid}
+    if Application.get_env(:kafka_ex, :disable_default_worker) == true do
+      {:ok, pid}
+    else
+      case KafkaEx.create_worker(KafkaEx.Server, []) do
+        {:error, reason} -> {:error, reason}
+        {:ok, _}         -> {:ok, pid}
+      end
     end
   end
 end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -81,11 +81,14 @@ defmodule KafkaEx.Integration.Test do
     assert consumer_group == :no_consumer_group
   end
 
-  test "create_worker provides a default sync_timeout of 1000" do
+  test "create_worker provides a default sync_timeout of 1000 if not set in config" do
+    value_before = Application.get_env(:kafka_ex, :sync_timeout)
+    Application.delete_env(:kafka_ex, :sync_timeout)
     {:ok, pid} = KafkaEx.create_worker(:bif, uris: uris)
     sync_timeout = :sys.get_state(pid).sync_timeout
 
     assert sync_timeout == 1000
+    Application.put_env(:kafka_ex, :sync_timeout, value_before)
   end
 
   test "create_worker takes a sync_timeout option and sets that as the sync_timeout of the worker" do
@@ -96,22 +99,20 @@ defmodule KafkaEx.Integration.Test do
   end
 
   test "create_worker uses sync_timeout default from config if set" do
-    Application.put_env(:kafka_ex, :sync_timeout, 3000)
+    value_before = Application.get_env(:kafka_ex, :sync_timeout)
+    Application.put_env(:kafka_ex, :sync_timeout, 4000)
 
     {:ok, pid} = KafkaEx.create_worker(:eve, [uris: uris])
     sync_timeout = :sys.get_state(pid).sync_timeout
 
-    Application.delete_env(:kafka_ex, :sync_timeout)
-    assert sync_timeout == 3000
+    assert sync_timeout == 4000
+    Application.put_env(:kafka_ex, :sync_timeout, value_before)
   end
 
   test "create_worker uses explicit sync_timeout even if set in config" do
-    Application.put_env(:kafka_ex, :sync_timeout, 3000)
-
     {:ok, pid} = KafkaEx.create_worker(:alice, [uris: uris, sync_timeout: 2000])
     sync_timeout = :sys.get_state(pid).sync_timeout
 
-    Application.delete_env(:kafka_ex, :sync_timeout)
     assert sync_timeout == 2000
   end
 

--- a/test/kafka_ex_test.exs
+++ b/test/kafka_ex_test.exs
@@ -1,0 +1,25 @@
+defmodule KafkaExTest do
+  use ExUnit.Case, async: false
+
+  test "Setting disable_default_worker to true removes the KafkaEx.Server worker" do
+    # stop the application, disable the default worker, restart the application
+    :ok = Application.stop(:kafka_ex)
+    Application.put_env(:kafka_ex, :disable_default_worker, true)
+    {:ok, _} = Application.ensure_all_started(:kafka_ex)
+
+    # the supervisor should now have no children and the default worker should not be registered
+    assert [] == Supervisor.which_children(KafkaEx.Supervisor)
+    assert nil == Process.whereis(KafkaEx.Server)
+
+    # revert the change, restart the application
+    :ok = Application.stop(:kafka_ex)
+    Application.put_env(:kafka_ex, :disable_default_worker, false)
+    {:ok, _} = Application.ensure_all_started(:kafka_ex)
+
+    # we should have the default worker back again
+    pid = Process.whereis(KafkaEx.Server)
+    assert is_pid(pid)
+    assert [{:undefined, pid, :worker, [KafkaEx.Server]}] ==
+      Supervisor.which_children(KafkaEx.Supervisor)
+  end
+end


### PR DESCRIPTION
The motivation to disable the default worker is described in #68

I updated the README to point to config/config.exs for the application
env, and updated config/config.exs with comments describing how to use
each of the supported env settings.  I think this makes it easier to
keep everything up-to-date.