### PR TITLE
Stop leaking connections on consumer group shutdown/rebalance

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -76,7 +76,7 @@ defmodule KafkaEx do
   @doc """
   Stop a worker created with create_worker/2
 
-  Returns `:ok` on succes or `:error` if `worker` is not a valid worker
+  Returns `:ok` on success or `:error` if `worker` is not a valid worker
   """
   @spec stop_worker(atom | pid) :: :ok |
     {:error, :not_found} | {:error, :simple_one_for_one}

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -74,6 +74,17 @@ defmodule KafkaEx do
   end
 
   @doc """
+  Stop a worker created with create_worker/2
+
+  Returns `:ok` on succes or `:error` if `worker` is not a valid worker
+  """
+  @spec stop_worker(atom | pid) :: :ok |
+    {:error, :not_found} | {:error, :simple_one_for_one}
+  def stop_worker(worker) do
+    KafkaEx.Supervisor.stop_child(worker)
+  end
+
+  @doc """
   Returns the name of the consumer group for the given worker.
 
   Worker may be an atom or pid.  The default worker is used by default.

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -258,6 +258,24 @@ defmodule KafkaEx.ConsumerGroup do
     end
   end
 
+  @doc """
+  Returns the pid of the `KafkaEx.ConsumerGroup.Manager` process for the
+  given consumer group supervisor.
+
+  Intended for introspection usage only.
+  """
+  @spec get_manager_pid(Supervisor.supervisor) :: pid
+  def get_manager_pid(supervisor_pid) do
+    {_, pid, _, _} = Enum.find(
+      Supervisor.which_children(supervisor_pid),
+      fn
+        ({KafkaEx.ConsumerGroup.Manager, _, _, _}) -> true
+        ({_, _, _, _}) -> false
+      end
+    )
+    pid
+  end
+
   @doc false # used by ConsumerGroup.Manager to set partition assignments
   def start_consumer(pid, consumer_module, group_name, assignments, opts) do
     child = supervisor(
@@ -301,16 +319,5 @@ defmodule KafkaEx.ConsumerGroup do
     supervisor_pid
     |> get_manager_pid
     |> GenServer.call(call)
-  end
-
-  defp get_manager_pid(supervisor_pid) do
-    {_, pid, _, _} = Enum.find(
-      Supervisor.which_children(supervisor_pid),
-      fn
-        ({KafkaEx.ConsumerGroup.Manager, _, _, _}) -> true
-        ({_, _, _, _}) -> false
-      end
-    )
-    pid
   end
 end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -12,7 +12,6 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
   alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse
   alias KafkaEx.Protocol.LeaveGroup.Request, as: LeaveGroupRequest
-  alias KafkaEx.Protocol.LeaveGroup.Response, as: LeaveGroupResponse
   alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
   alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
   alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
@@ -169,6 +168,8 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   def terminate(_reason, %State{generation_id: nil, member_id: nil}), do: :ok
   def terminate(_reason, %State{} = state) do
     :ok = leave(state)
+    Process.unlink(state.worker_name)
+    KafkaEx.stop_worker(state.worker_name)
   end
 
   ### Helpers

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -454,6 +454,8 @@ defmodule KafkaEx.GenConsumer do
 
   def terminate(_reason, %State{} = state) do
     commit(state)
+    Process.unlink(state.worker_name)
+    KafkaEx.stop_worker(state.worker_name)
   end
 
   # Helpers

--- a/lib/kafka_ex/supervisor.ex
+++ b/lib/kafka_ex/supervisor.ex
@@ -1,10 +1,15 @@
 defmodule KafkaEx.Supervisor do
-  use Supervisor
   @moduledoc false
+
+  use Supervisor
 
   def start_link(server, max_restarts, max_seconds) do
     {:ok, pid} = Supervisor.start_link(__MODULE__, [server, max_restarts, max_seconds], [name: __MODULE__])
     {:ok, pid}
+  end
+
+  def stop_child(child) do
+    Supervisor.terminate_child(__MODULE__, child)
   end
 
   def init([server, max_restarts, max_seconds]) do


### PR DESCRIPTION
This is related to #247 but also doesn't appear to be the root cause.
This should clear up the leaking gen_tcp connections that @cjpoll
observed.