### PR TITLE
Switch to dialyxir, add ssl to apps, update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,13 @@
 - Make sure the unit tests pass: `mix test --no-start`
 - Make sure the integration tests pass: `mix test --only integration`
 - Make sure the consumer group tests pass: `mix test --only consumer_group`
-- Make sure dialyzer returns clean: `mix dialyze --unmatched-returns --error-handling --race-conditions --underspecs`
+- Make sure dialyzer returns clean: `mix dialyzer` *See below*
 - Push your feature branch: `git push origin feature_branch`
 - Submit a pull request with your feature branch
 
 Thanks!
+
+*Dialyzer note*  This repo currently produces several dialyzer warnings.  We
+are working on cleaning those up.  In the meantime, try to make sure that your
+contribution does not _add_ any dialyzer warnings.  You can check this by
+comparing the results of `mix dialyzer` on master and your branch.

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ mix test --include integration
 ### Static analysis
 
 ```
-mix dialyze --unmatched-returns --error-handling --race-conditions --underspecs
+mix dialyzer
 ```
 
 ### Contributing

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,14 @@ defmodule KafkaEx.Mixfile do
     [app: :kafka_ex,
      version: "0.6.1",
      elixir: "~> 1.0",
+     dialyzer: [
+       plt_add_deps: :transitive,
+       flags: [
+         "-Werror_handling",
+         "-Wrace_conditions",
+         "-Wunderspecs"
+       ]
+     ],
      description: description,
      package: package,
      deps: deps,
@@ -14,14 +22,14 @@ defmodule KafkaEx.Mixfile do
   def application do
     [
       mod: {KafkaEx, []},
-      applications: [:logger]
+      applications: [:logger, :ssl]
     ]
   end
 
   defp deps do
     [
       {:earmark, "~> 0.2.1", only: :dev},
-      {:dialyze, "~> 0.2", only: :dev},
+      {:dialyxir, "~> 0.4.3", only: :dev},
       {:ex_doc, "~> 0.12.0", only: :dev},
       {:credo, "~> 0.4.5", only: :dev},
       {:snappy,

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.4.12", "f5e1973405ea25c6e64959fb0b6bf92950147a0278cc2a002a491b45f78f7b87", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
As per https://github.com/fishcakez/dialyze dialyze is no longer
maintained and dialyxir should be favored.

Adding `:ssl` to the apps list removes warnings about unknown functions
in the `:ssl` OTP and should be there for anyone who wants to use ssl
functionality inside a release built with distillery or exrm.