### PR TITLE
Validate ssl options, relax use_ssl false condns

### DIFF
--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -1,6 +1,15 @@
 defmodule KafkaEx.Config do
   @moduledoc false
 
+  require Logger
+
+  def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl)
+  # use this function to get the ssl options - it verifies the options and
+  #   either emits warnings or raises errors as appropriate on misconfiguration
+  def ssl_options do
+    ssl_options(use_ssl(), Application.get_env(:kafka_ex, :ssl_options))
+  end
+
   def default_worker do
     :kafka_ex
   end
@@ -15,4 +24,50 @@ defmodule KafkaEx.Config do
   defp server("0.8.2"), do: KafkaEx.Server0P8P2
   defp server(_), do: KafkaEx.Server0P9P0
 
+  # ssl_options should be an empty list by default if use_ssl is false
+  defp ssl_options(false, []), do: []
+  defp ssl_options(false, nil), do: []
+  # emit a warning if use_ssl is false but options are present
+  #   (this is not a fatal error and can occur if one disables ssl in the
+  #    default option set)
+  defp ssl_options(false, options) do
+    Logger.warn("Ignoring ssl_options #{inspect options} because " <>
+      "use_ssl is false.  If you do not intend to use ssl and want to " <>
+      "remove this warning, set `ssl_options: []` in the KafkaEx config.")
+    []
+  end
+  # if ssl is enabled, verify that cacertfile, certfile, and keyfile are set
+  # and point to readable files
+  defp ssl_options(true, options) do
+    options
+    |> verify_ssl_file(:cacertfile)
+    |> verify_ssl_file(:certfile)
+    |> verify_ssl_file(:keyfile)
+  end
+
+  defp verify_ssl_file(options, key) do
+    verify_ssl_file(options, key, Keyword.get(options, key))
+  end
+
+  defp verify_ssl_file(options, key, nil) do
+    # cert file not specified
+    raise(
+      ArgumentError,
+      message: "SSL option #{inspect key} was not set in #{inspect options}"
+    )
+  end
+  defp verify_ssl_file(options, key, path) do
+    # make sure the file is readable to us
+    #    (there is a way to do this without reading the file, but these should
+    #      be small files so this is probably the simplest option)
+    case File.read(path) do
+      {:ok, _} -> options
+      {:error, reason} ->
+        raise(
+          ArgumentError,
+          message: "SSL option #{inspect key} could not be read.  " <>
+            "Error: #{inspect reason}"
+        )
+    end
+  end
 end

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -3,6 +3,7 @@ defmodule KafkaEx.Server0P9P0 do
   Implements kafkaEx.Server behaviors for kafka 0.9.0 API.
   """
   use KafkaEx.Server
+  alias KafkaEx.Config
   alias KafkaEx.Protocol.ConsumerMetadata
   alias KafkaEx.Protocol.ConsumerMetadata.Response, as: ConsumerMetadataResponse
   alias KafkaEx.Protocol.Heartbeat
@@ -45,13 +46,13 @@ defmodule KafkaEx.Server0P9P0 do
     uris = Keyword.get(args, :uris, [])
     metadata_update_interval = Keyword.get(args, :metadata_update_interval, @metadata_update_interval)
     consumer_group_update_interval = Keyword.get(args, :consumer_group_update_interval, @consumer_group_update_interval)
-    use_ssl = Keyword.get(args, :use_ssl, false)
-    ssl_options = Keyword.get(args, :ssl_options, [])
-
     # this should have already been validated, but it's possible someone could
     # try to short-circuit the start call
     consumer_group = Keyword.get(args, :consumer_group)
     true = KafkaEx.valid_consumer_group?(consumer_group)
+
+    use_ssl = Config.use_ssl()
+    ssl_options = Config.ssl_options()
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end)
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -1,0 +1,48 @@
+defmodule KafkaEx.ConfigTest do
+  alias KafkaEx.Config
+
+  use ExUnit.Case
+
+  setup do
+    # reset application env after each test
+    env_before = Application.get_all_env(:kafka_ex)
+    on_exit fn ->
+      # this is basically Application.put_all_env
+      for {k, v} <- env_before do
+        Application.put_env(:kafka_ex, k, v)
+      end
+      :ok
+    end
+    :ok
+  end
+
+  test "ssl_options returns the correct value when configured properly" do
+    Application.put_env(:kafka_ex, :use_ssl, true)
+    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
+    assert ssl_options == Config.ssl_options()
+  end
+
+  test "ssl_options returns an empty list when use_ssl is false" do
+    Application.put_env(:kafka_ex, :use_ssl, false)
+    Application.put_env(:kafka_ex, :ssl_options, nil)
+    assert [] == Config.ssl_options()
+
+    Application.put_env(:kafka_ex, :ssl_options, [foo: :bar])
+    assert [] == Config.ssl_options()
+  end
+
+  test "ssl_options raises an error if cacertfile is missing or invalid" do
+    Application.put_env(:kafka_ex, :use_ssl, true)
+    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
+
+    key = :cacertfile
+    without_file = Keyword.delete(ssl_options, key)
+
+    Application.put_env(:kafka_ex, :ssl_options, without_file)
+    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
+
+    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
+    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
+    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
+  end
+end

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -45,4 +45,34 @@ defmodule KafkaEx.ConfigTest do
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
   end
+
+  test "ssl_options raises an error if certfile is missing or invalid" do
+    Application.put_env(:kafka_ex, :use_ssl, true)
+    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
+
+    key = :certfile
+    without_file = Keyword.delete(ssl_options, key)
+
+    Application.put_env(:kafka_ex, :ssl_options, without_file)
+    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
+
+    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
+    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
+    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
+  end
+
+  test "ssl_options raises an error if keyfile is missing or invalid" do
+    Application.put_env(:kafka_ex, :use_ssl, true)
+    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
+
+    key = :keyfile
+    without_file = Keyword.delete(ssl_options, key)
+
+    Application.put_env(:kafka_ex, :ssl_options, without_file)
+    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
+
+    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
+    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
+    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
+  end
 end


### PR DESCRIPTION
Closes #178

I'm not an ssl expert so wasn't sure what else to do for validation.  This checks for `:certfile` `:cacertfile` and `:keyfile` being set and pointing to readable files.  If anyone has input on that it'd be appreciated!