### PR TITLE
Fix correlation id bug, refactor consumer group network requests

### DIFF
--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -73,96 +73,116 @@ defmodule KafkaEx.Server0P9P0 do
     {:ok, state}
   end
 
-  def kafka_server_join_group(join_group_request, network_timeout, state) do
-    true = consumer_group?(state)
-    {broker, state} = broker_for_consumer_group_with_update(state)
-    wire_request = JoinGroup.create_request(
-      state.correlation_id,
-      @client_id,
-      join_group_request
+  def kafka_server_join_group(join_group_request, network_timeout, state_in) do
+    true = consumer_group?(state_in)
+
+    request_builder = fn(state) ->
+      JoinGroup.create_request(
+        state.correlation_id,
+        @client_id,
+        join_group_request
+      )
+    end
+    response_parser = &JoinGroup.parse_response/1
+
+    {response, state_out} = consumer_group_sync_request(
+      request_builder,
+      response_parser,
+      network_timeout,
+      state_in
     )
+
+    {:reply, response, state_out}
+  end
+
+  def kafka_server_sync_group(sync_group_request, network_timeout, state_in) do
+    true = consumer_group?(state_in)
+
+    request_builder = fn(state) ->
+      SyncGroup.create_request(
+        state.correlation_id,
+        @client_id,
+        sync_group_request
+      )
+    end
+    response_parser = &SyncGroup.parse_response/1
+
+    {response, state_out} = consumer_group_sync_request(
+      request_builder,
+      response_parser,
+      network_timeout,
+      state_in
+    )
+
+    {:reply, response, state_out}
+  end
+
+  def kafka_server_leave_group(request, network_timeout, state_in) do
+    true = consumer_group?(state_in)
+
+    request_builder = fn(state) ->
+      LeaveGroup.create_request(state.correlation_id, @client_id, request)
+    end
+    response_parser = &LeaveGroup.parse_response/1
+
+    {response, state_out} = consumer_group_sync_request(
+      request_builder,
+      response_parser,
+      network_timeout,
+      state_in
+    )
+
+    {:reply, response, state_out}
+  end
+
+  def kafka_server_heartbeat(request, network_timeout, state_in) do
+    true = consumer_group?(state_in)
+
+    request_builder = fn(state) ->
+      Heartbeat.create_request(state.correlation_id, @client_id, request)
+    end
+    response_parser = &Heartbeat.parse_response/1
+
+    {response, state_out} = consumer_group_sync_request(
+      request_builder,
+      response_parser,
+      network_timeout,
+      state_in
+    )
+
+    {:reply, response, state_out}
+  end
+
+  defp consumer_group_sync_request(
+    request_builder,
+    response_parser,
+    network_timeout,
+    state
+  ) do
+    {broker, state} = broker_for_consumer_group_with_update(state)
+
     sync_timeout = config_sync_timeout(network_timeout)
-    response = broker
-      |> NetworkClient.send_sync_request(wire_request, sync_timeout)
-      |> JoinGroup.parse_response
+
+    wire_request = request_builder.(state)
+    wire_response = NetworkClient.send_sync_request(
+      broker,
+      wire_request,
+      sync_timeout
+    )
+    response = response_parser.(wire_response)
+
+    state_out = %{state | correlation_id: state.correlation_id + 1}
 
     if response.error_code == :not_coordinator_for_consumer do
-      {_, updated_state} = update_consumer_metadata(state)
-      kafka_server_join_group(
-        join_group_request,
+      {_, updated_state_out} = update_consumer_metadata(state_out)
+      consumer_group_sync_request(
+        request_builder,
+        response_parser,
         network_timeout,
-        updated_state
+        updated_state_out
       )
     else
-      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
-    end
-  end
-
-  def kafka_server_sync_group(sync_group_request, network_timeout, state) do
-    true = consumer_group?(state)
-    {broker, state} = broker_for_consumer_group_with_update(state)
-    wire_request = SyncGroup.create_request(
-      state.correlation_id,
-      @client_id,
-      sync_group_request
-    )
-    sync_timeout = config_sync_timeout(network_timeout)
-    response = broker
-      |> NetworkClient.send_sync_request(wire_request, sync_timeout)
-      |> SyncGroup.parse_response
-
-    if response.error_code == :not_coordinator_for_consumer do
-      {_, updated_state} = update_consumer_metadata(state)
-      kafka_server_sync_group(
-        sync_group_request,
-        network_timeout,
-        updated_state
-      )
-    else
-      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
-    end
-  end
-
-  def kafka_server_leave_group(request, network_timeout, state) do
-    true = consumer_group?(state)
-    {broker, state} = broker_for_consumer_group_with_update(state)
-    wire_request = LeaveGroup.create_request(
-      state.correlation_id,
-      @client_id,
-      request
-    )
-
-    sync_timeout = config_sync_timeout(network_timeout)
-    response = broker
-      |> NetworkClient.send_sync_request(wire_request, sync_timeout)
-      |> LeaveGroup.parse_response
-
-    if response.error_code == :not_coordinator_for_consumer do
-      {_, updated_state} = update_consumer_metadata(state)
-      kafka_server_leave_group(request, network_timeout, updated_state)
-    else
-      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
-    end
-  end
-
-  def kafka_server_heartbeat(request, network_timeout, state) do
-    true = consumer_group?(state)
-    {broker, state} = broker_for_consumer_group_with_update(state)
-    wire_request = Heartbeat.create_request(
-      state.correlation_id,
-      @client_id,
-      request
-    )
-    sync_timeout = config_sync_timeout(network_timeout)
-    response = broker
-      |> NetworkClient.send_sync_request(wire_request, sync_timeout)
-      |> Heartbeat.parse_response
-
-    if response.error_code == :not_coordinator_for_consumer do
-      {_, updated_state} = update_consumer_metadata(state)
-      kafka_server_heartbeat(request, network_timeout, updated_state)
-    else
-      {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+      {response, state_out}
     end
   end
 


### PR DESCRIPTION
I introduced a minor bug in #251 - the correlation id was not being properly incremented for each request.  This is not really a big issue with KafkaEx because we don't really use the correlation id to correlate responses, but I still wanted to fix it.

Part of my fix here is to refactor the consumer group sync requests to a single function.  The behavior is the same for all of the calls:

* Convert a request struct to a wire request binary
* Do the sync network request
* Parse the response binary back into a struct
* Repeat the request if we get a "not group coordinator" error message

I would like to explore using [protocols](http://elixir-lang.github.io/getting-started/protocols.html) for this, but wanted to get the fix done first.