### PR TITLE
Typespec fixes

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -187,12 +187,12 @@ defmodule KafkaEx do
 
   ```elixir
   iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", partition: 0, required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]})
-  [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
+  :ok
   iex> KafkaEx.produce(%KafkaEx.Protocol.Produce.Request{topic: "foo", partition: 0, required_acks: 1, messages: [%KafkaEx.Protocol.Produce.Message{value: "hey"}]}, worker_name: :pr)
-  [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
+  :ok
   ```
   """
-  @spec produce(KafkaEx.Protocol.Produce.Request.t, Keyword.t) :: [KafkaEx.Protocol.Produce.Response.t] | :leader_not_available
+  @spec produce(KafkaEx.Protocol.Produce.Request.t, Keyword.t) :: nil | :ok | {:error, :closed} | {:error, :inet.posix} | iodata | :leader_not_available
   def produce(produce_request, opts \\ []) do
     worker_name   = Keyword.get(opts, :worker_name, KafkaEx.Server)
     GenServer.call(worker_name, {:produce, produce_request})
@@ -214,7 +214,7 @@ defmodule KafkaEx do
   [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
   ```
   """
-  @spec produce(binary, number, binary, Keyword.t) :: [KafkaEx.Protocol.Produce.Response.t] | :leader_not_available 
+  @spec produce(binary, number, binary, Keyword.t) :: nil | :ok | {:error, :closed} | {:error, :inet.posix} | iodata | :leader_not_available
   def produce(topic, partition, value, opts \\ []) do
     key             = Keyword.get(opts, :key, "")
     required_acks   = Keyword.get(opts, :required_acks, 0)

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -209,9 +209,9 @@ defmodule KafkaEx do
   ## Example
   ```elixir
   iex> KafkaEx.produce("bar", 0, "hey")
-  [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
+  :ok
   iex> KafkaEx.produce("foo", 0, "hey", [worker_name: :pr, require_acks: 1])
-  [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 75, partition: 0}], topic: "foo"}]
+  :ok
   ```
   """
   @spec produce(binary, number, binary, Keyword.t) :: nil | :ok | {:error, :closed} | {:error, :inet.posix} | iodata | :leader_not_available

--- a/lib/kafka_ex/compression.ex
+++ b/lib/kafka_ex/compression.ex
@@ -44,8 +44,6 @@ defmodule KafkaEx.Compression do
     {:ok, compressed_data} = :snappy.compress(data)
     {compressed_data, @snappy_attribute}
   end
-
-  @spec compress(compression_type_t, binary) :: {binary, attribute_t}
   def compress(:gzip, data) do
     compressed_data = :zlib.gzip(data)
     {compressed_data, @gzip_attribute}

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -20,7 +20,7 @@ defmodule KafkaEx.Protocol.Metadata do
                   nil -> nil
                   broker -> case Port.info(broker.socket) do
                     nil        -> nil
-                    :undefined -> nil
+                    :undefined -> nil      # Note this return value was removed in Elixir 1.1
                     _          -> broker
                   end
                 end

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -32,6 +32,7 @@ defmodule KafkaEx.Protocol.Metadata do
 
   defmodule Broker do
     defstruct node_id: 0, host: "", port: 0, socket: nil
+    @type t :: %Broker{node_id: non_neg_integer, host: binary, port: non_neg_integer, socket: nil | :gen_tcp.socket}
   end
 
   defmodule TopicMetadata do

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule KafkaEx.Mixfile do
   defp deps do
     [
       {:earmark, "~> 0.1", only: :dev},
-      {:dialyze, "~> 0.1.3", only: :dev},
+      {:dialyze, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},
       {:snappy,
        git: "https://github.com/fdmanana/snappy-erlang-nif",

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"dialyze": {:hex, :dialyze, "0.1.4"},
+%{"dialyze": {:hex, :dialyze, "0.2.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.9.0"},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "76417d16a8d39e04d66114d8f8a3c75df19474f0", []}}


### PR DESCRIPTION
Several of the typespecs were incorrect.  This fixes several of them to the best of my knowledge.  I ended up adding some specs in a couple places to help me figure out what the specs for KafkaEx should be.

Note that in Elixir v1.1+ there's a dialyzer warning in metadata.ex on the return value of `Port.info/1`.  As of v1.1 `Port.info/1` translates `:undefined` into `nil`.  I left the catch for `:undefined` so as not to break compatibility with Elixir 1.0.

The only remaining dialyzer warnings are the usual ones that get thrown for struct access.