### PR TITLE
Updates to CI - drops testing OTP 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,26 @@ cache:
     - _build
 otp_release:
   - 18.3
-  - 19.2
+  - 19.3
 elixir:
-  - 1.4.0
+  - 1.4.5
   - 1.3.4
   - 1.2.6
   - 1.1.1
 matrix:
   exclude:
     - elixir: 1.1.1
-      otp_release: 19.2
-    - elixir: 1.4.0
-      otp_release: 19.2
+      otp_release: 19.3
+    - elixir: 1.4.5
+      otp_release: 19.3
       env: COVERALLS=false
   include:
-    - elixir: 1.1.1
-      otp_release: 17.5
-    - elixir: 1.4.0
-      otp_release: 19.2
+    - elixir: 1.5.0
+      otp_release: 19.3
+    - elixir: 1.5.0
+      otp_release: 20.0
+    - elixir: 1.4.5
+      otp_release: 19.3
       env: COVERALLS=true
 dist: trusty
 sudo: required

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ KafkaEx
 [![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](http://hexdocs.pm/kafka_ex/)
 
 KafkaEx is an Elixir client for [Apache Kafka](http://kafka.apache.org/) with
-support for Kafka versions 0.8.0 and newer.
+support for Kafka versions 0.8.0 and newer.  KafkaEx requires Elixir 1.1.1+ and
+Erlang OTP 18+.
 
 See [http://hexdocs.pm/kafka_ex/](http://hexdocs.pm/kafka_ex/) for
 documentation,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule KafkaEx.Mixfile do
     [
       app: :kafka_ex,
       version: "0.7.0",
-      elixir: "~> 1.0",
+      elixir: "~> 1.1",
       dialyzer: [
         plt_add_deps: :transitive,
         flags: [

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -6,15 +6,24 @@
 #
 # This script could be used for local testing as long as COVERALLS is not set.
 
-set -ev
-
-# first test run - tends to work the kinks out of the kafka brokers
-#    (we should strive to remove this but it is necessary for now)
-mix test --include integration --include consumer_group --include server_0_p_9_p_0 || true
+export MIX_ENV=test
 
 if [ "$COVERALLS" = true ]
 then
-  MIX_ENV=test mix coveralls.travis --include integration --include consumer_group --include server_0_p_9_p_0
+  echo "Coveralls will be reported"
+  TEST_COMMAND=coveralls
 else
-  mix test --cover --include integration --include consumer_group --include server_0_p_9_p_0
+  TEST_COMMAND=test
+fi
+
+mix "$TEST_COMMAND" --include integration --include consumer_group --include server_0_p_9_p_0 
+
+# sometimes the first test run fails due to broker issues and we need to run it again
+#    (we should strive to remove this but it is necessary for now)
+if [ $? -eq 0 ]
+then
+  echo "First tests passed, skipping repeat"
+else
+  echo "Repeating tests"
+  mix "$TEST_COMMAND" --include integration --include consumer_group --include server_0_p_9_p_0 
 fi

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,16 +5,9 @@ ExUnit.configure exclude: [integration: true, consumer_group: true, server_0_p_9
 defmodule TestHelper do
 
   def generate_random_string(string_length \\ 20) do
-    # This allows Elixir 1.1 + OTP 17 to still run the tests, but doesn't throw a warning on higher
-    # versions. This should be removed once OTP 17 support is dropped.
-    rand_module = if :erlang.function_exported(:rand, :uniform, 0) do
-      :rand
-    else
-      r = :random
-      r.seed(:os.timestamp())
-      :random
-    end
-    Enum.map(1..string_length, fn _ -> (rand_module.uniform() * 25 + 65) |> round end) |> to_string
+    1..string_length
+    |> Enum.map(fn _ -> round(:rand.uniform * 25 + 65) end)
+    |> to_string
   end
 
   # Wait for the return value of value_getter to pass the predicate condn


### PR DESCRIPTION
* Only re-run the tests if necessary (in the new consumer-group branch this is not usually necessary)
* Drop building/testing Elixir 1.1.1 with OTP 17
* Update OTP 19.2 to OTP 19.3
* Update Elixir 1.4.0 to 1.4.5
* Add Elixir 1.5.0 with OTP 19.3 and OTP 20.0 