### PR TITLE
Set sane default values for using the default worker

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -533,7 +533,7 @@ defmodule KafkaEx do
     max_seconds = Application.get_env(:kafka_ex, :max_seconds, 60)
     {:ok, pid}     = KafkaEx.Supervisor.start_link(Config.server_impl, max_restarts, max_seconds)
 
-    if Application.get_env(:kafka_ex, :disable_default_worker) == true do
+    if Config.disable_default_worker do
       {:ok, pid}
     else
       case KafkaEx.create_worker(Config.default_worker, []) do

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -485,7 +485,7 @@ defmodule KafkaEx do
   def build_worker_options(worker_init) do
     defaults = [
       uris: Application.get_env(:kafka_ex, :brokers),
-      consumer_group: Application.get_env(:kafka_ex, :consumer_group),
+      consumer_group: Config.consumer_group(),
       use_ssl: Config.use_ssl(),
       ssl_options: Config.ssl_options(),
     ]

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -10,6 +10,11 @@ defmodule KafkaEx.Config do
   require Logger
 
   @doc false
+  def disable_default_worker do
+    Application.get_env(:kafka_ex, :disable_default_worker, false)
+  end
+
+  @doc false
   def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl, false)
 
   # use this function to get the ssl options - it verifies the options and

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -15,6 +15,11 @@ defmodule KafkaEx.Config do
   end
 
   @doc false
+  def consumer_group do
+    Application.get_env(:kafka_ex, :consumer_group, "kafka_ex")
+  end
+
+  @doc false
   def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl, false)
 
   # use this function to get the ssl options - it verifies the options and


### PR DESCRIPTION
This pull-request aims at making it easier to get started with `KafkaEx`.

I've noticed that some of the settings do not provide sane defaults. This pull-request introduces the following changes:

- The default worker is disabled by default
- Sets a sane default value for the `:consumer_group` option

Without these changes, `KafkaEx` yields an error at boot time.

```elixir
Erlang/OTP 20 [erts-9.1.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

=INFO REPORT==== 2-Apr-2018::14:54:55 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application kafka_ex: KafkaEx.start(:normal, []) returned an error: :invalid_consumer_group
```