### PR TITLE
Make ExUnit capture log output

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,3 +22,8 @@ config :kafka_ex,
   max_restarts: 10,
   # Supervision max_seconds -  the time frame in which :max_restarts applies
   max_seconds: 60
+
+env_config = Path.expand("#{Mix.env}.exs", __DIR__)
+if File.exists?(env_config) do
+  import_config(env_config)
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :ex_unit, capture_log: true


### PR DESCRIPTION
This cleans up the test output a bit by hiding logs unless tests fail. I haven't been able to clean up the initial log output which comes from the fact that Mix by default starts the application when running tests.