### PR TITLE
Use node_id for broker comparisons

### DIFF
--- a/lib/kafka_ex/protocol/consumer_metadata.ex
+++ b/lib/kafka_ex/protocol/consumer_metadata.ex
@@ -16,7 +16,7 @@ defmodule KafkaEx.Protocol.ConsumerMetadata do
     }
 
     def broker_for_consumer_group(brokers, consumer_group_metadata) do
-      Enum.find(brokers, &(&1.host == consumer_group_metadata.coordinator_host && &1.port == consumer_group_metadata.coordinator_port && &1.socket && is_list(Port.info(&1.socket))))
+      Enum.find(brokers, &(&1.node_id == consumer_group_metadata.coordinator_id && &1.socket && is_list(Port.info(&1.socket))))
     end
   end
 

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -49,7 +49,7 @@ defmodule KafkaEx.Protocol.Metadata do
 
   defmodule Broker do
     @moduledoc false
-    defstruct node_id: 0, host: "", port: 0, socket: nil
+    defstruct node_id: -1, host: "", port: 0, socket: nil
     @type t :: %Broker{node_id: non_neg_integer, host: binary, port: non_neg_integer, socket: nil | :gen_tcp.socket}
 
     def connected?(broker = %Broker{}) do
@@ -83,7 +83,7 @@ defmodule KafkaEx.Protocol.Metadata do
 
   defp parse_brokers(0, rest, brokers), do: {brokers, rest}
 
-  defp parse_brokers(brokers_size, << node_id :: 32-signed, host_len :: 16-signed, host :: size(host_len)-binary, port :: 32-signed, rest :: binary >>, brokers) do
+  defp parse_brokers(brokers_size, msg = << node_id :: 32-signed, host_len :: 16-signed, host :: size(host_len)-binary, port :: 32-signed, rest :: binary >>, brokers) do
     parse_brokers(brokers_size - 1, rest, [%Broker{node_id: node_id, host: host, port: port} | brokers])
   end
 

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -21,6 +21,8 @@ defmodule KafkaEx.Server0P8P0 do
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, sync_timeout)
     state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, metadata_update_interval: metadata_update_interval, worker_name: name, sync_timeout: sync_timeout}
+    # Get the initial "real" broker list and start a regular refresh cycle.
+    state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
 
     {:ok, state}

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -44,6 +44,8 @@ defmodule KafkaEx.Server0P8P2 do
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, sync_timeout)
     state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, sync_timeout: sync_timeout}
+    # Get the initial "real" broker list and start a regular refresh cycle.
+    state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
 
     # only start the consumer group update cycle if we are using consumer groups

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -47,6 +47,8 @@ defmodule KafkaEx.Server0P9P0 do
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, sync_timeout)
     state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, sync_timeout: sync_timeout}
+    # Get the initial "real" broker list and start a regular refresh cycle.
+    state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
 
     # only start the consumer group update cycle if we are using consumer groups

--- a/test/protocol/consumer_metadata_test.exs
+++ b/test/protocol/consumer_metadata_test.exs
@@ -15,14 +15,15 @@ defmodule KafkaEx.Protocol.ConsumerMetadata.Test do
 
   test "Response.broker_for_consumer_group returns correct coordinator_broker" do
     fake_socket = Port.open({:spawn, "cat"}, [])
-    consumer_group_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{coordinator_host: "192.168.59.103", coordinator_id: 49162, coordinator_port: 49162, error_code: :no_error}
+    # Note that just the coordinator_id is used here for comparison
+    consumer_group_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{coordinator_host: "127.0.0.1", coordinator_id: 49162, coordinator_port: 8123, error_code: :no_error}
 
     brokers = [
-        %KafkaEx.Protocol.Metadata.Broker{host: "192.168.0.1", port: 9092, socket: fake_socket},
-        %KafkaEx.Protocol.Metadata.Broker{host: "192.168.59.103", port: 49162, socket: fake_socket}
+        %KafkaEx.Protocol.Metadata.Broker{host: "192.168.0.1", port: 9092, node_id: 42, socket: fake_socket},
+        %KafkaEx.Protocol.Metadata.Broker{host: "192.168.59.103", port: 49162, node_id: 49162, socket: fake_socket}
     ]
 
-    assert KafkaEx.Protocol.ConsumerMetadata.Response.broker_for_consumer_group(brokers, consumer_group_metadata) == %KafkaEx.Protocol.Metadata.Broker{host: "192.168.59.103", port: 49162, socket: fake_socket}
+    assert KafkaEx.Protocol.ConsumerMetadata.Response.broker_for_consumer_group(brokers, consumer_group_metadata) == %KafkaEx.Protocol.Metadata.Broker{host: "192.168.59.103", port: 49162, node_id: 49162, socket: fake_socket}
     Port.close(fake_socket)
   end
 


### PR DESCRIPTION
This removes potential confusion when the configured broker hostport is different
from the advertised one. Also, a bootstrap metadata call is added that quickly
replaces whatever was configured with the actual cluster state to make sure that
these comparisons always work as we now work with returned broker information
including node ids instead of just host:port from the bootstrap broker list
in the configuration.

WIP - if these changes are ok for 0.9, then probably need to be applied to 0.8 as well.