### PR TITLE
Add consumer_group reader for introspection

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -46,6 +46,16 @@ defmodule KafkaEx do
   end
 
   @doc """
+  Returns the consumer group name for the given worker.
+
+  Worker may be an atom or pid.  The default worker is used by default.
+  """
+  @spec consumer_group(atom | pid) :: binary | :no_consumer_group
+  def consumer_group(worker \\ KafkaEx.Server) do
+    GenServer.call(worker, :consumer_group)
+  end
+
+  @doc """
   Return metadata for the given topic; returns for all topics if topic is empty string
 
   Optional arguments(KeywordList)

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -46,7 +46,7 @@ defmodule KafkaEx do
   end
 
   @doc """
-  Returns the consumer group name for the given worker.
+  Returns the name of the consumer group for the given worker.
 
   Worker may be an atom or pid.  The default worker is used by default.
   """

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -62,6 +62,10 @@ defmodule KafkaEx.Server do
     {:ok, state}
   end
 
+  def handle_call(:consumer_group, _from, state) do
+    {:reply, state.consumer_group, state}
+  end
+
   def handle_call({:produce, produce_request}, _from, state) do
     correlation_id = state.correlation_id + 1
     produce_request_data = Proto.Produce.create_request(correlation_id, @client_id, produce_request)

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -5,6 +5,15 @@ defmodule KafkaEx.ConsumerGroup.Test do
 
   @moduletag :consumer_group
 
+  test "asking the worker for the name of its consumer group" do
+    consumer_group = "this_is_my_consumer_group"
+    worker_name = :consumer_group_reader_test
+    {:ok, _pid} = KafkaEx.create_worker(worker_name,
+                                        consumer_group: consumer_group)
+    
+    assert consumer_group == KafkaEx.consumer_group(worker_name)
+  end
+
   test "consumer_group_metadata works" do
     random_string = generate_random_string
     KafkaEx.produce(%Proto.Produce.Request{topic: "food", partition: 0, required_acks: 1, messages: [%Proto.Produce.Message{value: "hey"}]})

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -10,6 +10,11 @@ defmodule KafkaEx.Integration.Test do
     assert is_pid(pid)
   end
 
+  test "fetching the consumer group from the default worker" do
+    assert Application.get_env(:kafka_ex, :consumer_group) ==
+      KafkaEx.consumer_group()
+  end
+
   #create_worker
   test "KafkaEx.Supervisor dynamically creates workers" do
     {:ok, pid} = KafkaEx.create_worker(:bar, uris: uris)


### PR DESCRIPTION
In an application with potentially many workers, this can help with
consistency as other code may need to know the consumer group.  One
alternative is to pass around the name of the consumer group wherever we
pass around the worker name/pid, but this is more error prone than being
able to introspect the given process to determine its consumer group.