### PR TITLE
Initialize consumer group metadata

### DIFF
--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -55,10 +55,15 @@ defmodule KafkaEx.Server0P8P2 do
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
 
-    # only start the consumer group update cycle if we are using consumer groups
-    if consumer_group?(state) do
-      {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
-    end
+    state =
+      if consumer_group?(state) do
+        # If we are using consumer groups then initialize the state and start the update cycle
+        {_, updated_state} = update_consumer_metadata(state)
+        {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
+        updated_state
+      else
+        state
+      end
 
     {:ok, state}
   end

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -60,10 +60,15 @@ defmodule KafkaEx.Server0P9P0 do
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
 
-    # only start the consumer group update cycle if we are using consumer groups
-    if consumer_group?(state) do
-      {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
-    end
+    state =
+      if consumer_group?(state) do
+        # If we are using consumer groups then initialize the state and start the update cycle
+        {_, updated_state} = update_consumer_metadata(state)
+        {:ok, _} = :timer.send_interval(state.consumer_group_update_interval, :update_consumer_metadata)
+        updated_state
+      else
+        state
+      end
 
     {:ok, state}
   end


### PR DESCRIPTION
Fixes #202 

Initialize consumer group metadata on startup. No tests were added because I was actually seeing `:not_coordinator_for_consumer` before my changes.