### PR TITLE
Dispatch genserver calls to support sync_timeout (when configured)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,11 @@ config :kafka_ex,
   # `KafkaEx.Server` worker to start during application start-up -
   # i.e., if you want to start your own set of named workers
   disable_default_worker: false,
-  # Timeout value, in msec, for synchronous operations (e.g., network calls)
+  # Timeout value, in msec, for synchronous operations (e.g., network calls).
+  # If this value is greater than GenServer's default timeout of 5000, it will also
+  # be used as the timeout for work dispatched via KafkaEx.Server.call (e.g., KafkaEx.metadata).
+  # In those cases, it should be considered a 'total timeout', encompassing both network calls and
+  # wait time for the genservers.
   sync_timeout: 3000,
   # Supervision max_restarts - the maximum amount of restarts allowed in a time frame
   max_restarts: 10,
@@ -32,7 +36,7 @@ config :kafka_ex,
     keyfile: System.cwd <> "/ssl/key.pem",
   ],
   # set this to the version of the kafka broker that you are using
-  # include only major.minor.patch versions.  must be at least 0.8.0 
+  # include only major.minor.patch versions.  must be at least 0.8.0
   kafka_version: "0.9.0"
 
 env_config = Path.expand("#{Mix.env}.exs", __DIR__)

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -14,6 +14,7 @@ defmodule KafkaEx do
   alias KafkaEx.Protocol.OffsetFetch.Request, as: OffsetFetchRequest
   alias KafkaEx.Protocol.Produce.Request, as: ProduceRequest
   alias KafkaEx.Protocol.Produce.Message
+  alias KafkaEx.Server
 
   @type uri() :: [{binary|char_list, number}]
   @type worker_init :: [worker_setting]
@@ -74,7 +75,7 @@ defmodule KafkaEx do
   """
   @spec consumer_group(atom | pid) :: binary | :no_consumer_group
   def consumer_group(worker \\ Config.default_worker) do
-    dispatch_call(worker, :consumer_group)
+    Server.call(worker, :consumer_group)
   end
 
   @doc """
@@ -101,12 +102,12 @@ defmodule KafkaEx do
   def metadata(opts \\ []) do
     worker_name  = Keyword.get(opts, :worker_name, Config.default_worker)
     topic = Keyword.get(opts, :topic, "")
-    dispatch_call(worker_name, {:metadata, topic}, opts)
+    Server.call(worker_name, {:metadata, topic}, opts)
   end
 
   @spec consumer_group_metadata(atom, binary) :: ConsumerMetadataResponse.t
   def consumer_group_metadata(worker_name, supplied_consumer_group) do
-    dispatch_call(worker_name, {:consumer_group_metadata, supplied_consumer_group})
+    Server.call(worker_name, {:consumer_group_metadata, supplied_consumer_group})
   end
 
   @doc """
@@ -147,7 +148,7 @@ defmodule KafkaEx do
   """
   @spec offset(binary, number, :calendar.datetime | :earliest | :latest, atom|pid) :: [OffsetResponse.t] | :topic_not_found
   def offset(topic, partition, time, name \\ Config.default_worker) do
-    dispatch_call(name, {:offset, topic, partition, time})
+    Server.call(name, {:offset, topic, partition, time})
   end
 
   @wait_time 10
@@ -189,7 +190,7 @@ defmodule KafkaEx do
 
     retrieved_offset = current_offset(supplied_offset, partition, topic, worker_name)
 
