### PR TITLE
Add handle_cast and handle_info callbacks to GenConsumer

### DIFF
--- a/test/kafka_ex/gen_consumer_test.exs
+++ b/test/kafka_ex/gen_consumer_test.exs
@@ -1,5 +1,6 @@
 defmodule KafkaEx.GenConsumerTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   # non-integration GenConsumer tests
 
@@ -11,5 +12,15 @@ defmodule KafkaEx.GenConsumerTest do
 
   test "calling handle_call raises an error if there is no implementation" do
     assert_raise RuntimeError, fn -> TestConsumer.handle_call(nil, nil, nil) end
+  end
+
+  test "calling handle_cast raises an error if there is no implementation" do
+    assert_raise RuntimeError, fn -> TestConsumer.handle_cast(nil, nil) end
+  end
+
+  test "calling handle_info raises an error if there is no implementation" do
+    assert capture_log(fn ->
+      TestConsumer.handle_info(nil, nil)
+    end) =~ "unexpected message in handle_info"
   end
 end


### PR DESCRIPTION
This makes `KafkaEx.GenConsumer` a bit more flexible, as per issue #270.