### PR TITLE
Call kafka_server_* functions locally

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -53,7 +53,7 @@ defmodule KafkaEx do
   def create_worker(name, worker_init \\ []) do
     case build_worker_options(worker_init) do
       {:ok, worker_init} ->
-        Supervisor.start_child(KafkaEx.Supervisor, [Config.server_impl, worker_init, name])
+        Supervisor.start_child(KafkaEx.Supervisor, [worker_init, name])
       {:error, error} ->
         {:error, error}
     end

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -26,14 +26,14 @@ defmodule KafkaEx.Server0P8P0 do
     {:ok, state}
   end
 
-  def start_link(server_impl, args, name \\ __MODULE__)
+  def start_link(args, name \\ __MODULE__)
 
-  def start_link(server_impl, args, :no_name) do
-    GenServer.start_link(__MODULE__, [server_impl, args])
+  def start_link(args, :no_name) do
+    GenServer.start_link(__MODULE__, [args])
   end
 
-  def start_link(server_impl, args, name) do
-    GenServer.start_link(__MODULE__, [server_impl, args, name], [name: name])
+  def start_link(args, name) do
+    GenServer.start_link(__MODULE__, [args, name], [name: name])
   end
 
   def kafka_server_fetch(fetch_request, state) do

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -17,13 +17,13 @@ defmodule KafkaEx.Server0P8P2 do
 
   @consumer_group_update_interval 30_000
 
-  def start_link(server_impl, args, name \\ __MODULE__)
+  def start_link(args, name \\ __MODULE__)
 
-  def start_link(server_impl, args, :no_name) do
-    GenServer.start_link(__MODULE__, [server_impl, args])
+  def start_link(args, :no_name) do
+    GenServer.start_link(__MODULE__, [args])
   end
-  def start_link(server_impl, args, name) do
-    GenServer.start_link(__MODULE__, [server_impl, args, name], [name: name])
+  def start_link(args, name) do
+    GenServer.start_link(__MODULE__, [args, name], [name: name])
   end
 
   def kafka_server_init([args]) do

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -20,13 +20,13 @@ defmodule KafkaEx.Server0P9P0 do
 
   @consumer_group_update_interval 30_000
 
-  def start_link(server_impl, args, name \\ __MODULE__)
+  def start_link(args, name \\ __MODULE__)
 
-  def start_link(server_impl, args, :no_name) do
-    GenServer.start_link(__MODULE__, [server_impl, args])
+  def start_link(args, :no_name) do
+    GenServer.start_link(__MODULE__, [args])
   end
-  def start_link(server_impl, args, name) do
-    GenServer.start_link(__MODULE__, [server_impl, args, name], [name: name])
+  def start_link(args, name) do
+    GenServer.start_link(__MODULE__, [args, name], [name: name])
   end
 
   def kafka_server_init([args]) do

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -18,41 +18,41 @@ defmodule KafkaEx.ConsumerGroup.Test do
   test "create_worker allows us to disable the consumer group" do
     {:ok, pid} = KafkaEx.create_worker(:barney, consumer_group: :no_consumer_group)
 
-    consumer_group = :sys.get_state(pid).callback_state.consumer_group
+    consumer_group = :sys.get_state(pid).consumer_group
     assert consumer_group == :no_consumer_group
   end
 
   test "create_worker allows us to provide a consumer group" do
     {:ok, pid} = KafkaEx.create_worker(:bah, consumer_group: "my_consumer_group")
-    consumer_group = :sys.get_state(pid).callback_state.consumer_group
+    consumer_group = :sys.get_state(pid).consumer_group
 
     assert consumer_group == "my_consumer_group"
   end
 
   test "create_worker allows custom consumer_group_update_interval" do
     {:ok, pid} = KafkaEx.create_worker(:consumer_group_update_interval_custom, uris: uris, consumer_group_update_interval: 10)
-    consumer_group_update_interval = :sys.get_state(pid).callback_state.consumer_group_update_interval
+    consumer_group_update_interval = :sys.get_state(pid).consumer_group_update_interval
 
     assert consumer_group_update_interval == 10
   end
 
   test "create_worker provides a default consumer_group_update_interval of '30000'" do
     {:ok, pid} = KafkaEx.create_worker(:de, uris: uris)
