### PR TITLE
Update documentation with potential gotcha around broker configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,10 @@
 use Mix.Config
 
 config :kafka_ex,
-  # a list of brokers to connect to in {"HOST", port} format
+  # A list of brokers to connect to in {"HOST", port} format. If you receive :leader_not_available
+  # errors when producing messages, it may be necessary to modify "advertised.host.name" in the
+  # server.properties file.
+  # In the case below you would set "advertised.host.name=localhost"
   brokers: [
     {"localhost", 9092},
     {"localhost", 9093},


### PR DESCRIPTION
After following the examples in the documentation I lost a few hours trying to figure out why I was getting a message that I'd successfully connected to a broker but that a leader was not present.  Hopefully this note will help others save that time when trying to get started using a stock kafka `server.properties` config file.

Please let me know if this is appropriate or if there are changes necessary to better match the goals/tone of the documentation