### PR TITLE
Consumer Group

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -6,6 +6,12 @@ defmodule KafkaEx do
   alias KafkaEx.Protocol.ConsumerMetadata.Response, as: ConsumerMetadataResponse
   alias KafkaEx.Protocol.Fetch.Response, as: FetchResponse
   alias KafkaEx.Protocol.Fetch.Request, as: FetchRequest
+  alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
+  alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse
+  alias KafkaEx.Protocol.JoinGroup.Request, as: JoinGroupRequest
+  alias KafkaEx.Protocol.JoinGroup.Response, as: JoinGroupResponse
+  alias KafkaEx.Protocol.LeaveGroup.Request, as: LeaveGroupRequest
+  alias KafkaEx.Protocol.LeaveGroup.Response, as: LeaveGroupResponse
   alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
   alias KafkaEx.Protocol.Offset.Response, as: OffsetResponse
   alias KafkaEx.Protocol.OffsetCommit.Request, as: OffsetCommitRequest
@@ -14,6 +20,8 @@ defmodule KafkaEx do
   alias KafkaEx.Protocol.OffsetFetch.Request, as: OffsetFetchRequest
   alias KafkaEx.Protocol.Produce.Request, as: ProduceRequest
   alias KafkaEx.Protocol.Produce.Message
+  alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
+  alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
   alias KafkaEx.Server
 
   @type uri() :: [{binary|char_list, number}]
@@ -72,6 +80,46 @@ defmodule KafkaEx do
   @spec consumer_group(atom | pid) :: binary | :no_consumer_group
   def consumer_group(worker \\ Config.default_worker) do
     Server.call(worker, :consumer_group)
