### PR TITLE
Handle partition list for nonexistent topic

### DIFF
--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -34,8 +34,6 @@ defmodule KafkaEx.Protocol.Metadata do
       topic_metadatas: [TopicMetadata.t]
     }
 
-    require Logger
-
     def broker_for_topic(metadata, brokers, topic, partition) do
       case Enum.find(metadata.topic_metadatas, &(topic == &1.topic)) do
         nil -> nil
@@ -46,9 +44,6 @@ defmodule KafkaEx.Protocol.Metadata do
     def partitions_for_topic(metadata, topic) do
       case Enum.find(metadata.topic_metadatas, &(&1.topic == topic)) do
         nil ->
-          Logger.debug(fn ->
-            "Partitions requested for nonexistent topic #{inspect topic}"
-          end)
           []  # topic doesn't exist yet, no partitions
         topic_metadata ->
           Enum.map(topic_metadata.partition_metadatas, &(&1.partition_id))

--- a/test/protocol/metadata_test.exs
+++ b/test/protocol/metadata_test.exs
@@ -147,4 +147,40 @@ defmodule KafkaEx.Protocol.Metadata.Test do
     assert KafkaEx.Protocol.Metadata.Response.broker_for_topic(metadata, brokers, "bar", 0) == nil
     Port.close(fake_socket)
   end
+
+  test "Response.partitions_for_topic returns a list of partition ids" do
+    alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
+    alias KafkaEx.Protocol.Metadata.TopicMetadata
+
+    partition_metadata = %KafkaEx.Protocol.Metadata.PartitionMetadata{
+      partition_id: 0
+    }
+
+    metadata = %MetadataResponse{
+      topic_metadatas: [
+        %TopicMetadata{
+          error_code: :no_error,
+          partition_metadatas: [
+            %{partition_metadata | partition_id: 0},
+            %{partition_metadata | partition_id: 1},
+            %{partition_metadata | partition_id: 2},
+            %{partition_metadata | partition_id: 3}
+          ],
+          topic: "bar"
+        }
+      ]
+    }
+
+    assert [0, 1, 2, 3] ==
+      MetadataResponse.partitions_for_topic(metadata, "bar")
+  end
+
+  test "Response.partitions_for_topic returns an empty list for a topic " <>
+    "that does not exist" do
+    alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
+
+    metadata = %MetadataResponse{topic_metadatas: []}
+
+    assert [] == MetadataResponse.partitions_for_topic(metadata, "foo")
+  end
 end


### PR DESCRIPTION
This would cause an unuseful crash if a topic does not exist.  Now we emit a warning from the Manager.  

Note that crashing here does not necessarily make sense because a consumer group may have more than one topic and there may be operational reasons for a particular topic to not exist. OTOH this is most likely going to be due to a setup problem by the user, so we emit a warning.