-    dispatch_call(worker_name, {:fetch,
+    Server.call(worker_name, {:fetch,
       %FetchRequest{
         auto_commit: auto_commit,
         topic: topic, partition: partition,
@@ -201,12 +202,12 @@ defmodule KafkaEx do
 
   @spec offset_commit(atom, OffsetCommitRequest.t) :: OffsetCommitResponse.t
   def offset_commit(worker_name, offset_commit_request) do
-    dispatch_call(worker_name, {:offset_commit, offset_commit_request})
+    Server.call(worker_name, {:offset_commit, offset_commit_request})
   end
 
   @spec offset_fetch(atom, OffsetFetchRequest.t) :: [OffsetFetchResponse.t] | :topic_not_found
   def offset_fetch(worker_name, offset_fetch_request) do
-  dispatch_call(worker_name, {:offset_fetch, offset_fetch_request})
+  Server.call(worker_name, {:offset_fetch, offset_fetch_request})
 end
 
 @doc """
@@ -226,7 +227,7 @@ Optional arguments(KeywordList)
   @spec produce(ProduceRequest.t, Keyword.t) :: nil | :ok | {:ok, integer} | {:error, :closed} | {:error, :inet.posix} | {:error, any} | iodata | :leader_not_available
   def produce(produce_request, opts \\ []) do
     worker_name   = Keyword.get(opts, :worker_name, Config.default_worker)
-    dispatch_call(worker_name, {:produce, produce_request}, opts)
+    Server.call(worker_name, {:produce, produce_request}, opts)
   end
 
   @doc """
@@ -293,7 +294,7 @@ Optional arguments(KeywordList)
     min_bytes         = Keyword.get(opts, :min_bytes, @min_bytes)
     max_bytes         = Keyword.get(opts, :max_bytes, @max_bytes)
 
-    event_stream      = dispatch_call(worker_name, {:create_stream, handler, handler_init})
+    event_stream      = Server.call(worker_name, {:create_stream, handler, handler_init})
     retrieved_offset = current_offset(supplied_offset, partition, topic, worker_name)
 
     send(worker_name, {
@@ -372,25 +373,5 @@ Optional arguments(KeywordList)
         {:ok, _}         -> {:ok, pid}
       end
     end
-  end
-
-  @default_call_timeout 5000 # default genserver timeout
-
-  defp dispatch_call(server, term, opts \\ [])
-
-  defp dispatch_call(server, term, opts) when is_list(opts) do
-    dispatch_call(server, term, opts[:timeout])
-  end
-
-  defp dispatch_call(server, term, nil) do
-    # If using the configured sync_timeout that is less than the default
-    # GenServer.call timeout, use the larger value unless explicitly set
-    # using opts[:timeout].
-    timeout = max(@default_call_timeout, Application.get_env(:kafka_ex, :sync_timeout, @default_call_timeout))
-    dispatch_call(server, term, timeout)
-  end
-
-  defp dispatch_call(server, term, timeout) when is_integer(timeout) do
-    GenServer.call(server, term, timeout)
   end
 end

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -101,7 +101,7 @@ defmodule KafkaEx do
   def metadata(opts \\ []) do
     worker_name  = Keyword.get(opts, :worker_name, Config.default_worker)
     topic = Keyword.get(opts, :topic, "")
-    dispatch_call(worker_name, {:metadata, topic})
+    dispatch_call(worker_name, {:metadata, topic}, opts)
   end
 
   @spec consumer_group_metadata(atom, binary) :: ConsumerMetadataResponse.t
@@ -196,7 +196,7 @@ defmodule KafkaEx do
         offset: retrieved_offset, wait_time: wait_time,
         min_bytes: min_bytes, max_bytes: max_bytes
       }
-    })
+    }, opts)
   end
 
   @spec offset_commit(atom, OffsetCommitRequest.t) :: OffsetCommitResponse.t
@@ -226,7 +226,7 @@ Optional arguments(KeywordList)
   @spec produce(ProduceRequest.t, Keyword.t) :: nil | :ok | {:ok, integer} | {:error, :closed} | {:error, :inet.posix} | {:error, any} | iodata | :leader_not_available
   def produce(produce_request, opts \\ []) do
     worker_name   = Keyword.get(opts, :worker_name, Config.default_worker)
-    dispatch_call(worker_name, {:produce, produce_request})
+    dispatch_call(worker_name, {:produce, produce_request}, opts)
   end
 
   @doc """
@@ -385,7 +385,7 @@ Optional arguments(KeywordList)
     # GenServer.call timeout, use the larger value unless explicitly set
     # using opts[:timeout].
     timeout = max(@default_call_timeout, Application.get_env(:kafka_ex, :sync_timeout, @default_call_timeout))
-    dispatch_call(server, term, call_timeout)
+    dispatch_call(server, term, timeout)
   end
 
   defp dispatch_call(server, term, timeout) when is_integer(timeout) do

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -376,7 +376,9 @@ Optional arguments(KeywordList)
 
   @default_call_timeout 5000 # default genserver timeout
 
-  defp dispatch_call(server, term, opts \\ []) when is_list(opts) do
+  defp dispatch_call(server, term, opts \\ [])
+
+  defp dispatch_call(server, term, opts) when is_list(opts) do
     dispatch_call(server, term, opts[:timeout])
   end
 

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -24,7 +24,6 @@ defmodule KafkaEx do
                         {:password, binary}]
   @type worker_setting :: {:uris, uri}  |
                           {:consumer_group, binary | :no_consumer_group} |
-                          {:sync_timeout, non_neg_integer} |
                           {:metadata_update_interval, non_neg_integer} |
                           {:consumer_group_update_interval, non_neg_integer} |
                           {:ssl_options, ssl_options}
@@ -37,7 +36,6 @@ defmodule KafkaEx do
   - uris: List of brokers in `{"host", port}` form, defaults to `Application.get_env(:kafka_ex, :brokers)`
   - metadata_update_interval: How often `kafka_ex` would update the Kafka cluster metadata information in milliseconds, default is 30000
   - consumer_group_update_interval: How often `kafka_ex` would update the Kafka cluster consumer_groups information in milliseconds, default is 30000
-  - sync_timeout: Timeout for synchronous requests to kafka in milliseconds, default is 1000
   - use_ssl: Boolean flag specifying if ssl should be used for the connection by the worker to kafka, default is false
   - ssl_options: see SSL OPTION DESCRIPTIONS - CLIENT SIDE at http://erlang.org/doc/man/ssl.html, default is []
 
@@ -51,8 +49,6 @@ defmodule KafkaEx do
   iex> KafkaEx.create_worker(:pr, uris: [{"localhost", 9092}])
   {:ok, #PID<0.172.0>}
   iex> KafkaEx.create_worker(:pr, [uris: [{"localhost", 9092}], consumer_group: "foo"])
-  {:ok, #PID<0.173.0>}
-  iex> KafkaEx.create_worker(:pr, [uris: [{"localhost", 9092}], consumer_group: "foo", sync_timeout: 2000])
   {:ok, #PID<0.173.0>}
   iex> KafkaEx.create_worker(:pr, consumer_group: nil)
   {:error, :invalid_consumer_group}

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -49,9 +49,8 @@ defmodule KafkaEx.Server0P8P2 do
     true = KafkaEx.valid_consumer_group?(consumer_group)
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port)} end)
-    sync_timeout = Keyword.get(args, :sync_timeout, Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout))
-    {correlation_id, metadata} = retrieve_metadata(brokers, 0, sync_timeout)
-    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, sync_timeout: sync_timeout}
+    {correlation_id, metadata} = retrieve_metadata(brokers, 0, sync_timeout())
+    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name}
     # Get the initial "real" broker list and start a regular refresh cycle.
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
@@ -92,7 +91,7 @@ defmodule KafkaEx.Server0P8P2 do
         {:topic_not_found, state}
       _ ->
         response = broker
-          |> NetworkClient.send_sync_request(offset_fetch_request, state.sync_timeout)
+          |> NetworkClient.send_sync_request(offset_fetch_request, sync_timeout())
           |> OffsetFetch.parse_response
         {response, %{state | correlation_id: state.correlation_id + 1}}
     end
@@ -189,7 +188,7 @@ defmodule KafkaEx.Server0P8P2 do
         {:topic_not_found, state}
       _ ->
         response = broker
-          |> NetworkClient.send_sync_request(fetch_data, state.sync_timeout)
+          |> NetworkClient.send_sync_request(fetch_data, sync_timeout())
           |> Fetch.parse_response
         state = %{state | correlation_id: state.correlation_id + 1}
         last_offset = response |> hd |> Map.get(:partitions) |> hd |> Map.get(:last_offset)
@@ -217,7 +216,7 @@ defmodule KafkaEx.Server0P8P2 do
 
     offset_commit_request_payload = OffsetCommit.create_request(state.correlation_id, @client_id, offset_commit_request)
     response = broker
-      |> NetworkClient.send_sync_request(offset_commit_request_payload, state.sync_timeout)
+      |> NetworkClient.send_sync_request(offset_commit_request_payload, sync_timeout())
       |> OffsetCommit.parse_response
 
     {response, %{state | correlation_id: state.correlation_id + 1}}
@@ -255,6 +254,6 @@ defmodule KafkaEx.Server0P8P2 do
   end
 
   defp first_broker_response(request, state) do
-    first_broker_response(request, state.brokers, state.sync_timeout)
+    first_broker_response(request, state.brokers, sync_timeout())
   end
 end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -36,41 +36,6 @@ defmodule KafkaEx.Integration.Test do
     assert metadata_update_interval == 30000
   end
 
-  test "create_worker provides a default sync_timeout of 1000 if not set in config" do
-    value_before = Application.get_env(:kafka_ex, :sync_timeout)
-    Application.delete_env(:kafka_ex, :sync_timeout)
-    {:ok, pid} = KafkaEx.create_worker(:bif, uris: uris())
-    sync_timeout = :sys.get_state(pid).sync_timeout
-
-    assert sync_timeout == 1000
-    Application.put_env(:kafka_ex, :sync_timeout, value_before)
-  end
-
-  test "create_worker takes a sync_timeout option and sets that as the sync_timeout of the worker" do
-    {:ok, pid} = KafkaEx.create_worker(:babar, [uris: uris(), sync_timeout: 2000])
-    sync_timeout = :sys.get_state(pid).sync_timeout
-
-    assert sync_timeout == 2000
-  end
-
-  test "create_worker uses sync_timeout default from config if set" do
-    value_before = Application.get_env(:kafka_ex, :sync_timeout)
-    Application.put_env(:kafka_ex, :sync_timeout, 4000)
-
-    {:ok, pid} = KafkaEx.create_worker(:eve, [uris: uris()])
-    sync_timeout = :sys.get_state(pid).sync_timeout
-
-    assert sync_timeout == 4000
-    Application.put_env(:kafka_ex, :sync_timeout, value_before)
-  end
-
-  test "create_worker uses explicit sync_timeout even if set in config" do
-    {:ok, pid} = KafkaEx.create_worker(:alice, [uris: uris(), sync_timeout: 2000])
-    sync_timeout = :sys.get_state(pid).sync_timeout
-
-    assert sync_timeout == 2000
-  end
-
   #update_metadata
   test "worker updates metadata after specified interval" do
     random_string = generate_random_string()


### PR DESCRIPTION
For the top-level API, make synchronous GenServer calls respect the configured `sync_timeout` value if it is greater than the default 5000:

- if configured, and no `:timeout` is given in opts, GenServer timeout is the greater of `sync_timeout` and 5000
- if a timeout option is explicitly given, it is used unchanged.