### PR TITLE
handle_info/2 for :trap_exit in GenConsumer.

### DIFF
--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -441,6 +441,12 @@ defmodule KafkaEx.GenConsumer do
     {:noreply, new_state, 0}
   end
 
+  def handle_info({:EXIT, _pid, :normal}, %State{} = state) do
+    new_state = consume(state)
+
+    {:noreply, new_state, 0}
+  end
+
   def terminate(_reason, %State{} = state) do
     commit(state)
   end


### PR DESCRIPTION
With the `:trap_exit` flag set, the process is reset every time a normal exit occurs. This consumes the event so the following error doesn't occur:

```
** (FunctionClauseError) no function clause matching in KafkaEx.GenConsumer.handle_info/2
    (kafka_ex) lib/kafka_ex/gen_consumer.ex:426: KafkaEx.GenConsumer.handle_info({:EXIT, #PID<0.287.0>, :normal}, %KafkaEx.GenConsumer.State{acked_offset: 201796, commit_interval: 5000, commit_threshold: 100, committed_offset: 201795, consumer_module: MyTestModule.EventHandler, consumer_state: %{partition: 0, topic: "abc"}, current_offset: 10, group: "def", last_commit: -576460739051, partition: 0, topic: "abc", worker_name: #PID<0.286.0>})
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.287.0>, :normal}
```