### PR TITLE
Use 'iolist' when building packet.

### DIFF
--- a/test/protocol/produce_test.exs
+++ b/test/protocol/produce_test.exs
@@ -10,7 +10,7 @@ defmodule KafkaEx.Protocol.Produce.Test do
       ]
     })
 
-    assert expected_request == request
+    assert expected_request == :erlang.iolist_to_binary(request)
   end
 
   test "create_request correctly batches multiple request messages" do
@@ -24,7 +24,7 @@ defmodule KafkaEx.Protocol.Produce.Test do
       ]
     })
 
-    assert expected_request == request
+    assert expected_request == :erlang.iolist_to_binary(request)
   end
 
   test "create_request correctly encodes messages with gzip" do
@@ -44,7 +44,7 @@ defmodule KafkaEx.Protocol.Produce.Test do
 
     request = KafkaEx.Protocol.Produce.create_request(1, "compression_client_test", produce)
 
-    assert expected_request == request
+    assert expected_request == :erlang.iolist_to_binary(request)
   end
 
   test "create_request correctly encodes messages with snappy" do
@@ -66,7 +66,7 @@ defmodule KafkaEx.Protocol.Produce.Test do
                                                       "compression_client_test",
                                                       produce)
 
-    assert expected_request == request
+    assert expected_request == :erlang.iolist_to_binary(request)
   end
 
   test "parse_response correctly parses a valid response with single topic and partition" do


### PR DESCRIPTION
This change makes using iolist instead of contiguous binary when building packet being compressed and/or sent.

P.S. Unit tests & dialyzer passed successfully but I'm failed to wait for finish integration tests, they just hanging without any log messages. Anyway, I making this PR, in case someone find time to run all integration tests. 