-    consumer_group_update_interval = :sys.get_state(pid).callback_state.consumer_group_update_interval
+    consumer_group_update_interval = :sys.get_state(pid).consumer_group_update_interval
 
     assert consumer_group_update_interval == 30000
   end
 
   test "create_worker provides a default consumer_group of 'kafka_ex'" do
     {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris)
-    consumer_group = :sys.get_state(pid).callback_state.consumer_group
+    consumer_group = :sys.get_state(pid).consumer_group
 
     assert consumer_group == "kafka_ex"
   end
 
   test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
     {:ok, pid} = KafkaEx.create_worker(:joe, [uris: uris, consumer_group: "foo"])
-    consumer_group = :sys.get_state(pid).callback_state.consumer_group
+    consumer_group = :sys.get_state(pid).consumer_group
 
     assert consumer_group == "foo"
   end
@@ -73,7 +73,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
     KafkaEx.create_worker(:consumer_group_metadata_worker, consumer_group: random_string, uris: Application.get_env(:kafka_ex, :brokers))
     pid = Process.whereis(:consumer_group_metadata_worker)
     metadata = KafkaEx.consumer_group_metadata(:consumer_group_metadata_worker, random_string)
-    consumer_group_metadata = :sys.get_state(pid).callback_state.consumer_metadata
+    consumer_group_metadata = :sys.get_state(pid).consumer_metadata
 
     assert metadata != %Proto.ConsumerMetadata.Response{}
     assert metadata.coordinator_host != nil
@@ -86,12 +86,10 @@ defmodule KafkaEx.ConsumerGroup.Test do
     {:ok, pid} = KafkaEx.create_worker(:update_consumer_metadata, [uris: uris, consumer_group: "kafka_ex", consumer_group_update_interval: 100])
     consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
     :sys.replace_state(pid, fn(state) ->
-      callback_state = state.callback_state
-      new_callback_state = %{callback_state | :consumer_metadata => consumer_metadata}
-      %{state | :callback_state => new_callback_state}
+      %{state | :consumer_metadata => consumer_metadata}
     end)
     :timer.sleep(105)
-    new_consumer_metadata = :sys.get_state(pid).callback_state.consumer_metadata
+    new_consumer_metadata = :sys.get_state(pid).consumer_metadata
 
     refute new_consumer_metadata == consumer_metadata
   end
@@ -100,12 +98,10 @@ defmodule KafkaEx.ConsumerGroup.Test do
     {:ok, pid} = KafkaEx.create_worker(:no_consumer_metadata_update, [uris: uris, consumer_group: :no_consumer_group, consumer_group_update_interval: 100])
     consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
     :sys.replace_state(pid, fn(state) ->
-      callback_state = state.callback_state
-      new_callback_state = %{callback_state | :consumer_metadata => consumer_metadata}
-      %{state | :callback_state => new_callback_state}
+      %{state | :consumer_metadata => consumer_metadata}
     end)
     :timer.sleep(105)
-    new_consumer_metadata = :sys.get_state(pid).callback_state.consumer_metadata
+    new_consumer_metadata = :sys.get_state(pid).consumer_metadata
 
     assert new_consumer_metadata == consumer_metadata
   end
@@ -191,7 +187,7 @@ defmodule KafkaEx.ConsumerGroup.Test do
 
     KafkaEx.offset_fetch(worker_name, %KafkaEx.Protocol.OffsetFetch.Request{topic: topic, partition: 0})
 
-    assert :sys.get_state(:offset_fetch_consumer_group).callback_state.consumer_group == consumer_group
+    assert :sys.get_state(:offset_fetch_consumer_group).consumer_group == consumer_group
   end
 
   #offset_commit


### PR DESCRIPTION
After calling `use KafkaEx.Server`, the handle_call/info callbacks are inserted
into the current module. Thus they can call kafka_server_* functions locally,
rather than as server_impl.kafka_server_*. This saves the trouble of storing
server_impl in the GenServer state.