### PR TITLE
Reduce logging level when connecting to broker

### DIFF
--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -383,7 +383,7 @@ defmodule KafkaEx.Server do
         case length(brokers_to_keep) do
           0 -> brokers_to_remove
           _ -> Enum.each(brokers_to_remove, fn(broker) ->
-            Logger.log(:info, "Closing connection to broker #{broker.node_id}: #{inspect broker.host} on port #{inspect broker.port}")
+            Logger.log(:debug, "Closing connection to broker #{broker.node_id}: #{inspect broker.host} on port #{inspect broker.port}")
             NetworkClient.close_socket(broker.socket)
           end)
             brokers_to_keep

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -393,7 +393,7 @@ defmodule KafkaEx.Server do
       defp add_new_brokers(brokers, [], _, _), do: brokers
       defp add_new_brokers(brokers, [metadata_broker|metadata_brokers], ssl_options, use_ssl) do
         case Enum.find(brokers, &(metadata_broker.node_id == &1.node_id)) do
-          nil -> Logger.log(:info, "Establishing connection to broker #{metadata_broker.node_id}: #{inspect metadata_broker.host} on port #{inspect metadata_broker.port}")
+          nil -> Logger.log(:debug, "Establishing connection to broker #{metadata_broker.node_id}: #{inspect metadata_broker.host} on port #{inspect metadata_broker.port}")
             add_new_brokers([%{metadata_broker | socket: NetworkClient.create_socket(metadata_broker.host, metadata_broker.port, ssl_options, use_ssl)} | brokers], metadata_brokers, ssl_options, use_ssl)
           _ -> add_new_brokers(brokers, metadata_brokers, ssl_options, use_ssl)
         end


### PR DESCRIPTION
Hi, Thank you for the great library!

We are trying to reduce the amount of logging our application is producing and this log in particular is generating on the order of 100k logs per hour.

```"Establishing connection to broker #{metadata_broker.node_id}: #{inspect metadata_broker.host} on port #{inspect metadata_broker.port}"```

Do you mind reducing the logging level to :debug so that we may compile it out when we run in production?

Thanks,

David