### PR TITLE
More gracefully handle errors on leaving consumer group

### DIFF
--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -339,10 +339,17 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       member_id: member_id,
     }
 
-    %LeaveGroupResponse{error_code: :no_error} =
+    leave_group_response =
       KafkaEx.leave_group(leave_request, worker_name: worker_name)
 
-    Logger.debug(fn -> "Left consumer group #{group_name}" end)
+    if leave_group_response.error_code == :no_error do
+      Logger.debug(fn -> "Left consumer group #{group_name}" end)
+    else
+      Logger.warn(fn ->
+        "Received error #{inspect leave_group_response.error_code}, "
+        "consumer group manager will exit regardless."
+      end)
+    end
 
     :ok
   end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -346,7 +346,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       Logger.debug(fn -> "Left consumer group #{group_name}" end)
     else
       Logger.warn(fn ->
-        "Received error #{inspect leave_group_response.error_code}, "
+        "Received error #{inspect leave_group_response.error_code}, " <>
         "consumer group manager will exit regardless."
       end)
     end


### PR DESCRIPTION
This seems to be related to #247 though it may not be the root cause.

We were seeing the leave group fail with an `unknown_member_id`, which
happens when there is a problem between the client and the broker.  This
would cause the manager to exit abruptly and may be causing the rest of
the consumer group's processes to exit uncleanly.

Regardless of the error returned, we want to exit the consumer group
cleanly.