### PR TITLE
Consumer coordinator fix

### DIFF
--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -278,6 +278,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     case sync_group_response do
       %SyncGroupResponse{error_code: :no_error, assignments: assignments} ->
         new_state = state
+                    |> stop_consumer()
                     |> start_consumer(unpack_assignments(assignments))
                     |> start_heartbeat_timer()
         {:ok, new_state}

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -14,6 +14,8 @@ defmodule KafkaEx.Server0P9P0 do
   alias KafkaEx.NetworkClient
   alias KafkaEx.Server0P8P2
 
+  require Logger
+
   @consumer_group_update_interval 30_000
 
   def start_link(args, name \\ __MODULE__)
@@ -74,41 +76,66 @@ defmodule KafkaEx.Server0P9P0 do
   def kafka_server_join_group(join_group_request, network_timeout, state) do
     true = consumer_group?(state)
     {broker, state} = broker_for_consumer_group_with_update(state)
-    request = JoinGroup.create_request(state.correlation_id, @client_id, join_group_request)
+    wire_request = JoinGroup.create_request(state.correlation_id, @client_id, join_group_request)
     response = broker
-      |> NetworkClient.send_sync_request(request, config_sync_timeout(network_timeout))
+      |> NetworkClient.send_sync_request(wire_request, config_sync_timeout(network_timeout))
       |> JoinGroup.parse_response
-    {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+
+    if response.error_code == :not_coordinator_for_consumer do
+      {_, updated_state} = update_consumer_metadata(state)
+      kafka_server_join_group(join_group_request, network_timeout, updated_state)
+    else
+      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+    end
   end
 
   def kafka_server_sync_group(sync_group_request, network_timeout, state) do
     true = consumer_group?(state)
     {broker, state} = broker_for_consumer_group_with_update(state)
-    request = SyncGroup.create_request(state.correlation_id, @client_id, sync_group_request)
+    wire_request = SyncGroup.create_request(state.correlation_id, @client_id, sync_group_request)
     response = broker
-      |> NetworkClient.send_sync_request(request, config_sync_timeout(network_timeout))
+      |> NetworkClient.send_sync_request(wire_request, config_sync_timeout(network_timeout))
       |> SyncGroup.parse_response
-    {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+
+    if response.error_code == :not_coordinator_for_consumer do
+      {_, updated_state} = update_consumer_metadata(state)
+      kafka_server_sync_group(sync_group_request, network_timeout, updated_state)
+    else
+      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+    end
   end
 
   def kafka_server_leave_group(request, network_timeout, state) do
     true = consumer_group?(state)
     {broker, state} = broker_for_consumer_group_with_update(state)
-    request = LeaveGroup.create_request(state.correlation_id, @client_id, request)
+    wire_request = LeaveGroup.create_request(state.correlation_id, @client_id, request)
+
     response = broker
-      |> NetworkClient.send_sync_request(request, config_sync_timeout(network_timeout))
+      |> NetworkClient.send_sync_request(wire_request, config_sync_timeout(network_timeout))
       |> LeaveGroup.parse_response
-    {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+
+    if response.error_code == :not_coordinator_for_consumer do
+      {_, updated_state} = update_consumer_metadata(state)
+      kafka_server_leave_group(request, network_timeout, updated_state)
+    else
+      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+    end
   end
 
   def kafka_server_heartbeat(request, network_timeout, state) do
     true = consumer_group?(state)
     {broker, state} = broker_for_consumer_group_with_update(state)
-    request = Heartbeat.create_request(state.correlation_id, @client_id, request)
+    wire_request = Heartbeat.create_request(state.correlation_id, @client_id, request)
     response = broker
-      |> NetworkClient.send_sync_request(request, config_sync_timeout(network_timeout))
+      |> NetworkClient.send_sync_request(wire_request, config_sync_timeout(network_timeout))
       |> Heartbeat.parse_response
-    {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+
+    if response.error_code == :not_coordinator_for_consumer do
+      {_, updated_state} = update_consumer_metadata(state)
+      kafka_server_heartbeat(request, network_timeout, updated_state)
+    else
+      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+    end
   end
 
   defp update_consumer_metadata(state), do: update_consumer_metadata(state, @retry_count, 0)


### PR DESCRIPTION
I believe this should fix #247 

In addition to #248 and #249 I think there were two lingering issues: 
1) Not stopping the previous consumer supervisor on rebalance.  This accounts for the `{:error, {:already_started, _}}` errors.
2) Not gracefully handling a change in consumer group coordinator node.  

I think (1) is pretty straightforward but I would appreciate some discussion on (2).  The previous behavior could fall under the "let it fail" mantra but I think it was causing enough failures to run into restart policies.  I don't think what I've done here is overly complicated - it just detects the failure and re-acquires the group metadata then recursively tries itself again.

I also had a concern about the right scope for this to happen.  Part of me says it should happen in the server implementation because one could argue that the server implementation is intended to abstract away the notion of talking to a cluster, and this is dealing with figuring out which cluster node we need to talk to.  Part of me says that following the consumer group coordinator node is part of the behavior of the consumer group itself.

The changes to the server implementation also feel a little un-DRY, but I didn't want to do any significant refactoring until the above concerns were addressed.

If this approach seems reasonable, we may actually want to implement something similar for other server transactions - e.g., update metadata whenever we get `:not_leader_for_partition`.

I'll update #247 with instructions on how to reproduce the original problem.

@bjhaid and @joshuawscott I know it's the holiday week but I'd really appreciate your input on this.  @cjpoll this hopefully fixes our issue.