### PR TITLE
Fix `GenConsumer.handle_call` default implementation

### DIFF
--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -272,8 +272,8 @@ defmodule KafkaEx.GenConsumer do
         # We do this to trick Dialyzer to not complain about non-local returns.
         case :erlang.phash2(1, 1) do
           0 ->
-            raise "attempted to call GenServer #{inspect proc} but no " <>
-              "handle_call/3 clause was provided"
+            raise "attempted to call KafkaEx.GenConsumer #{inspect proc} " <>
+              "but no handle_call/3 clause was provided"
           1 -> {:reply, {:bad_call, msg}, consumer_state}
         end
       end

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -262,9 +262,9 @@ defmodule KafkaEx.GenConsumer do
         {:ok, nil}
       end
 
-      def handle_call(msg, _from, _consumer_state) do
+      def handle_call(msg, _from, consumer_state) do
         # taken from the GenServer handle_call implementation
-        case Process.info(self(), :registered_name) do
+        proc = case Process.info(self(), :registered_name) do
           {_, []}   -> self()
           {_, name} -> name
         end

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -151,7 +151,7 @@ defmodule KafkaEx.GenConsumer do
   ```
 
   **NOTE** If you do not implement a `c:handle_call/3` callback, any calls to
-  `GenConsumer.call/3` that go to your consumer will cause a `MatchError`.
+  `GenConsumer.call/3` that go to your consumer will raise an error.
 
   ## Testing
 
@@ -262,9 +262,20 @@ defmodule KafkaEx.GenConsumer do
         {:ok, nil}
       end
 
-      def handle_call(_call, _from, _consumer_state) do
-        # the user must implement this if they expect to recieve calls
-        :handle_call_not_implemented
+      def handle_call(msg, _from, _consumer_state) do
+        # taken from the GenServer handle_call implementation
+        case Process.info(self(), :registered_name) do
+          {_, []}   -> self()
+          {_, name} -> name
+        end
+
+        # We do this to trick Dialyzer to not complain about non-local returns.
+        case :erlang.phash2(1, 1) do
+          0 ->
+            raise "attempted to call GenServer #{inspect proc} but no " <>
+              "handle_call/3 clause was provided"
+          1 -> {:reply, {:bad_call, msg}, consumer_state}
+        end
       end
 
       defoverridable [init: 2, handle_call: 3]

--- a/test/kafka_ex/gen_consumer_test.exs
+++ b/test/kafka_ex/gen_consumer_test.exs
@@ -1,0 +1,15 @@
+defmodule KafkaEx.GenConsumerTest do
+  use ExUnit.Case
+
+  # non-integration GenConsumer tests
+
+  defmodule TestConsumer do
+    use KafkaEx.GenConsumer
+
+    def handle_message_set(_, state), do: state
+  end
+
+  test "calling handle_call raises an error if there is no implementation" do
+    assert_raise RuntimeError, fn -> TestConsumer.handle_call(nil, nil, nil) end
+  end
+end


### PR DESCRIPTION
Fixes #237

The previous implementation causes a dialyzer error if the user does not
implement a handle_call.  This version is taken from the
GenServer.handle_call default implementation.