### PR TITLE
Adds CSV broker definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for details of these features.
 The standard approach for adding dependencies to an Elixir application applies:
 add KafkaEx to the deps and applications lists in your project's mix.exs file.
 You may also optionally add
-[snappy-erlang-nif](https://github.com/fdmanana/snappy-erlang-nif) (required 
+[snappy-erlang-nif](https://github.com/fdmanana/snappy-erlang-nif) (required
 only if you want to use snappy compression).
 
 ```elixir
@@ -53,7 +53,7 @@ defmodule MyApp.Mixfile do
       ]
     ]
   end
- 
+
   defp deps do
     [
       # add to your existing deps
@@ -73,7 +73,7 @@ See [config/config.exs](https://github.com/kafkaex/kafka_ex/blob/master/config/c
 or [KafkaEx.Config](https://hexdocs.pm/kafka_ex/KafkaEx.Config.html)
 for a description of configuration variables, including the Kafka broker list
  and default consumer group.
- 
+
 You can also override options when creating a worker, see below.
 
 ## Usage Examples
@@ -145,7 +145,7 @@ To do this, you will need to call:
 ```elixir
 GenServer.start_link(KafkaEx.Config.server_impl,
   [
-    [uris: Application.get_env(:kafka_ex, :brokers),
+    [uris: KafkaEx.Config.brokers(),
      consumer_group: Application.get_env(:kafka_ex, :consumer_group)],
     :no_name
   ]

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -42,7 +42,7 @@ defmodule KafkaEx do
 
   Optional arguments(KeywordList)
   - consumer_group: Name of the group of consumers, `:no_consumer_group` should be passed for Kafka < 0.8.2, defaults to `Application.get_env(:kafka_ex, :consumer_group)`
-  - uris: List of brokers in `{"host", port}` form, defaults to `Application.get_env(:kafka_ex, :brokers)`
+  - uris: List of brokers in `{"host", port}` or comma separated value `"host:port,host:port"` form, defaults to `Application.get_env(:kafka_ex, :brokers)`
   - metadata_update_interval: How often `kafka_ex` would update the Kafka cluster metadata information in milliseconds, default is 30000
   - consumer_group_update_interval: How often `kafka_ex` would update the Kafka cluster consumer_groups information in milliseconds, default is 30000
   - use_ssl: Boolean flag specifying if ssl should be used for the connection by the worker to kafka, default is false
@@ -380,7 +380,7 @@ defmodule KafkaEx do
   If you pass a value for the `consumer_group` option and true for
   `auto_commit`, the offset of the last message consumed will be committed to
   the broker during each cycle.
-  
+
   For example, suppose we start at the beginning of a partition with millions
   of messages and the `max_bytes` setting is such that each `fetch` request
   gets 25 messages.  In this setting, we will (roughly) be committing offsets
@@ -484,7 +484,7 @@ defmodule KafkaEx do
     {:ok, worker_init} | {:error, :invalid_consumer_group}
   def build_worker_options(worker_init) do
     defaults = [
-      uris: Application.get_env(:kafka_ex, :brokers),
+      uris: Config.brokers(),
       consumer_group: Config.consumer_group(),
       use_ssl: Config.use_ssl(),
       ssl_options: Config.ssl_options(),

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -9,6 +9,8 @@ defmodule KafkaEx.Config do
 
   require Logger
 
+  @default_port 9092
+
   @doc false
   def disable_default_worker do
     Application.get_env(:kafka_ex, :disable_default_worker, false)
@@ -39,6 +41,29 @@ defmodule KafkaEx.Config do
     :kafka_ex
       |> Application.get_env(:kafka_version, :default)
       |> server
+  end
+
+  @doc false
+  def brokers() do
+    :kafka_ex
+      |> Application.get_env(:brokers)
+      |> brokers()
+  end
+
+  defp brokers(nil),
+    do: nil
+  defp brokers(list) when is_list(list),
+    do: list
+  defp brokers(csv) when is_binary(csv) do
+    for line <- String.split(csv, ","), into: [] do
+      case line |> String.trim() |> String.split(":") do
+        [host] ->
+          {host, @default_port}
+        [host, port] ->
+          {port, _} = Integer.parse(port)
+          {host, port}
+      end
+    end
   end
 
   defp server("0.8.0"), do: KafkaEx.Server0P8P0

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -43,4 +43,26 @@ defmodule KafkaEx.ConfigTest do
     Application.put_env(:kafka_ex, :ssl_options, %{cacertfile: "/ssl/ca-cert"})
     assert_raise(ArgumentError, ~r/invalid ssl_options/, &Config.ssl_options/0)
   end
+
+  describe "brokers" do
+    test "with list of hosts" do
+      brokers = [{"example.com", 9092}]
+      Application.put_env(:kafka_ex, :brokers, brokers)
+
+      assert brokers == Config.brokers()
+    end
+
+    test "with a csv of hosts" do
+      brokers = " example.com,one.example.com:4534, two.example.com:9999 "
+
+      parsed_brokers = [
+        {"example.com", 9092},
+        {"one.example.com", 4534},
+        {"two.example.com", 9999}
+      ]
+
+      Application.put_env(:kafka_ex, :brokers, brokers)
+      assert parsed_brokers == Config.brokers()
+    end
+  end
 end


### PR DESCRIPTION
When configuring brokers from an environment variable being able to parse a list of CSV style host/ports is useful.

This is a simple change that allows the broker list in configuration to be given as either a list of CSV value.