### PR TITLE
Only perform a branch build for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: elixir
+branches:
+  only:
+    - "master"
 otp_release:
   - 18.3
   - 19.2


### PR DESCRIPTION
I learned this working on another project.  Pull requests should still build.  This will avoid us having duplicate builds for PR branches.