### PR TITLE
Add Elixir 1.6 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,21 @@ cache:
   directories:
     - deps
     - _build
-otp_release:
-  - 18.3
-  - 19.3
-elixir:
-  - 1.4.5
-  - 1.3.4
-  - 1.2.6
-  - 1.1.1
 matrix:
-  exclude:
-    - elixir: 1.1.1
-      otp_release: 19.3
-    - elixir: 1.4.5
-      otp_release: 19.3
-      env: COVERALLS=false
   include:
-    - elixir: 1.5.2
-      otp_release: 19.3
-    - elixir: 1.5.2
-      otp_release: 20.1
+    - elixir: 1.6.2
+      otp_release: 20.2
+    - elixir: 1.5.3
+      otp_release: 20.2
     - elixir: 1.4.5
       otp_release: 19.3
       env: COVERALLS=true
+    - elixir: 1.3.4
+      otp_release: 19.3
+    - elixir: 1.2.6
+      otp_release: 18.3
+    - elixir: 1.1.1
+      otp_release: 18.3
 dist: trusty
 sudo: required
 services:

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -34,7 +34,7 @@ defmodule KafkaEx.Protocol.Produce do
   def create_request(
     correlation_id,
     client_id,
-    request = %Request{compression: compression, messages: messages}
+    %Request{compression: compression, messages: messages} = request
   ) do
     message_set = create_message_set(messages, compression)
     header = produce_header(correlation_id, client_id, request, message_set)

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -53,7 +53,7 @@ defmodule KafkaEx.Server do
       }
 
     @spec increment_correlation_id(t) :: t
-    def increment_correlation_id(state = %State{correlation_id: cid}) do
+    def increment_correlation_id(%State{correlation_id: cid} = state) do
       %{state | correlation_id: cid + 1}
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,11 +35,10 @@ defmodule KafkaEx.Mixfile do
 
   defp deps do
     [
-      {:credo, "~> 0.8.6", only: :dev},
+      {:credo, "~> 0.8.10", only: :dev},
       {:dialyxir, "~> 0.5.1", only: :dev},
-      {:earmark, "~> 1.0.3", only: :dev},
       {:excoveralls, "~> 0.7", only: :test},
-      {:ex_doc, "~> 0.14.5", only: :dev},
+      {:ex_doc, "~> 0.18", only: :dev},
       {:snappy,
        git: "https://github.com/fdmanana/snappy-erlang-nif",
        only: [:dev, :test]}

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,11 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.7.1", "3dd659db19c290692b5e2c4a2365ae6d4488091a1ba58f62dcbdaa0c03da5491", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2"},
@@ -16,4 +17,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6"},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "c4cd1bb35f3a3a399737d64bd03b479817b90e75", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
I also trimmed down the number of builds so that we only run a single
build for each version of Elixir.

I found 2 credo issues and fixed them. I would be in favor of running
credo and dialyzer in travis, but would like a second opinion on that.

Also updated some dependencies