### PR TITLE
Add `ConsumerGroup.group_name/1` helper

### DIFF
--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -224,6 +224,14 @@ defmodule KafkaEx.ConsumerGroup do
   end
 
   @doc """
+  Returns the name of the consumer group
+  """
+  @spec group_name(Supervisor.supervisor) :: binary
+  def group_name(supervisor_pid) do
+    call_manager(supervisor_pid, :group_name)
+  end
+
+  @doc """
   Returns a map from `{topic, partition_id}` to consumer pid
   """
   @spec partition_consumer_map(Supervisor.supervisor) ::

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -138,6 +138,10 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   def handle_call(:consumer_supervisor_pid, _from, state) do
     {:reply, state.consumer_supervisor_pid, state}
   end
+
+  def handle_call(:group_name, _from, state) do
+    {:reply, state.group_name, state}
+  end
   ######################################################################
 
   # If `member_id` and `generation_id` aren't set, we haven't yet joined the

--- a/test/integration/consumer_group_implementation_test.exs
+++ b/test/integration/consumer_group_implementation_test.exs
@@ -140,6 +140,9 @@ defmodule KafkaEx.ConsumerGroupImplementationTest do
     generation_id2 = ConsumerGroup.generation_id(context[:consumer_group_pid2])
     assert generation_id1 == generation_id2
 
+    assert @consumer_group_name ==
+      ConsumerGroup.group_name(context[:consumer_group_pid1])
+
     member1 = ConsumerGroup.member_id(context[:consumer_group_pid1])
     member2 = ConsumerGroup.member_id(context[:consumer_group_pid2])
     assert member1 != member2


### PR DESCRIPTION
When instrumenting for production, it's useful to be able to introspect
processes like this to, e.g., tag metrics for datadog.