### PR TITLE
Improve error messages in network_client

### DIFF
--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -5,10 +5,10 @@ defmodule KafkaEx.NetworkClient do
   def create_socket(host, port) do
     case :gen_tcp.connect(format_host(host), port, [:binary, {:packet, 4}]) do
       {:ok, socket} ->
-        Logger.log(:debug, "Succesfully connected to #{inspect(host)} on port #{inspect port}")
+        Logger.log(:debug, "Succesfully connected to broker #{inspect(host)}:#{inspect port}")
         socket
       _             ->
-        Logger.log(:error, "Could not connect to broker #{inspect(host)} on port #{inspect port}")
+        Logger.log(:error, "Could not connect to broker #{inspect(host)}:#{inspect port}")
         nil
     end
   end
@@ -23,7 +23,7 @@ defmodule KafkaEx.NetworkClient do
     case :gen_tcp.send(socket, data) do
       :ok -> :ok
       {_, reason} ->
-        Logger.log(:error, "Sending data to broker #{inspect broker.host} on port #{inspect broker.port} failed with #{inspect reason}")
+        Logger.log(:error, "Asynchronously sending data to broker #{inspect broker.host}:#{inspect broker.port} failed with #{inspect reason}")
         reason
     end
   end
@@ -37,11 +37,11 @@ defmodule KafkaEx.NetworkClient do
         case :gen_tcp.recv(socket, 0, timeout) do
           {:ok, data} -> data
           {:error, reason} ->
-            Logger.log(:error, "Sending data to broker #{inspect broker.host}, #{inspect broker.port} failed with #{inspect reason}")
+            Logger.log(:error, "Receiving data from broker #{inspect broker.host}:#{inspect broker.port} failed with #{inspect reason}")
             nil
         end
       {_, reason} ->
-        Logger.log(:error, "Sending data to broker #{inspect broker.host}, #{inspect broker.port} failed with #{inspect reason}")
+        Logger.log(:error, "Sending data to broker #{inspect broker.host}:#{inspect broker.port} failed with #{inspect reason}")
         nil
     end
 


### PR DESCRIPTION
- More consistently refer to brokers
- Specify async case in error message
- Specify send/receive in sync case

@bjhaid Quick review/merge would be much appreciated as this is related to a problem we're experiencing in production.  We're getting timeouts from the network client but can't tell if it's in the send or receive step because the error messages are identical and both return `nil`.