### PR TITLE
Use earliest available offset on partition

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -339,7 +339,8 @@ Optional arguments(KeywordList)
           |> OffsetFetchResponse.last_offset
 
         if last_offset <= 0 do
-          0
+          earliest_offset(topic, partition, worker_name)
+          |> OffsetResponse.extract_offset
         else
           last_offset + 1
         end

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -15,6 +15,9 @@ defmodule KafkaEx.Protocol.Offset do
     @moduledoc false
     defstruct topic: nil, partition_offsets: []
     @type t :: %Response{topic: binary, partition_offsets: list}
+
+    def extract_offset([%__MODULE__{partition_offsets: [%{offset: [offset]}]}]), do: offset
+    def extract_offset([%__MODULE__{partition_offsets: [%{offset: []}]}]), do: 0
   end
 
   def create_request(correlation_id, client_id, topic, partition, time) do


### PR DESCRIPTION
If you use offset 0 for a topic that's been around a while, it might not be available. At least on Kafka 0.8.2 you get an error `:offset_out_of_range` and no messages are returns.

This PR uses `earliest_offset` to get the first that's available.

I don't know if tests pass, as I am still working on getting `snappy` to compile on my machine. Until I do, I'd like input on if you think this change is a good idea.