### PR TITLE
Offsets start at -1, 0 is valid

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -338,7 +338,7 @@ Optional arguments(KeywordList)
           |> offset_fetch(%OffsetFetchRequest{topic: topic, partition: partition})
           |> OffsetFetchResponse.last_offset
 
-        if last_offset <= 0 do
+        if last_offset < 0 do
           earliest_offset(topic, partition, worker_name)
           |> OffsetResponse.extract_offset
         else


### PR DESCRIPTION
We have noticed a bug in the behavior of `KafkaEx`'s boundary conditions for offsets. Specifically, topic-partitions are initialized at an offset value of -1. In the existing code, a last_offset of 0 is special-cased, while all positive integer offsets are incremented. This PR removes the special case for 0.

