### PR TITLE
Fix ssl configuration per worker

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -17,9 +17,9 @@ defmodule KafkaEx do
 
   @type uri() :: [{binary|char_list, number}]
   @type worker_init :: [worker_setting]
-  @type ssl_options :: [{:ssl_ca_cert_file, binary} |
-                        {:ssl_cert_file, binary} |
-                        {:ssl_cert_key_file, binary} |
+  @type ssl_options :: [{:cacertfile, binary} |
+                        {:certfile, binary} |
+                        {:keyfile, binary} |
                         {:password, binary}]
   @type worker_setting :: {:uris, uri}  |
                           {:consumer_group, binary | :no_consumer_group} |
@@ -318,8 +318,8 @@ Optional arguments(KeywordList)
     defaults = [
       uris: Application.get_env(:kafka_ex, :brokers),
       consumer_group: Application.get_env(:kafka_ex, :consumer_group),
-      use_ssl: Application.get_env(:kafka_ex, :use_ssl, false),
-      ssl_options: Application.get_env(:kafka_ex, :ssl_options, []),
+      use_ssl: Config.use_ssl(),
+      ssl_options: Config.ssl_options(),
     ]
 
     worker_init = Keyword.merge(defaults, worker_init)

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -50,11 +50,9 @@ defmodule KafkaEx.Config do
   end
 
   defp verify_ssl_file(options, key, nil) do
-    # cert file not specified
-    raise(
-      ArgumentError,
-      message: "SSL option #{inspect key} was not set in #{inspect options}"
-    )
+    # cert file not present - it will be up to :ssl to determine if this is ok
+    # given the other settings
+    options
   end
   defp verify_ssl_file(options, key, path) do
     # make sure the file is readable to us

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -49,7 +49,7 @@ defmodule KafkaEx.Config do
     verify_ssl_file(options, key, Keyword.get(options, key))
   end
 
-  defp verify_ssl_file(options, key, nil) do
+  defp verify_ssl_file(options, _key, nil) do
     # cert file not present - it will be up to :ssl to determine if this is ok
     # given the other settings
     options

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -3,7 +3,6 @@ defmodule KafkaEx.Server0P9P0 do
   Implements kafkaEx.Server behaviors for kafka 0.9.0 API.
   """
   use KafkaEx.Server
-  alias KafkaEx.Config
   alias KafkaEx.Protocol.ConsumerMetadata
   alias KafkaEx.Protocol.ConsumerMetadata.Response, as: ConsumerMetadataResponse
   alias KafkaEx.Protocol.Heartbeat
@@ -51,8 +50,8 @@ defmodule KafkaEx.Server0P9P0 do
     consumer_group = Keyword.get(args, :consumer_group)
     true = KafkaEx.valid_consumer_group?(consumer_group)
 
-    use_ssl = Config.use_ssl()
-    ssl_options = Config.ssl_options()
+    use_ssl = Keyword.get(args, :use_ssl, false)
+    ssl_options = Keyword.get(args, :ssl_options, [])
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end)
     sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -31,46 +31,31 @@ defmodule KafkaEx.ConfigTest do
     assert [] == Config.ssl_options()
   end
 
-  test "ssl_options raises an error if cacertfile is missing or invalid" do
+  test "ssl_options raises an error if cacertfile is invalid" do
     Application.put_env(:kafka_ex, :use_ssl, true)
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :cacertfile
-    without_file = Keyword.delete(ssl_options, key)
-
-    Application.put_env(:kafka_ex, :ssl_options, without_file)
-    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
-
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
   end
 
-  test "ssl_options raises an error if certfile is missing or invalid" do
+  test "ssl_options raises an error if certfile is invalid" do
     Application.put_env(:kafka_ex, :use_ssl, true)
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :certfile
-    without_file = Keyword.delete(ssl_options, key)
-
-    Application.put_env(:kafka_ex, :ssl_options, without_file)
-    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
-
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
   end
 
-  test "ssl_options raises an error if keyfile is missing or invalid" do
+  test "ssl_options raises an error if keyfile is invalid" do
     Application.put_env(:kafka_ex, :use_ssl, true)
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :keyfile
-    without_file = Keyword.delete(ssl_options, key)
-
-    Application.put_env(:kafka_ex, :ssl_options, without_file)
-    assert_raise(ArgumentError, ~r/not set/, &Config.ssl_options/0)
-
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -36,6 +36,12 @@ defmodule KafkaEx.ConfigTest do
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :cacertfile
+
+    # the option may be omitted - it is up to :ssl to determine if this is ok
+    without_key = Keyword.delete(ssl_options, key)
+    Application.put_env(:kafka_ex, :ssl_options, without_key)
+    assert without_key == Config.ssl_options()
+
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
@@ -46,6 +52,12 @@ defmodule KafkaEx.ConfigTest do
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :certfile
+
+    # the option may be omitted - it is up to :ssl to determine if this is ok
+    without_key = Keyword.delete(ssl_options, key)
+    Application.put_env(:kafka_ex, :ssl_options, without_key)
+    assert without_key == Config.ssl_options()
+
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
@@ -56,6 +68,12 @@ defmodule KafkaEx.ConfigTest do
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
     key = :keyfile
+
+    # the option may be omitted - it is up to :ssl to determine if this is ok
+    without_key = Keyword.delete(ssl_options, key)
+    Application.put_env(:kafka_ex, :ssl_options, without_key)
+    assert without_key == Config.ssl_options()
+
     with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
     Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
     assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,8 +4,8 @@ ExUnit.configure exclude: [integration: true, consumer_group: true, server_0_p_9
 
 defmodule TestHelper do
   def generate_random_string(string_length \\ 20) do
-    :random.seed(:os.timestamp)
-    Enum.map(1..string_length, fn _ -> (:random.uniform * 25 + 65) |> round end) |> to_string
+    :rand.seed(:os.timestamp)
+    Enum.map(1..string_length, fn _ -> (:rand.uniform * 25 + 65) |> round end) |> to_string
   end
 
   # Wait for the return value of value_getter to pass the predicate condn

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,7 +4,8 @@ ExUnit.configure exclude: [integration: true, consumer_group: true, server_0_p_9
 
 defmodule TestHelper do
   def generate_random_string(string_length \\ 20) do
-    Enum.map(1..string_length, fn _ -> (:rand.uniform * 25 + 65) |> round end) |> to_string
+    :random.seed(:os.timestamp)
+    Enum.map(1..string_length, fn _ -> (:random.uniform * 25 + 65) |> round end) |> to_string
   end
 
   # Wait for the return value of value_getter to pass the predicate condn

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,7 +4,6 @@ ExUnit.configure exclude: [integration: true, consumer_group: true, server_0_p_9
 
 defmodule TestHelper do
   def generate_random_string(string_length \\ 20) do
-    :rand.seed(:os.timestamp)
     Enum.map(1..string_length, fn _ -> (:rand.uniform * 25 + 65) |> round end) |> to_string
   end
 


### PR DESCRIPTION
Fixes a problem I accidentally introduced in #179 

Also:
* Fix `ssl_options` type
* Remove validation of the presence of the certfiles in ssl_options - It looks like there are other valid combinations of options here.  We still validate that the files are readable if they are present in the options and use_ssl is set to true.
