### PR TITLE
Set sane default values for SSL settings

### DIFF
--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -10,13 +10,13 @@ defmodule KafkaEx.Config do
   require Logger
 
   @doc false
-  def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl)
+  def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl, false)
 
   # use this function to get the ssl options - it verifies the options and
   #   either emits warnings or raises errors as appropriate on misconfiguration
   @doc false
   def ssl_options do
-    ssl_options(use_ssl(), Application.get_env(:kafka_ex, :ssl_options))
+    ssl_options(use_ssl(), Application.get_env(:kafka_ex, :ssl_options, []))
   end
 
   @doc false
@@ -37,7 +37,6 @@ defmodule KafkaEx.Config do
 
   # ssl_options should be an empty list by default if use_ssl is false
   defp ssl_options(false, []), do: []
-  defp ssl_options(false, nil), do: []
   # emit a warning if use_ssl is false but options are present
   #   (this is not a fatal error and can occur if one disables ssl in the
   #    default option set)


### PR DESCRIPTION
This is a small pull-request that aims at setting sane defaults for KafkaEx's SSL settings.

The current implementation requires `KafkaEx` to explicitly set `:use_ssl` to either `true` or `false`. Otherwise, `KafkaEx` yields an error at boot time.

```elixir
iex -S mix
Erlang/OTP 20 [erts-9.1.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

=INFO REPORT==== 2-Apr-2018::14:47:51 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application kafka_ex: exited in: KafkaEx.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in KafkaEx.Config.ssl_options/2
            (kafka_ex) lib/kafka_ex/config.ex:39: KafkaEx.Config.ssl_options(nil, nil)
            (kafka_ex) lib/kafka_ex.ex:490: KafkaEx.build_worker_options/1
            (kafka_ex) lib/kafka_ex.ex:68: KafkaEx.create_worker/2
            (kafka_ex) lib/kafka_ex.ex:539: KafkaEx.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4
```

The only required change would be **L19**. However, I took the liberty to set `:ssl_options` default value to an empty list, which is what the comments suggest.

```elixir
# ssl_options should be an empty list by default if use_ssl is false
```

By doing this, we can safely remove the following `ssl_option/2`'s function clause, which becomes dead code.

```elixir
defp ssl_options(false, nil), do: []
```