### PR TITLE
Allow any keyword list for ssl_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ defmodule MyApp.Mixfile do
   defp deps do
     [
       # add to your existing deps
-      {:kafka_ex, "~> 0.6.4"},
+      {:kafka_ex, "~> 0.6.5"},
       # if using snappy compression
       {:snappy, git: "https://github.com/fdmanana/snappy-erlang-nif"}
     ]

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -47,36 +47,16 @@ defmodule KafkaEx.Config do
       "remove this warning, set `ssl_options: []` in the KafkaEx config.")
     []
   end
-  # if ssl is enabled, verify that cacertfile, certfile, and keyfile are set
-  # and point to readable files
+  # verify that options is at least a keyword list
   defp ssl_options(true, options) do
-    options
-    |> verify_ssl_file(:cacertfile)
-    |> verify_ssl_file(:certfile)
-    |> verify_ssl_file(:keyfile)
-  end
-
-  defp verify_ssl_file(options, key) do
-    verify_ssl_file(options, key, Keyword.get(options, key))
-  end
-
-  defp verify_ssl_file(options, _key, nil) do
-    # cert file not present - it will be up to :ssl to determine if this is ok
-    # given the other settings
-    options
-  end
-  defp verify_ssl_file(options, key, path) do
-    # make sure the file is readable to us
-    #    (there is a way to do this without reading the file, but these should
-    #      be small files so this is probably the simplest option)
-    case File.read(path) do
-      {:ok, _} -> options
-      {:error, reason} ->
-        raise(
-          ArgumentError,
-          message: "SSL option #{inspect key} could not be read.  " <>
-            "Error: #{inspect reason}"
-        )
+    if Keyword.keyword?(options) do
+      options
+    else
+      raise(
+        ArgumentError,
+        "SSL is enabled and invalid ssl_options were provided: " <>
+          inspect(options)
+      )
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Mixfile do
   def project do
     [
       app: :kafka_ex,
-      version: "0.6.4",
+      version: "0.6.5",
       elixir: "~> 1.0",
       dialyzer: [
         plt_add_deps: :transitive,

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -31,51 +31,16 @@ defmodule KafkaEx.ConfigTest do
     assert [] == Config.ssl_options()
   end
 
-  test "ssl_options raises an error if cacertfile is invalid" do
+  test "ssl_options raises an error if use_ssl is true and ssl_options " <>
+    "are invalid" do
     Application.put_env(:kafka_ex, :use_ssl, true)
-    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
 
-    key = :cacertfile
+    # when ssl_options is not set we should get an error
+    Application.put_env(:kafka_ex, :ssl_options, nil)
+    assert_raise(ArgumentError, ~r/invalid ssl_options/, &Config.ssl_options/0)
 
-    # the option may be omitted - it is up to :ssl to determine if this is ok
-    without_key = Keyword.delete(ssl_options, key)
-    Application.put_env(:kafka_ex, :ssl_options, without_key)
-    assert without_key == Config.ssl_options()
-
-    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
-    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
-    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
-  end
-
-  test "ssl_options raises an error if certfile is invalid" do
-    Application.put_env(:kafka_ex, :use_ssl, true)
-    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
-
-    key = :certfile
-
-    # the option may be omitted - it is up to :ssl to determine if this is ok
-    without_key = Keyword.delete(ssl_options, key)
-    Application.put_env(:kafka_ex, :ssl_options, without_key)
-    assert without_key == Config.ssl_options()
-
-    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
-    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
-    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
-  end
-
-  test "ssl_options raises an error if keyfile is invalid" do
-    Application.put_env(:kafka_ex, :use_ssl, true)
-    ssl_options = Application.get_env(:kafka_ex, :ssl_options)
-
-    key = :keyfile
-
-    # the option may be omitted - it is up to :ssl to determine if this is ok
-    without_key = Keyword.delete(ssl_options, key)
-    Application.put_env(:kafka_ex, :ssl_options, without_key)
-    assert without_key == Config.ssl_options()
-
-    with_invalid_file = Keyword.put(ssl_options, key, "./should_not_exist")
-    Application.put_env(:kafka_ex, :ssl_options, with_invalid_file)
-    assert_raise(ArgumentError, ~r/could not/, &Config.ssl_options/0)
+    # should also get an error if ssl_options is not a list
+    Application.put_env(:kafka_ex, :ssl_options, %{cacertfile: "/ssl/ca-cert"})
+    assert_raise(ArgumentError, ~r/invalid ssl_options/, &Config.ssl_options/0)
   end
 end


### PR DESCRIPTION
This should clear up #194 and #199.   We still raise an error with a (hopefully) useful error message when certain invalid situations are detected.

@bjhaid I went ahead and made a hotfix version bump b/c this should be released ASAP if it's acceptable.