### PR TITLE
Make tests work under Erlang 7.3/Elixir 1.2.3

### DIFF
--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -1,6 +1,8 @@
 defmodule KafkaEx.Supervisor.Test do
   use ExUnit.Case, async: false
 
+  @restart_elem 10
+
   test "uses configured max_restarts" do
     # stop the application, configure supervision max_restarts and restart the application
     configured_max_restarts = 15
@@ -8,7 +10,7 @@ defmodule KafkaEx.Supervisor.Test do
     :ok = Application.stop(:kafka_ex)
     Application.put_env(:kafka_ex, :max_restarts, configured_max_restarts)
     {:ok, _} = Application.ensure_all_started(:kafka_ex)
-    [max_restarts, _max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(9)
+    [max_restarts, _max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(@restart_elem)
 
     assert configured_max_restarts == max_restarts
 
@@ -16,7 +18,7 @@ defmodule KafkaEx.Supervisor.Test do
     :ok = Application.stop(:kafka_ex)
     Application.delete_env(:kafka_ex, :max_restarts)
     {:ok, _} = Application.ensure_all_started(:kafka_ex)
-    [max_restarts, _max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(9)
+    [max_restarts, _max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(@restart_elem)
 
     refute configured_max_restarts == max_restarts
   end
@@ -28,7 +30,7 @@ defmodule KafkaEx.Supervisor.Test do
     :ok = Application.stop(:kafka_ex)
     Application.put_env(:kafka_ex, :max_seconds, configured_max_seconds)
     {:ok, _} = Application.ensure_all_started(:kafka_ex)
-    [_max_restarts, max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(9)
+    [_max_restarts, max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(@restart_elem)
 
     assert configured_max_seconds == max_seconds
 
@@ -36,7 +38,7 @@ defmodule KafkaEx.Supervisor.Test do
     :ok = Application.stop(:kafka_ex)
     Application.delete_env(:kafka_ex, :max_seconds)
     {:ok, _} = Application.ensure_all_started(:kafka_ex)
-    [_max_restarts, max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(9)
+    [_max_restarts, max_seconds] = :sys.get_state(KafkaEx.Supervisor) |> elem(@restart_elem)
 
     refute configured_max_seconds == max_seconds
   end


### PR DESCRIPTION
I assume that the new output format of `:sys.get_state` is due to me upgrading to Erlang 7.3 - I guess we need a version check?