### PR TITLE
NetworkClient should not send nil in case of failure

### DIFF
--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -40,11 +40,11 @@ defmodule KafkaEx.NetworkClient do
           {:ok, data} -> data
           {:error, reason} ->
             Logger.log(:error, "Receiving data from broker #{inspect broker.host}:#{inspect broker.port} failed with #{inspect reason}")
-            nil
+            {:error, reason}
         end
       {_, reason} ->
         Logger.log(:error, "Sending data to broker #{inspect broker.host}:#{inspect broker.port} failed with #{inspect reason}")
-        nil
+        {:error, reason}
     end
 
     :ok = Socket.setopts(socket, [:binary, {:packet, 4}, {:active, true}])


### PR DESCRIPTION
As pointed out by @dantswain Swallowing `nil` in https://github.com/kafkaex/kafka_ex/pull/272 was not a good idea. It leads to further crashes in here 
`response |> hd |> Map.get(:partitions) |> hd |> Map.get(:last_offset)`

![screen shot 2018-02-26 at 17 25 03](https://user-images.githubusercontent.com/779409/36928899-94daa452-1ecd-11e8-9461-d831052c83d1.png)

If we return the `{:error, reason}` in case of network_client's `send_sync_reuqest` failure, it leads to the genserver crashing but with a valid reason.
<img width="1306" alt="screen shot 2018-03-03 at 10 17 01" src="https://user-images.githubusercontent.com/779409/36928916-c9bb4f32-1ecd-11e8-89e9-d05d5ad44043.png">

I would like to fix the issues related to https://github.com/kafkaex/kafka_ex/issues/233 as much as possible. 
@joshuawscott @dantswain  would appreciate the guidance/suggestions to fix this behaviour. Thank you.
1. Should the network_client retry the connection?
2. If the network_client continues to timeout, should the `genconsumer's consume/1` handle the result and reply with error?

While we are at it, I would like to send `{:ok, response}` in case of success if thats ok.