### PR TITLE
Adds a clause to match when a partial messageSet is received.

### DIFF
--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -73,12 +73,8 @@ defmodule KafkaEx.Protocol.Fetch do
   defp parse_message_set([last|_] = list, _) do
     {:ok, Enum.reverse(list), last.offset}
   end
-  defp parse_message_set(_, << offset :: 64, msg_size :: 32, rest :: binary >>) do
-    if byte_size(rest) < msg_size do
-      raise RuntimeError, "Too little data fetched at offset #{offset}. Message size #{msg_size} but only got another #{byte_size rest} bytes! Try increasing max_bytes to at least #{msg_size + 12}."
-    else
-      raise FunctionClauseError, "no function clause matching in #{__MODULE__}.parse_message_set/2"
-    end
+  defp parse_message_set(_, << offset :: 64, msg_size :: 32, partial_msg_data :: binary >>) when byte_size(partial_message_data> < msg_size do
+    raise RuntimeError, "Insufficient data fetched at offset #{offset}. Message size is #{msg_size} but only received #{byte_size(partial_message_data)} bytes. Try increasing max_bytes."
   end
 
   # handles the single message case and the batch (compression) case

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -73,6 +73,13 @@ defmodule KafkaEx.Protocol.Fetch do
   defp parse_message_set([last|_] = list, _) do
     {:ok, Enum.reverse(list), last.offset}
   end
+  defp parse_message_set(_, << offset :: 64, msg_size :: 32, rest :: binary >>) do
+    if byte_size(rest) < msg_size do
+      raise RuntimeError, "Too little data fetched at offset #{offset}. Message size #{msg_size} but only got another #{byte_size rest} bytes! Try increasing max_bytes to at least #{msg_size + 12}."
+    else
+      raise FunctionClauseError, "no function clause matching in #{__MODULE__}.parse_message_set/2"
+    end
+  end
 
   # handles the single message case and the batch (compression) case
   defp append_messages([], list) do

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -73,7 +73,7 @@ defmodule KafkaEx.Protocol.Fetch do
   defp parse_message_set([last|_] = list, _) do
     {:ok, Enum.reverse(list), last.offset}
   end
-  defp parse_message_set(_, << offset :: 64, msg_size :: 32, partial_msg_data :: binary >>) when byte_size(partial_message_data> < msg_size do
+  defp parse_message_set(_, << offset :: 64, msg_size :: 32, partial_message_data :: binary >>) when byte_size(partial_message_data) < msg_size do
     raise RuntimeError, "Insufficient data fetched at offset #{offset}. Message size is #{msg_size} but only received #{byte_size(partial_message_data)} bytes. Try increasing max_bytes."
   end
 


### PR DESCRIPTION
We had a recent production issue where our consumer was unable to progress. It turns out that our Kafka broker was sending the client a Message Set of around 1.7MB, which is incompatible with a `max_bytes` of 61000. We use a small `max_bytes` as we currently run all 64 partition consumers on a single host and don't want to OOM if it falls a bit behind. Our message producer is limited to messages <61000 bytes, so we didn't expect KafkaEx to have a problem.

This PR doesn't fix the problem, but it would have greatly reduced the amount of running around and not knowing what was going on (`FunctionClauseError` really doesn't tell you what is going on). As a stopgap for providing more elastic message sizes, this new error message should at least give users the help they need to proceed.

Here's an example stack trace from patching this locally:
```
** (exit) exited in: GenServer.call(:pr, {:fetch, "ile_group_requests", 52, 128110540, 10, 1, 60000, false}, 5000)
    ** (EXIT) an exception was raised:
        ** (RuntimeError) Too little data at offset 128110540. Message size 1712101 but only got another 59988 bytes!  Try increasing max_bytes to at least 1712113.
            (kafka_ex) lib/kafka_ex/protocol/fetch.ex:46: KafkaEx.Protocol.Fetch.parse_message_set/2
            (kafka_ex) lib/kafka_ex/protocol/fetch.ex:31: KafkaEx.Protocol.Fetch.parse_partitions/3
            (kafka_ex) lib/kafka_ex/protocol/fetch.ex:24: KafkaEx.Protocol.Fetch.parse_topics/2
            (kafka_ex) lib/kafka_ex/server.ex:324: KafkaEx.Server.fetch/8
            (kafka_ex) lib/kafka_ex/server.ex:92: KafkaEx.Server.handle_call/3
            (stdlib) gen_server.erl:615: :gen_server.try_handle_call/4
            (stdlib) gen_server.erl:647: :gen_server.handle_msg/5
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:604: GenServer.call/3
```

Let me know what else I can do to help!