### PR TITLE
Allow to pass uris as parameters to the ConsumerGroup

### DIFF
--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -91,8 +91,11 @@ defmodule KafkaEx.ConsumerGroup.Manager do
       ]
     )
 
-    {:ok, worker_name} =
-      KafkaEx.create_worker(:no_name, consumer_group: group_name)
+    worker_opts = Keyword.take(opts, [:uris])
+    {:ok, worker_name} = KafkaEx.create_worker(
+      :no_name,
+      [consumer_group: group_name] ++ worker_opts
+    )
 
     state = %State{
       supervisor_pid: supervisor_pid,

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -391,8 +391,11 @@ defmodule KafkaEx.GenConsumer do
     )
 
     {:ok, consumer_state} = consumer_module.init(topic, partition)
-    {:ok, worker_name} =
-      KafkaEx.create_worker(:no_name, consumer_group: group_name)
+    worker_opts = Keyword.take(opts, [:uris])
+    {:ok, worker_name} = KafkaEx.create_worker(
+      :no_name,
+      [consumer_group: group_name] ++ worker_opts
+    )
 
     state = %State{
       consumer_module: consumer_module,


### PR DESCRIPTION
You can now load the broker list from the environment and do something like:
```elixir
brokers = [
  {System.get_env("KAFKA_HOST"), String.to_integer(System.get_env("KAFKA_PORT"))},
]

children = [
  supervisor(KafkaEx.ConsumerGroup, [
    gen_consumer_impl,
    consumer_group_name,
    topic_names,
    [uris: brokers]
  ])
]
Supervisor.start_link(children, strategy: :one_for_one)
```