+  end
+
+  @doc """
+  Sends a request to join a consumer group.
+  """
+  @spec join_group(JoinGroupRequest.t, Keyword.t) :: JoinGroupResponse.t
+  def join_group(request, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    timeout = Keyword.get(opts, :timeout)
+    Server.call(worker_name, {:join_group, request, timeout}, opts)
+  end
+
+  @doc """
+  Sends a request to synchronize with a consumer group.
+  """
+  @spec sync_group(SyncGroupRequest.t, Keyword.t) :: SyncGroupResponse.t
+  def sync_group(request, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    timeout = Keyword.get(opts, :timeout)
+    Server.call(worker_name, {:sync_group, request, timeout}, opts)
+  end
+
+  @doc """
+  Sends a request to leave a consumer group.
+  """
+  @spec leave_group(LeaveGroupRequest.t, Keyword.t) :: LeaveGroupResponse.t
+  def leave_group(request, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    timeout = Keyword.get(opts, :timeout)
+    Server.call(worker_name, {:leave_group, request, timeout}, opts)
+  end
+
+  @doc """
+  Sends a heartbeat to maintain membership in a consumer group.
+  """
+  @spec heartbeat(HeartbeatRequest.t, Keyword.t) :: HeartbeatResponse.t
+  def heartbeat(request, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    timeout = Keyword.get(opts, :timeout)
+    Server.call(worker_name, {:heartbeat, request, timeout}, opts)
   end
 
   @doc """
@@ -196,7 +244,7 @@ defmodule KafkaEx do
     }, opts)
   end
 
-  @spec offset_commit(atom, OffsetCommitRequest.t) :: OffsetCommitResponse.t
+  @spec offset_commit(atom, OffsetCommitRequest.t) :: [OffsetCommitResponse.t]
   def offset_commit(worker_name, offset_commit_request) do
     Server.call(worker_name, {:offset_commit, offset_commit_request})
   end

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -1,0 +1,309 @@
+defmodule KafkaEx.ConsumerGroup do
+  @moduledoc """
+  A process that manages membership in a Kafka consumer group.
+
+  Consumers in a consumer group coordinate with each other through a Kafka broker to distribute the
+  work of consuming one or several topics without any overlap. This is facilitated by the [Kafka
+  client-side assignment
+  protocol](https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Client-side+Assignment+Proposal).
+
+  Any time group membership changes (a member joins or leaves the group), a Kafka broker initiates
+  group synchronization by asking one of the group members (the leader) to provide partition
+  assignments for the whole group. Partition assignment is handled by the
+  `c:KafkaEx.GenConsumer.assign_partitions/2` callback of the provided consumer module.
+
+  A `ConsumerGroup` process is responsible for:
+
+  1. Maintaining membership in a Kafka consumer group.
+  2. Determining partition assignments if elected as the group leader.
+  3. Launching and terminating `GenConsumer` processes based on its assigned partitions.
+
+  To use a `ConsumerGroup`, a developer must define a module that implements the
+  `KafkaEx.GenConsumer` behaviour and start a `ConsumerGroup` with that module.
+
+  ## Example
+
+  The following consumer prints each message with the name of the node that's consuming the message:
+
+  ```
+  defmodule DistributedConsumer do
+    use KafkaEx.GenConsumer
+
+    def handle_message(%Message{value: message}, state) do
+      IO.puts(to_string(node()) <> ": " <> inspect(message))
+      {:ack, state}
+    end
+  end
+
+  # use DistributedConsumer in a consumer group
+  {:ok, pid} = KafkaEx.ConsumerGroup.start_link(DistributedConsumer, "test_group", ["test_topic"])
+  ```
+
+  Running this on multiple nodes might display the following:
+
+  ```txt
+  node1@host: "messages"
+  node2@host: "on"
+  node2@host: "multiple"
+  node1@host: "nodes"
+  ```
+
+  It is not necessary for the nodes to be connected, because `ConsumerGroup` uses Kafka's built-in
+  group coordination protocol.
+  """
+
+  use GenServer
+
+  alias KafkaEx.Config
+  alias KafkaEx.Protocol.JoinGroup.Request, as: JoinGroupRequest
+  alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
+  alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse
+  alias KafkaEx.Protocol.LeaveGroup.Request, as: LeaveGroupRequest
+  alias KafkaEx.Protocol.LeaveGroup.Response, as: LeaveGroupResponse
+  alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
+  alias KafkaEx.Protocol.Metadata.TopicMetadata
+  alias KafkaEx.Protocol.Metadata.PartitionMetadata
+  alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
+  alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
+
+  require Logger
+
+  defmodule State do
+    @moduledoc false
+    defstruct [
+      :worker_name,
+      :heartbeat_interval,
+      :session_timeout,
+      :consumer_module,
+      :consumer_opts,
+      :group_name,
+      :topics,
+      :partitions,
+      :member_id,
+      :generation_id,
+      :assignments,
+      :consumer_pid,
+    ]
+  end
+
+  @heartbeat_interval 5_000
+  @session_timeout 30_000
+
+  # Client API
+
+  @doc """
+  Starts a `ConsumerGroup` process linked to the current process.
+
+  This can be used to start a `ConsumerGroup` as part of a supervision tree.
+
+  `module` is a module that implements the `KafkaEx.GenConsumer` behaviour. `group_name` is the name
+  of the consumer group. `topics` is a list of topics that the consumer group should consume from.
+  `opts` can be any options accepted by `GenConsumer` or `GenServer`.
+
+  ### Return Values
+
+  This function has the same return values as `GenServer.start_link/3`.
+
+  If the consumer group is successfully created and initialized, this function returns `{:ok, pid}`,
+  where `pid` is the PID of the consumer group process.
+  """
+  @spec start_link(module, binary, [binary], KafkaEx.GenConsumer.options) :: GenServer.on_start
+  def start_link(consumer_module, group_name, topics, opts \\ []) do
+    {server_opts, consumer_opts} = Keyword.split(opts, [:debug, :name, :timeout, :spawn_opt])
+
+    GenServer.start_link(__MODULE__, {consumer_module, group_name, topics, consumer_opts}, server_opts)
+  end
+
+  # GenServer callbacks
+
+  def init({consumer_module, group_name, topics, opts}) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    heartbeat_interval = Keyword.get(opts, :heartbeat_interval, Application.get_env(:kafka_ex, :heartbeat_interval, @heartbeat_interval))
+    session_timeout = Keyword.get(opts, :session_timeout, Application.get_env(:kafka_ex, :session_timeout, @session_timeout))
+
+    consumer_opts = Keyword.drop(opts, [:heartbeat_interval, :session_timeout])
+
+    state = %State{
+      worker_name: worker_name,
+      heartbeat_interval: heartbeat_interval,
+      session_timeout: session_timeout,
+      consumer_module: consumer_module,
+      consumer_opts: consumer_opts,
+      group_name: group_name,
+      topics: topics,
+      member_id: "",
+    }
+
+    Process.flag(:trap_exit, true)
+
+    {:ok, state, 0}
+  end
+
+  def handle_info(:timeout, %State{generation_id: nil, member_id: ""} = state) do
+    new_state = join(state)
+
+    {:noreply, new_state, new_state.heartbeat_interval}
+  end
+
+  def handle_info(:timeout, %State{} = state) do
+    new_state = heartbeat(state)
+
+    {:noreply, new_state, new_state.heartbeat_interval}
+  end
+
+  def handle_info({:EXIT, pid, reason}, %State{consumer_pid: pid} = state) do
+    new_state = %State{state | consumer_pid: nil}
+
+    {:stop, reason, new_state}
+  end
+
+  def handle_info({:EXIT, _pid, _reason}, %State{} = state) do
+    {:noreply, state, state.heartbeat_interval}
+  end
+
+  def terminate(_reason, %State{} = state) do
+    leave(state)
+  end
+
+  # Helpers
+
+  defp join(%State{worker_name: worker_name, session_timeout: session_timeout, group_name: group_name, topics: topics, member_id: member_id} = state) do
+    join_request = %JoinGroupRequest{
+      group_name: group_name,
+      member_id: member_id,
+      topics: topics,
+      session_timeout: session_timeout,
+    }
+
+    join_response = KafkaEx.join_group(join_request, worker_name: worker_name, timeout: session_timeout + 5000)
+    new_state = %State{state | member_id: join_response.member_id, generation_id: join_response.generation_id}
+
+    Logger.debug("Joined consumer group #{group_name}")
+
+    if join_response.member_id == join_response.leader_id do
+      sync_leader(new_state, join_response.members)
+    else
+      sync_follower(new_state)
+    end
+  end
+
+  defp sync_leader(%State{worker_name: worker_name, topics: topics, partitions: nil} = state, members) do
+    %MetadataResponse{topic_metadatas: topic_metadatas} = KafkaEx.metadata(worker_name: worker_name)
+
+    partitions = Enum.flat_map(topics, fn (topic) ->
+      %TopicMetadata{error_code: :no_error, partition_metadatas: partition_metadatas} = Enum.find(topic_metadatas, &(&1.topic == topic))
+
+      Enum.map(partition_metadatas, fn (%PartitionMetadata{error_code: :no_error, partition_id: partition_id}) ->
+        {topic, partition_id}
+      end)
+    end)
+
+    sync_leader(%State{state | partitions: partitions}, members)
+  end
+
+  defp sync_leader(%State{worker_name: worker_name, session_timeout: session_timeout,
+                          group_name: group_name, generation_id: generation_id, member_id: member_id} = state, members) do
+    assignments = assign_partitions(state, members)
+
+    sync_request = %SyncGroupRequest{
+      group_name: group_name,
+      member_id: member_id,
+      generation_id: generation_id,
+      assignments: assignments,
+    }
+
+    sync_request
+    |> KafkaEx.sync_group(worker_name: worker_name, timeout: session_timeout + 5000)
+    |> update_assignments(state)
+  end
+
+  defp sync_follower(%State{worker_name: worker_name, session_timeout: session_timeout,
+                            group_name: group_name, generation_id: generation_id, member_id: member_id} = state) do
+    sync_request = %SyncGroupRequest{
+      group_name: group_name,
+      member_id: member_id,
+      generation_id: generation_id,
+      assignments: [],
+    }
+
+    sync_request
+    |> KafkaEx.sync_group(timeout: session_timeout + 5000, worker_name: worker_name)
+    |> update_assignments(state)
+  end
+
+  defp update_assignments(%SyncGroupResponse{error_code: :rebalance_in_progress}, %State{} = state), do: rebalance(state)
+  defp update_assignments(%SyncGroupResponse{error_code: :no_error, assignments: assignments}, %State{} = state) do
+    start_consumer(state, assignments)
+  end
+
+  defp heartbeat(%State{worker_name: worker_name, group_name: group_name, generation_id: generation_id, member_id: member_id} = state) do
+    heartbeat_request = %HeartbeatRequest{
+      group_name: group_name,
+      member_id: member_id,
+      generation_id: generation_id,
+    }
+
+    case KafkaEx.heartbeat(heartbeat_request, worker_name: worker_name) do
+      %HeartbeatResponse{error_code: :no_error} ->
+        state
+
+      %HeartbeatResponse{error_code: :rebalance_in_progress} ->
+        rebalance(state)
+    end
+  end
+
+  defp rebalance(%State{} = state) do
+    state
+    |> stop_consumer()
+    |> join()
+  end
+
+  defp leave(%State{worker_name: worker_name, group_name: group_name, member_id: member_id} = state) do
+    stop_consumer(state)
+
+    leave_request = %LeaveGroupRequest{
+      group_name: group_name,
+      member_id: member_id,
+    }
+
+    %LeaveGroupResponse{error_code: :no_error} = KafkaEx.leave_group(leave_request, worker_name: worker_name)
+
+    Logger.debug("Left consumer group #{group_name}")
+  end
+
+  defp start_consumer(%State{consumer_module: consumer_module, consumer_opts: consumer_opts,
+                             group_name: group_name, consumer_pid: nil} = state, assignments) do
+    assignments =
+      Enum.flat_map(assignments, fn ({topic, partition_ids}) ->
+        Enum.map(partition_ids, &({topic, &1}))
+      end)
+
+    {:ok, pid} = KafkaEx.GenConsumer.Supervisor.start_link(consumer_module, group_name, assignments, consumer_opts)
+
+    %State{state | assignments: assignments, consumer_pid: pid}
+  end
+
+  defp stop_consumer(%State{consumer_pid: nil} = state), do: state
+  defp stop_consumer(%State{consumer_pid: pid} = state) when is_pid(pid) do
+    :ok = Supervisor.stop(pid)
+    %State{state | consumer_pid: nil}
+  end
+
+  defp assign_partitions(%State{consumer_module: consumer_module, partitions: partitions}, members) do
+    assignments =
+      consumer_module.assign_partitions(members, partitions)
+      |> Enum.map(fn ({member, topic_partitions}) ->
+        assigns =
+          topic_partitions
+          |> Enum.group_by(&(elem(&1, 0)), &(elem(&1, 1)))
+          |> Enum.into([])
+
+        {member, assigns}
+      end)
+      |> Map.new
+
+    Enum.map(members, fn (member) ->
+      {member, Map.get(assignments, member, [])}
+    end)
+  end
+end

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -1,0 +1,474 @@
+defmodule KafkaEx.GenConsumer do
+  @moduledoc """
+  A behaviour module for implementing a Kafka consumer.
+
+  A `GenConsumer` is an Elixir process that consumes messages from Kafka. A single `GenConsumer`
+  process consumes from a single partition of a Kafka topic. Several `GenConsumer` processes can be
+  used to consume from multiple partitions or even multiple topics. Partition assignments for a
+  group of `GenConsumer`s can be defined manually using `KafkaEx.GenConsumer.Supervisor` or
+  coordinated across a cluster of nodes using `KafkaEx.ConsumerGroup`.
+
+  ## Example
+
+  The `GenConsumer` behaviour abstracts common Kafka consumer interactions. `GenConsumer` will take
+  care of the details of determining a starting offset, fetching messages from a Kafka broker, and
+  committing offsets for consumed messages. Developers are only required to implement
+  `c:handle_message/2` to process messages from the queue.
+
+  The following is a minimal example that logs each message as it's consumed:
+
+  ```
+  defmodule ExampleGenConsumer do
+    use KafkaEx.GenConsumer
+
+    require Logger
+
+    def handle_message(%Message{value: message}, state) do
+      Logger.debug("message: " <> inspect(message))
+      {:ack, state}
+    end
+  end
+  ```
+
+  `c:handle_message/2` will be called for each message that's fetched from a Kafka broker. In this
+  example, since `c:handle_message/2` always returns `{:ack, new_state}`, the message offsets will
+  be auto-committed.
+
+  ## Auto-Committing Offsets
+
+  `GenConsumer` manages a consumer's offsets by committing the offsets of acknowledged messages.
+  Messages are acknowledged by returning `{:ack, new_state}` from `c:handle_message/2`.
+  Acknowledged messages are not committed immediately. To avoid excessive network calls,
+  acknowledged messages may be batched and committed periodically. Offsets are also committed when a
+  `GenServer` is terminated.
+
+  How often a `GenConsumer` auto-commits offsets is controlled by the two configuration values
+  `:commit_interval` and `:commit_threshold`. These can be set globally in the `:kafka_ex` app's
+  environment or on a per-consumer basis by passing options to `start_link/5`:
+
+  ```
+  # In config/config.exs
+  config :kafka_ex,
+    commit_interval: 5000,
+    commit_threshold: 100
+
+  # As options to start_link/5
+  KafkaEx.GenConsumer.start_link(MyConsumer, "my_group", "topic", 0,
+                                 commit_interval: 5000,
+                                 commit_threshold: 100)
+  ```
+
+  * `:commit_interval` is the maximum time (in milliseconds) that a `GenConsumer` will delay
+    committing the offset for an acknowledged message.
+  * `:commit_threshold` is the maximum number of acknowledged messages that a `GenConsumer` will
+    allow to be uncommitted before triggering an auto-commit.
+
+  For low-volume topics, `:commit_interval` is the dominant factor for how often a `GenConsumer`
+  auto-commits. For high-volume topics, `:commit_threshold` is the dominant factor.
+
+  ## Callbacks
+
+  There are three callbacks that are required to be implemented in a `GenConsumer`. By adding `use
+  KafkaEx.GenServer` to a module, two of the callbacks will be defined with default behavior,
+  leaving you to implement `c:handle_message/2`.
+
+  ## Integration with OTP
+
+  A `GenConsumer` is a specialized `GenServer`. It can be supervised, registered, and debugged the
+  same as any other `GenServer`. However, its arguments for `c:GenServer.init/1` are unspecified, so
+  `start_link/5` should be used to start a `GenConsumer` process instead of `GenServer` primitives.
+
+  ## Testing
+
+  A `GenConsumer` can be unit-tested without a running Kafka broker by sending messages directly to
+  its `c:handle_message/2` function. The following recipe can be used as a starting point when
+  testing a `GenConsumer`:
+
+  ```
+  defmodule ExampleGenConsumerTest do
+    use ExUnit.Case, async: true
+
+    alias KafkaEx.Protocol.Fetch.Message
+
+    @topic "topic"
+    @partition 0
+
+    setup do
+      {:ok, state} = ExampleGenConsumer.init(@topic, @partition)
+      {:ok, %{state: state}}
+    end
+
+    test "it acks a message", %{state: state} do
+      message = %Message{offset: 0, value: "hello"}
+      {response, _new_state} = ExampleGenConsumer.handle_message(message, state)
+      assert response == :ack
+    end
+  end
+  ```
+  """
+
+  use GenServer
+
+  alias KafkaEx.Config
+  alias KafkaEx.Protocol.OffsetCommit.Request, as: OffsetCommitRequest
+  alias KafkaEx.Protocol.OffsetCommit.Response, as: OffsetCommitResponse
+  alias KafkaEx.Protocol.OffsetFetch.Request, as: OffsetFetchRequest
+  alias KafkaEx.Protocol.OffsetFetch.Response, as: OffsetFetchResponse
+  alias KafkaEx.Protocol.Offset.Response, as: OffsetResponse
+  alias KafkaEx.Protocol.Fetch.Response, as: FetchResponse
+  alias KafkaEx.Protocol.Fetch.Message
+
+  require Logger
+
+  @typedoc """
+  The ID of a member of a consumer group, assigned by a Kafka broker.
+  """
+  @type member_id :: binary
+
+  @typedoc """
+  The name of a Kafka topic.
+  """
+  @type topic :: binary
+
+  @typedoc """
+  The ID of a partition of a Kafka topic.
+  """
+  @type partition_id :: integer
+
+  @typedoc """
+  A partition of a particular Kafka topic.
+  """
+  @type partition :: {topic, partition_id}
+
+  @typedoc """
+  Option values used when starting a `GenConsumer`.
+  """
+  @type option :: {:worker_name, atom | pid}
+                | {:commit_interval, non_neg_integer}
+                | {:commit_threshold, non_neg_integer}
+
+  @typedoc """
+  Options used when starting a `GenConsumer`.
+  """
+  @type options :: [option | GenServer.option]
+
+  @doc """
+  Invoked when the server is started. `start_link/5` will block until it returns.
+
+  `topic` and `partition` are the arguments passed to `start_link/5`. They identify the Kafka
+  partition that the `GenConsumer` will consume from.
+
+  Returning `{:ok, state}` will cause `start_link/5` to return `{:ok, pid}` and the process to start
+  consuming from its assigned partition. `state` becomes the consumer's state.
+
+  Any other return value will cause the `start_link/5` to return `{:error, error}` and the process
+  to exit.
+  """
+  @callback init(topic :: topic, partition :: partition_id) :: {:ok, state :: term}
+
+  @doc """
+  Invoked for each message consumed from a Kafka queue.
+
+  `message` is a message fetched from a Kafka broker and `state` is the current state of the
+  `GenConsumer`.
+
+  Returning `{:ack, new_state}` acknowledges `message` and continues to consume from the Kafka queue
+  with new state `new_state`. Acknowledged messages will be auto-committed (possibly at a later
+  time) based on the `:commit_interval` and `:commit_threshold` options.
+
+  Returning `{:commit, new_state}` commits `message` synchronously before continuing to consume from
+  the Kafka queue with new state `new_state`. Committing a message synchronously means that no more
+  messages will be consumed until the message's offset is committed. `:commit` should be used
+  sparingly, since committing every message synchronously would impact a consumer's performance and
+  could result in excessive network traffic.
+  """
+  @callback handle_message(message :: Message.t, state :: term) :: {:ack, new_state :: term}
+                                                                 | {:commit, new_state :: term}
+
+  @doc """
+  Invoked to determine partition assignments for a coordinated consumer group.
+
+  `members` is a list of member IDs and `partitions` is a list of partitions that need to be
+  assigned to a group member.
+
+  The return value must be a map with member IDs as keys and a list of partition assignments as
+  values. For each member ID in the returned map, the assigned partitions will become the
+  `assignments` argument to `KafkaEx.GenConsumer.Supervisor.start_link/4` in the corresponding
+  member process. Any member that's omitted from the return value will not be assigned any
+  partitions.
+
+  If this callback is not implemented, the default implementation by `use KafkaEx.GenConsumer`
+  implements a simple round-robin assignment.
+
+  ### Example
+
+  Given the following `members` and `partitions` to be assigned:
+
+  ```
+  members = ["member1", "member2", "member3"]
+  partitions = [{"topic", 0}, {"topic", 1}, {"topic", 2}]
+  ```
+
+  One possible assignment is as follows:
+
+  ```
+  ExampleGenConsumer.assign_partitions(members, partitions)
+  #=> %{"member1" => [{"topic", 0}, {"topic", 2}], "member2" => [{"topic", 1}]}
+  ```
+
+  In this case, the consumer group process for `"member1"` will launch two `GenConsumer` processes
+  (one for each of its assigned partitions), `"member2"` will launch one `GenConsumer` process, and
+  `"member3"` will launch no processes.
+  """
+  @callback assign_partitions(members :: [member_id], partitions :: [partition]) :: %{member_id => [partition]}
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour KafkaEx.GenConsumer
+      alias KafkaEx.Protocol.Fetch.Message
+
+      def init(_topic, _partition) do
+        {:ok, nil}
+      end
+
+      def assign_partitions(members, partitions) do
+        Stream.cycle(members)
+        |> Enum.zip(partitions)
+        |> Enum.group_by(&(elem(&1, 0)), &(elem(&1, 1)))
+      end
+
+      defoverridable [init: 2, assign_partitions: 2]
+    end
+  end
+
+  defmodule Supervisor do
+    @moduledoc """
+    A supervisor for managing `GenConsumer` processes that are part of a consumer group.
+
+    The supervisor will launch individual `GenConsumer` processes for each partition given by the
+    `partitions` argument to `start_link/4`. When terminated, each of the supervisor's child
+    processes will commit its latest offset before terminating.
+
+    This module manages a static list of consumer processes. For dynamically distributing consumers
+    in a consumer group across a cluster of nodes, see `KafkaEx.ConsumerGroup`.
+    """
+
+    use Elixir.Supervisor
+
+    @doc """
+    Starts a `GenConsumer.Supervisor` process linked to the current process.
+
+    `module` is a module that implements the `GenConsumer` behaviour. `group_name` is the name of a
+    consumer group, and `assignments` is a list of partitions for the `GenConsumer`s to consume.
+    `opts` accepts the same options as `KafkaEx.GenConsumer.start_link/5`.
+
+    ### Return Values
+
+    This function has the same return values as `Supervisor.start_link/3`.
+
+    If the supervisor and its consumers are successfully created, this function returns `{:ok,
+    pid}`, where `pid` is the PID of the supervisor.
+    """
+    @spec start_link(module, binary, [KafkaEx.GenConsumer.partition], KafkaEx.GenConsumer.options) :: Elixir.Supervisor.on_start
+    def start_link(consumer_module, group_name, assignments, opts \\ []) do
+      case Elixir.Supervisor.start_link(__MODULE__, {consumer_module, group_name, assignments, opts}) do
+        {:ok, pid} ->
+          Enum.each(assignments, fn ({topic, partition}) ->
+            case Elixir.Supervisor.start_child(pid, [topic, partition, opts]) do
+              {:ok, _child} -> nil
+              {:ok, _child, _info} -> nil
+            end
+          end)
+
+          {:ok, pid}
+
+        error ->
+          error
+      end
+    end
+
+    def init({consumer_module, group_name, _assignments, _opts}) do
+      children = [
+        worker(KafkaEx.GenConsumer, [consumer_module, group_name])
+      ]
+
+      supervise(children, strategy: :simple_one_for_one)
+    end
+  end
+
+  defmodule State do
+    @moduledoc false
+    defstruct [
+      :consumer_module,
+      :consumer_state,
+      :commit_interval,
+      :commit_threshold,
+      :worker_name,
+      :group,
+      :topic,
+      :partition,
+      :current_offset,
+      :committed_offset,
+      :acked_offset,
+      :last_commit,
+    ]
+  end
+
+  @commit_interval 5_000
+  @commit_threshold 100
+
+  # Client API
+
+  @doc """
+  Starts a `GenConsumer` process linked to the current process.
+
+  This can be used to start the `GenConsumer` as part of a supervision tree.
+
+  Once the consumer has been started, the `c:init/2` function of the given `consumer_module` is
+  called with the given `topic` and `partition`. `group_name` is the consumer group name that will
+  be used for managing consumer offsets.
+
+  ### Options
+
+  * `:commit_interval` - the interval in milliseconds that the consumer will wait to commit
+    acknowledged messages. If not present, the `:commit_interval` environment value is used.
+  * `:commit_threshold` - the maximum number of messages that can be acknowledged without being
+    committed. If not present, the `:commit_threshold` environment value is used.
+  * `:worker_name` - the name of the `KafkaEx.Server` process to use for communicating with the
+    Kafka brokers. If not present, the default worker is used.
+
+  Any valid options for `GenServer.start_link/3` can also be specified.
+
+  ### Return Values
+
+  This function has the same return values as `GenServer.start_link/3`.
+
+  If the consumer is successfully created and initialized, this function returns `{:ok, pid}`, where
+  `pid` is the PID of the consumer process.
+  """
+  @spec start_link(module, binary, topic, partition_id, options) :: GenServer.on_start
+  def start_link(consumer_module, group_name, topic, partition, opts \\ []) do
+    {server_opts, consumer_opts} = Keyword.split(opts, [:debug, :name, :timeout, :spawn_opt])
+
+    GenServer.start_link(__MODULE__, {consumer_module, group_name, topic, partition, consumer_opts}, server_opts)
+  end
+
+  # GenServer callbacks
+
+  def init({consumer_module, group_name, topic, partition, opts}) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker)
+    commit_interval = Keyword.get(opts, :commit_interval, Application.get_env(:kafka_ex, :commit_interval, @commit_interval))
+    commit_threshold = Keyword.get(opts, :commit_threshold, Application.get_env(:kafka_ex, :commit_threshold, @commit_threshold))
+
+    {:ok, consumer_state} = consumer_module.init(topic, partition)
+
+    state = %State{
+      consumer_module: consumer_module,
+      consumer_state: consumer_state,
+      commit_interval: commit_interval,
+      commit_threshold: commit_threshold,
+      worker_name: worker_name,
+      group: group_name,
+      topic: topic,
+      partition: partition,
+    }
+
+    Process.flag(:trap_exit, true)
+
+    {:ok, state, 0}
+  end
+
+  def handle_info(:timeout, %State{current_offset: nil, last_commit: nil} = state) do
+    new_state = %State{load_offsets(state) | last_commit: :erlang.monotonic_time(:milli_seconds)}
+
+    {:noreply, new_state, 0}
+  end
+
+  def handle_info(:timeout, %State{} = state) do
+    new_state = consume(state)
+
+    {:noreply, new_state, 0}
+  end
+
+  def terminate(_reason, %State{} = state) do
+    commit(state)
+  end
+
+  # Helpers
+
+  defp consume(%State{worker_name: worker_name, topic: topic, partition: partition, current_offset: offset} = state) do
+    [%FetchResponse{topic: ^topic, partitions: [response = %{error_code: :no_error, partition: ^partition}]}] =
+      KafkaEx.fetch(topic, partition, offset: offset, auto_commit: false, worker_name: worker_name)
+
+    case response do
+      %{last_offset: nil, message_set: []} ->
+        auto_commit(state)
+
+      %{last_offset: _, message_set: messages} ->
+        Enum.reduce(messages, state, &handle_message/2)
+    end
+  end
+
+  defp handle_message(%Message{offset: offset} = message, %State{consumer_module: consumer_module, consumer_state: consumer_state} = state) do
+    case consumer_module.handle_message(message, consumer_state) do
+      {:ack, new_state} ->
+        auto_commit %State{state | consumer_state: new_state, acked_offset: offset + 1, current_offset: offset + 1}
+
+      {:commit, new_state} ->
+        commit %State{state | consumer_state: new_state, acked_offset: offset + 1, current_offset: offset + 1}
+    end
+  end
+
+  defp auto_commit(%State{acked_offset: acked, committed_offset: committed, commit_threshold: threshold,
+                          last_commit: last_commit, commit_interval: interval} = state) do
+    case acked - committed do
+      0 ->
+        %State{state | last_commit: :erlang.monotonic_time(:milli_seconds)}
+
+      n when n >= threshold ->
+        commit(state)
+
+      _ ->
+        if :erlang.monotonic_time(:milli_seconds) - last_commit >= interval do
+          commit(state)
+        else
+          state
+        end
+    end
+  end
+
+  defp commit(%State{acked_offset: offset, committed_offset: offset} = state), do: state
+  defp commit(%State{worker_name: worker_name, group: group, topic: topic, partition: partition, acked_offset: offset} = state) do
+    request = %OffsetCommitRequest{
+      consumer_group: group,
+      topic: topic,
+      partition: partition,
+      offset: offset,
+    }
+
+    [%OffsetCommitResponse{topic: ^topic, partitions: [^partition]}] =
+      KafkaEx.offset_commit(worker_name, request)
+
+    Logger.debug("Committed offset #{topic}/#{partition}@#{offset} for #{group}")
+
+    %State{state | committed_offset: offset, last_commit: :erlang.monotonic_time(:milli_seconds)}
+  end
+
+  defp load_offsets(%State{worker_name: worker_name, group: group, topic: topic, partition: partition} = state) do
+    request = %OffsetFetchRequest{consumer_group: group, topic: topic, partition: partition}
+
+    [%OffsetFetchResponse{topic: ^topic, partitions: [%{partition: ^partition, error_code: error_code, offset: offset}]}] =
+      KafkaEx.offset_fetch(worker_name, request)
+
+    case error_code do
+      :no_error ->
+        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
+
+      :unknown_topic_or_partition ->
+        [%OffsetResponse{topic: ^topic, partition_offsets: [%{partition: ^partition, error_code: :no_error, offset: [offset]}]}] =
+          KafkaEx.earliest_offset(topic, partition, worker_name)
+
+        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
+    end
+  end
+end

--- a/lib/kafka_ex/protocol/heartbeat.ex
+++ b/lib/kafka_ex/protocol/heartbeat.ex
@@ -3,6 +3,17 @@ defmodule KafkaEx.Protocol.Heartbeat do
   Implementation of the Kafka Hearbeat request and response APIs
   """
 
+  defmodule Request do
+    @moduledoc false
+    defstruct group_name: nil, member_id: nil, generation_id: nil
+
+    @type t :: %Request{
+      group_name: binary,
+      member_id: binary,
+      generation_id: integer,
+    }
+  end
+
   defmodule Response do
     @moduledoc false
     # We could just return the error code instead of having the struct, but this
@@ -11,17 +22,16 @@ defmodule KafkaEx.Protocol.Heartbeat do
     @type t :: %Response{error_code: atom | integer}
   end
 
-  @spec create_request(integer, binary, binary, binary, integer) :: binary
-  def create_request(correlation_id, client_id, member_id, group_id, generation_id) do
+  @spec create_request(integer, binary, Request.t) :: binary
+  def create_request(correlation_id, client_id, request) do
     KafkaEx.Protocol.create_request(:heartbeat, correlation_id, client_id) <>
-      << byte_size(group_id) :: 16-signed, group_id :: binary,
-         generation_id :: 32-signed,
-         byte_size(member_id) :: 16-signed, member_id :: binary >>
+      << byte_size(request.group_name) :: 16-signed, request.group_name :: binary,
+         request.generation_id :: 32-signed,
+         byte_size(request.member_id) :: 16-signed, request.member_id :: binary >>
   end
 
   @spec parse_response(binary) :: Response.t
   def parse_response(<< _correlation_id :: 32-signed, error_code :: 16-signed >>) do
     %Response{error_code: KafkaEx.Protocol.error(error_code)}
   end
-
 end

--- a/lib/kafka_ex/protocol/join_group.ex
+++ b/lib/kafka_ex/protocol/join_group.ex
@@ -4,19 +4,17 @@ defmodule KafkaEx.Protocol.JoinGroup do
   @moduledoc """
   Implementation of the Kafka JoinGroup request and response APIs
   """
+
   @protocol_type "consumer"
   @strategy_name "assign"
   @metadata_version 0
 
   defmodule Request do
     @moduledoc false
-    defstruct correlation_id: nil,
-      client_id: nil, member_id: nil,
+    defstruct member_id: nil,
       group_name: nil, topics: nil,
       session_timeout: nil
     @type t :: %Request{
-      correlation_id: integer,
-      client_id: binary,
       member_id: binary,
       group_name: binary,
       topics: [binary],
@@ -31,17 +29,15 @@ defmodule KafkaEx.Protocol.JoinGroup do
                          leader_id: binary, member_id: binary, members: [binary]}
   end
 
-  @spec create_request(Request.t) :: binary
-  def create_request(join_group_req) do
+  @spec create_request(integer, binary, Request.t) :: binary
+  def create_request(correlation_id, client_id, %Request{} = join_group_req) do
     metadata =
       << @metadata_version :: 16-signed,
          length(join_group_req.topics) :: 32-signed, topic_data(join_group_req.topics) :: binary,
          0 :: 32-signed
          >>
 
-    KafkaEx.Protocol.create_request(
-      :join_group, join_group_req.correlation_id, join_group_req.client_id
-    ) <>
+    KafkaEx.Protocol.create_request(:join_group, correlation_id, client_id) <>
       << byte_size(join_group_req.group_name) :: 16-signed, join_group_req.group_name :: binary,
          join_group_req.session_timeout :: 32-signed,
          byte_size(join_group_req.member_id) :: 16-signed, join_group_req.member_id :: binary,

--- a/lib/kafka_ex/protocol/leave_group.ex
+++ b/lib/kafka_ex/protocol/leave_group.ex
@@ -1,12 +1,27 @@
 defmodule KafkaEx.Protocol.LeaveGroup do
-  defmodule Response do
-    defstruct error_code: nil
+  defmodule Request do
+    @moduledoc false
+    defstruct group_name: nil, member_id: nil
+
+    @type t :: %Request{
+      group_name: binary,
+      member_id: binary,
+    }
   end
 
-  def create_request(correlation_id, client_id, group_id, member_id) do
+  defmodule Response do
+    defstruct error_code: nil
+
+    @type t :: %Response{
+      error_code: atom | integer,
+    }
+  end
+
+  @spec create_request(integer, binary, Request.t) :: binary
+  def create_request(correlation_id, client_id, request) do
     KafkaEx.Protocol.create_request(:leave_group, correlation_id, client_id) <>
-      << byte_size(group_id) :: 16-signed, group_id :: binary,
-         byte_size(member_id) :: 16-signed, member_id :: binary >>
+      << byte_size(request.group_name) :: 16-signed, request.group_name :: binary,
+         byte_size(request.member_id) :: 16-signed, request.member_id :: binary >>
   end
 
   def parse_response(<< _correlation_id :: 32-signed, error_code :: 16-signed >>) do

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -4,6 +4,9 @@ defmodule KafkaEx.Server do
   """
 
   alias KafkaEx.Protocol.ConsumerMetadata
+  alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
+  alias KafkaEx.Protocol.JoinGroup.Request, as: JoinGroupRequest
+  alias KafkaEx.Protocol.LeaveGroup.Request, as: LeaveGroupRequest
   alias KafkaEx.Protocol.Metadata
   alias KafkaEx.Protocol.Metadata.Broker
   alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
@@ -12,6 +15,7 @@ defmodule KafkaEx.Server do
   alias KafkaEx.Protocol.Fetch.Request, as: FetchRequest
   alias KafkaEx.Protocol.Produce
   alias KafkaEx.Protocol.Produce.Request, as: ProduceRequest
+  alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
   alias KafkaEx.Socket
 
   defmodule State do
@@ -108,28 +112,28 @@ defmodule KafkaEx.Server do
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason, reply, new_state} |
     {:stop, reason, new_state} when reply: term, new_state: term, reason: term
-  @callback kafka_server_join_group(topics :: [binary], session_timeout :: integer, state :: State.t) ::
+  @callback kafka_server_join_group(JoinGroupRequest.t, network_timeout :: integer, state :: State.t) ::
     {:reply, reply, new_state} |
     {:reply, reply, new_state, timeout | :hibernate} |
     {:noreply, new_state} |
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason, reply, new_state} |
     {:stop, reason, new_state} when reply: term, new_state: term, reason: term
-  @callback kafka_server_sync_group(group_name :: binary, generation_id :: integer, member_id :: binary, assignments :: [binary] , state :: State.t) ::
+  @callback kafka_server_sync_group(SyncGroupRequest.t, network_timeout :: integer, state :: State.t) ::
     {:reply, reply, new_state} |
     {:reply, reply, new_state, timeout | :hibernate} |
     {:noreply, new_state} |
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason, reply, new_state} |
     {:stop, reason, new_state} when reply: term, new_state: term, reason: term
-  @callback kafka_server_leave_group(group_name :: binary, member_id :: binary, state :: State.t) ::
+  @callback kafka_server_leave_group(LeaveGroupRequest.t, network_timeout :: integer, state :: State.t) ::
     {:reply, reply, new_state} |
     {:reply, reply, new_state, timeout | :hibernate} |
     {:noreply, new_state} |
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason, reply, new_state} |
     {:stop, reason, new_state} when reply: term, new_state: term, reason: term
-  @callback kafka_server_heartbeat(group_name :: binary, generation_id :: integer, member_id :: binary, state :: State.t) ::
+  @callback kafka_server_heartbeat(HeartbeatRequest.t, network_timeout :: integer, state :: State.t) ::
     {:reply, reply, new_state} |
     {:reply, reply, new_state, timeout | :hibernate} |
     {:noreply, new_state} |
@@ -237,20 +241,20 @@ defmodule KafkaEx.Server do
         kafka_server_metadata(topic, state)
       end
 
-      def handle_call({:join_group, topics, session_timeout}, _from, state) do
-        kafka_server_join_group(topics, session_timeout,state)
+      def handle_call({:join_group, request, network_timeout}, _from, state) do
+        kafka_server_join_group(request, network_timeout, state)
       end
 
-      def handle_call({:sync_group, group_name, generation_id, member_id, assignments}, _from, state) do
-        kafka_server_sync_group(group_name, generation_id, member_id, assignments, state)
+      def handle_call({:sync_group, request, network_timeout}, _from, state) do
+        kafka_server_sync_group(request, network_timeout, state)
       end
 
-      def handle_call({:leave_group, group_name, member_id}, _from, state) do
-        kafka_server_leave_group(group_name, member_id, state)
+      def handle_call({:leave_group, request, network_timeout}, _from, state) do
+        kafka_server_leave_group(request, network_timeout, state)
       end
 
-      def handle_call({:heartbeat, group_name, generation_id, member_id}, _from, state) do
-        kafka_server_heartbeat(group_name, generation_id, member_id, state)
+      def handle_call({:heartbeat, request, network_timeout}, _from, state) do
+        kafka_server_heartbeat(request, network_timeout, state)
       end
 
       def handle_call({:create_stream, handler, handler_init}, _from, state) do
@@ -454,8 +458,8 @@ defmodule KafkaEx.Server do
         end)
       end
 
-      defp sync_timeout do
-        Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout)
+      defp sync_timeout(timeout \\ nil) do
+        timeout || Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout)
       end
     end
   end

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -5,8 +5,8 @@ defmodule KafkaEx.Server0P8P0 do
 
   # these functions aren't implemented for 0.8.0
   @dialyzer [
-    {:nowarn_function, kafka_server_heartbeat: 4},
-    {:nowarn_function, kafka_server_sync_group: 5},
+    {:nowarn_function, kafka_server_heartbeat: 3},
+    {:nowarn_function, kafka_server_sync_group: 3},
     {:nowarn_function, kafka_server_join_group: 3},
     {:nowarn_function, kafka_server_leave_group: 3},
     {:nowarn_function, kafka_server_update_consumer_metadata: 1},
@@ -62,9 +62,9 @@ defmodule KafkaEx.Server0P8P0 do
   def kafka_server_consumer_group(_state), do: raise "Consumer Group is not supported in 0.8.0 version of kafka"
   def kafka_server_consumer_group_metadata(_state), do: raise "Consumer Group Metadata is not supported in 0.8.0 version of kafka"
   def kafka_server_join_group(_, _, _state), do: raise "Join Group is not supported in 0.8.0 version of kafka"
-  def kafka_server_sync_group(_, _, _, _, _state), do: raise "Sync Group is not supported in 0.8.0 version of kafka"
+  def kafka_server_sync_group(_, _, _state), do: raise "Sync Group is not supported in 0.8.0 version of kafka"
   def kafka_server_leave_group(_, _, _state), do: raise "Leave Group is not supported in 0.8.0 version of Kafka"
-  def kafka_server_heartbeat(_, _, _, _state), do: raise "Heartbeat is not supported in 0.8.0 version of kafka"
+  def kafka_server_heartbeat(_, _, _state), do: raise "Heartbeat is not supported in 0.8.0 version of kafka"
   def kafka_server_update_consumer_metadata(_state), do: raise "Consumer Group Metadata is not supported in 0.8.0 version of kafka"
 
   def kafka_server_start_streaming(_, state = %State{event_pid: nil}) do

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -5,8 +5,8 @@ defmodule KafkaEx.Server0P8P2 do
 
   # these functions aren't implemented for 0.8.2
   @dialyzer [
-    {:nowarn_function, kafka_server_heartbeat: 4},
-    {:nowarn_function, kafka_server_sync_group: 5},
+    {:nowarn_function, kafka_server_heartbeat: 3},
+    {:nowarn_function, kafka_server_sync_group: 3},
     {:nowarn_function, kafka_server_join_group: 3},
     {:nowarn_function, kafka_server_leave_group: 3}
   ]
@@ -145,9 +145,9 @@ defmodule KafkaEx.Server0P8P2 do
   end
 
   def kafka_server_join_group(_, _, _state), do: raise "Join Group is not supported in 0.8.0 version of kafka"
-  def kafka_server_sync_group(_, _, _, _, _state), do: raise "Sync Group is not supported in 0.8.0 version of kafka"
+  def kafka_server_sync_group(_, _, _state), do: raise "Sync Group is not supported in 0.8.0 version of kafka"
   def kafka_server_leave_group(_, _, _state), do: raise "Leave Group is not supported in 0.8.0 version of Kafka"
-  def kafka_server_heartbeat(_, _, _, _state), do: raise "Heartbeat is not supported in 0.8.0 version of kafka"
+  def kafka_server_heartbeat(_, _, _state), do: raise "Heartbeat is not supported in 0.8.0 version of kafka"
   defp update_consumer_metadata(state), do: update_consumer_metadata(state, @retry_count, 0)
 
   defp update_consumer_metadata(state = %State{consumer_group: consumer_group}, 0, error_code) do

--- a/test/protocol/heartbeat_test.exs
+++ b/test/protocol/heartbeat_test.exs
@@ -8,7 +8,13 @@ defmodule KafkaEx.Protocol.Heartbeat.Test do
       1234 :: 32, # GenerationId
       9 :: 16, "member_id" :: binary # MemberId
     >>
-    request = KafkaEx.Protocol.Heartbeat.create_request(42, "client_id", "member_id", "group_id", 1234)
+    heartbeat_request = %KafkaEx.Protocol.Heartbeat.Request{
+      group_name: "group_id",
+      member_id: "member_id",
+      generation_id: 1234,
+    }
+
+    request = KafkaEx.Protocol.Heartbeat.create_request(42, "client_id", heartbeat_request)
     assert request == good_request
   end
 

--- a/test/protocol/join_group_test.exs
+++ b/test/protocol/join_group_test.exs
@@ -15,10 +15,8 @@ defmodule  KafkaEx.Protocol.JoinGroup.Test do
          0 :: 16, # v0
          2 :: 32, 9 :: 16, "topic_one" :: binary, 9 :: 16, "topic_two" :: binary, # Topics array
          0 :: 32 >> # UserData
-    request = JoinGroup.create_request(
+    request = JoinGroup.create_request(42, "client_id",
       %JoinGroup.Request{
-        correlation_id: 42,
-        client_id: "client_id",
         member_id: "member_id",
         group_name: "group",
         topics: ["topic_one", "topic_two"],

--- a/test/protocol/leave_group_test.exs
+++ b/test/protocol/leave_group_test.exs
@@ -8,7 +8,12 @@ defmodule KafkaEx.Protocol.LeaveGroup.Test do
         byte_size("member") :: 16, "member" :: binary, # MemberId
       >>
 
-    request = KafkaEx.Protocol.LeaveGroup.create_request(42, "client_id", "group", "member")
+    leave_request = %KafkaEx.Protocol.LeaveGroup.Request{
+      group_name: "group",
+      member_id: "member",
+    }
+
+    request = KafkaEx.Protocol.LeaveGroup.create_request(42, "client_id", leave_request)
 
     assert request == good_request
   end


### PR DESCRIPTION
I've taken a shot at implementing the consumer group API (#67).  There's still some more to do for this PR, but I wanted to get some feedback on some specific questions before going further.  First, I'll explain the implementation.

At a high level, this PR provides an API that allows one to write a consumer like this:

```elixir
defmodule MyApp.Consumer do
  use KafkaEx.GenConsumer

  require Logger

  def init(topic, partition) do
    {:ok, {topic, partition}}
  end

  def handle_message(%Message{offset: offset, value: message}, {topic, partition} = state) do
    Logger.info("#{topic}/#{partition}@#{offset}: #{inspect(message)}")

    {:ack, state}
  end
end
```

The API is modeled after `GenServer`.  `init/2` is expected to return `{:ok, state}`.  `handle_message/2` is passed a message and state and is expected to return an instruction (`:ack`, `:commit`, etc) and a new state.

The consumer can be launched as a consumer group like this:

```elixir
{:ok, pid} = KafkaEx.ConsumerGroup.start_link(MyApp.Consumer, "group_name", ~w[topic1 topic2])
```

It's also possible to launch an individual consumer manually, if not using the consumer group protocol, but this is not the intended use case:

```elixir
{:ok, pid} = KafkaEx.GenConsumer.start_link(MyApp.Consumer, "group_name", "topic1", 0)
```

## Design

I think this is pretty close to what we brainstormed on Slack.

The implementation uses the `KafkaEx` module as a low-level API, which picks up four methods (`join_group/3`, `sync_group/5`, `leave_group/3`, and `heartbeat/4`), which implement the individual network calls.  The rest of the high-level consumer API is implemented as a layer on top of the interface provided by the `KafkaEx` module.

The [Kafka client-side assignment protocol](https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Client-side+Assignment+Proposal) is implemented by `KafkaEx.ConsumerGroup`.  This module manages an individual BEAM node's membership in a single consumer group.  After receiving a `SyncGroupResponse` from the broker, it launches a supervisor to manage the consumption from its assigned partitions.  When shutdown by its supervisor or notified by a Kafka broker that the consumer group needs to rebalance, it shuts down the process tree starting at `KafakEx.GenConsumer.Supervisor`, which triggers offset commits.

![](https://cloud.githubusercontent.com/assets/138065/23574807/f7175a44-0037-11e7-97ce-fa6bfc280f85.png)

`KafkaEx.GenConsumer.Supervisor` is given a list of assigned partitions when it's started, which it uses to manage a group of `KafkaEx.GenConsumer` processes.  It launches one `GenConsumer` per assigned partition, as shown in the diagram above.

A single instance of `KafkaEx.GenConsumer` consumes from a single partition.  It requires an application to implement `handle_message/2`, which is called for each message consumed from the partition.  The implementation is required to return an atom to indicate how the message should be handled:

  * `:ack` means that the message was consumed successfully.  The highest acked offset will be committed at the next auto-commit point.  Auto-committing can be configured based on a number of acked messages or time since last commit.
  * `:commit` means that the message was consumed successfuly and the offset should be committed synchronously, before the next message is handled.  This would obviously hurt throughput, but could be used sparingly when a consumer makes non-idempotent changes, for example.

When shutdown, a `GenConsumer` will commit the last acked offset.

The `GenConsumer` will also be consulted by `ConsumerGroup` when determining partition assignments.  `GenConsumer.assign_partitions/2` implements round-robin assignment by default, but can be overridden by a client application to provide a different assignment strategy.

## Questions

While working on this, I ran into a few issues that I would like feedback on:

1. In the diagram above, there's a red box that says, "All requests serialized here." Each call to `GenServer.call()` is synchronous and will block until previous calls finish.  This is going to limit the available concurrency, because only one request can be in flight per `KafkaEx.Server` at any time, even though each `KafkaEx.Server` holds a connection to each broker.  All other `NetworkClient` connections owned by a `KafkaEx.Server` will be idle during a network request.

   This can be partially mitigated by having a pool of `KafkaEx.Server` workers and check out a worker for each call, but there's still a lot of active `NetworkClient` connections that can't be used concurrently.  It seems a more efficient option would be to pool `NetworkClient` connections on a per-broker basis.  Or maybe using `GenServer.reply()` to reply asynchronously instead of returning `{:reply, ...}` would be enough to allow multiple simultaneous calls.

   I'm curious what your thoughts are on this issue.  I don't feel like I know this library well enough yet to know the best way to approach this.

   Ultimately, I'm wondering what would be considered good enough for this PR that would be compatible with tackling this issue later, if possible.

2. My biggest stumbling block to understanding the library well is that I'm not sure what level of abstraction is intended for `KafkaEx.Server`.  The servers implement a lot of calls that map one-to-one to requests in the Kafka network protocol.  I added four more methods that follow that pattern and treated it as a low-level API interface for the rest of this PR.  Is that the intended way to use `KafkaEx.Server`?

   I see that it also has state for consumer groups and metadata as well as functionality for streaming.  Have you considered separating this functionality out into high-level modules and keeping `KafkaEx.Server` as a low-level interface for the network protocol?  That approach is what felt most natural to me in working on this PR.  `ConsumerGroup` is a separate `GenServer` which uses `KafakEx.Server` for its network protocol, but it feels like it's duplicating some of the state that's currently kept in the `KafkaEx.Server` implementations.

3. When shutting down `KafkaEx.GenConsumer.Supervisor`, I want to shutdown all of the supervised consumers in parallel, so that they can commit their offsets concurrently.  The only way I could find to get a supervisor to shutdown its children in parallel was to use the `:simple_one_for_one` restart strategy.  From the [Erlang docs](http://erlang.org/doc/man/supervisor.html):

   > As a `simple_one_for_one` supervisor can have many children, it shuts them all down asynchronously. This means that the children do their cleanup in parallel, and therefore the order in which they are stopped is not defined.

   `:simple_one_for_one` seems like it's geared more towards dynamically managed children, so the resulting code is a little messy IMO.  You can see the difference in commit [3aa8ae3](https://github.com/TheRealReal/kafka_ex/commit/3aa8ae33aee6b16fc1c2079102149e78242d2bf6).  I'm still learning OTP, so I'm wondering if you know a cleaner or more idiomatic way to shutdown a supervisor's children in parallel.

4. I haven't fleshed out all of the possible responses for `GenConsumer.handle_message/2`.  All the use cases I have are fine with just `:ack`, and `:commit` is a natural extension of `:ack`.

   I could use your help defining the initial return values.  I don't know enough about other people's use cases to know what's useful here.  It will be easier to add new return values than to change existing ones, so I'm erring on the side of fewer to start with.  Do you have any use cases that aren't satisfied by `:ack` and `:commit`?

   I could see adding `:noreply` with `GenConsumer.ack/2` and `GenConsumer.commit/2` methods (analogous to `GenServer.reply/2`) to allow offloading message handling to another process, such as a `GenStage`, but I don't have a use case to motivate it.

5. I made the network and `GenServer` timeout an option that can be passed to `KafkaEx.join_group/3` and friends.  This was necessary for `join_group`, because the broker doesn't respond until all group members join or the session timeout expires.  Since the default minimum for session timeouts (`group.min.session.timeout.ms`) is 6 seconds and `JoinGroupRequest` can potentially block for as long as the session timeout, this can easily exceed the default `GenServer` timeout of 5 seconds.

   There's a ticket related to this (#94).  If you like the way I handled this for `join_group/3`, `sync_group/5`, `leave_group/3`, and `heartbeat/4`, I could propogate the change to the rest of the `KafkaEx` methods that use `GenServer.call`.  Please let me know if you think that's the right direction.