### PR TITLE
Separate Heartbeat from Manager

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 80
+]

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -1,0 +1,81 @@
+defmodule KafkaEx.ConsumerGroup.Heartbeat do
+  @moduledoc false
+  # GenServer to send heartbeats to the broker
+  #
+  # A `HeartbeatRequest` is sent periodically by each active group member (after
+  # completing the join/sync phase) to inform the broker that the member is
+  # still alive and participating in the group. If a group member fails to send
+  # a heartbeat before the group's session timeout expires, the coordinator
+  # removes that member from the group and initiates a rebalance.
+  #
+  # `HeartbeatResponse` allows the coordinating broker to communicate the
+  # group's status to each member:
+  #
+  #   * `:no_error` indicates that the group is up to date and no action is
+  #   needed.
+  #   * `:rebalance_in_progress` a rebalance has been initiated, so each member
+  #   should re-join.
+  #   * `:unknown_member_id` means that this heartbeat was from a previous dead
+  #   generation.
+  #
+  # For either of the error conditions, the heartbeat process exits, which is
+  # trapped by the KafkaEx.ConsumerGroup.Manager and handled by re-joining the
+  # consumer group. (see KafkaEx.ConsumerGroup.Manager.join/1)
+
+  require Logger
+  alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
+  alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse
+
+  defmodule State do
+    defstruct [
+      :worker_name,
+      :heartbeat_request,
+      :heartbeat_interval
+    ]
+  end
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options)
+  end
+
+  def init(%{group_name: group_name, member_id: member_id, generation_id: generation_id, worker_name: worker_name, heartbeat_interval: heartbeat_interval}) do
+    heartbeat_request = %HeartbeatRequest{
+      group_name: group_name,
+      member_id: member_id,
+      generation_id: generation_id
+    }
+
+    state = %State{
+      worker_name: worker_name,
+      heartbeat_request: heartbeat_request,
+      heartbeat_interval: heartbeat_interval
+    }
+
+    {:ok, state, state.heartbeat_interval}
+  end
+
+  def handle_info(
+        :timeout,
+        %State{
+          worker_name: worker_name,
+          heartbeat_request: heartbeat_request,
+          heartbeat_interval: heartbeat_interval
+        } = state
+      ) do
+    case KafkaEx.heartbeat(heartbeat_request, worker_name: worker_name) do
+      %HeartbeatResponse{error_code: :no_error} ->
+        Logger.debug("XXX: HB OK")
+        {:noreply, state, heartbeat_interval}
+
+      %HeartbeatResponse{error_code: :rebalance_in_progress} ->
+        Logger.debug("XXX: HB REBALANCE")
+        {:stop, :rebalance, state}
+
+      %HeartbeatResponse{error_code: :unknown_member_id} ->
+        {:stop, :rebalance, state}
+
+      %HeartbeatResponse{error_code: error_code} ->
+        Logger.warn("Heartbeat failed, got error code #{error_code}")
+    end
+  end
+end

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -22,6 +22,7 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
   # trapped by the KafkaEx.ConsumerGroup.Manager and handled by re-joining the
   # consumer group. (see KafkaEx.ConsumerGroup.Manager.join/1)
 
+  use GenServer
   require Logger
   alias KafkaEx.Protocol.Heartbeat.Request, as: HeartbeatRequest
   alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -77,6 +77,7 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
 
       %HeartbeatResponse{error_code: error_code} ->
         Logger.warn("Heartbeat failed, got error code #{error_code}")
+        {:stop, {:error, error_code}, state}
     end
   end
 end

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -70,14 +70,14 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
         {:noreply, state, heartbeat_interval}
 
       %HeartbeatResponse{error_code: :rebalance_in_progress} ->
-        {:stop, :rebalance, state}
+        {:stop, {:shutdown, :rebalance}, state}
 
       %HeartbeatResponse{error_code: :unknown_member_id} ->
-        {:stop, :rebalance, state}
+        {:stop, {:shutdown, :rebalance}, state}
 
       %HeartbeatResponse{error_code: error_code} ->
         Logger.warn("Heartbeat failed, got error code #{error_code}")
-        {:stop, {:error, error_code}, state}
+        {:stop, {:shutdown, {:error, error_code}}, state}
     end
   end
 end

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -27,18 +27,21 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
   alias KafkaEx.Protocol.Heartbeat.Response, as: HeartbeatResponse
 
   defmodule State do
-    defstruct [
-      :worker_name,
-      :heartbeat_request,
-      :heartbeat_interval
-    ]
+    @moduledoc false
+    defstruct [:worker_name, :heartbeat_request, :heartbeat_interval]
   end
 
   def start_link(options) do
     GenServer.start_link(__MODULE__, options)
   end
 
-  def init(%{group_name: group_name, member_id: member_id, generation_id: generation_id, worker_name: worker_name, heartbeat_interval: heartbeat_interval}) do
+  def init(%{
+        group_name: group_name,
+        member_id: member_id,
+        generation_id: generation_id,
+        worker_name: worker_name,
+        heartbeat_interval: heartbeat_interval
+      }) do
     heartbeat_request = %HeartbeatRequest{
       group_name: group_name,
       member_id: member_id,
@@ -64,11 +67,9 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
       ) do
     case KafkaEx.heartbeat(heartbeat_request, worker_name: worker_name) do
       %HeartbeatResponse{error_code: :no_error} ->
-        Logger.debug("XXX: HB OK")
         {:noreply, state, heartbeat_interval}
 
       %HeartbeatResponse{error_code: :rebalance_in_progress} ->
-        Logger.debug("XXX: HB REBALANCE")
         {:stop, :rebalance, state}
 
       %HeartbeatResponse{error_code: :unknown_member_id} ->

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -159,7 +159,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   end
 
   # If the heartbeat gets an error, we need to rebalance.
-  def handle_info({:EXIT, heartbeat_timer, :rebalance}, %State{heartbeat_timer: heartbeat_timer} = state) do
+  def handle_info({:EXIT, heartbeat_timer, {:shutdown, :rebalance}}, %State{heartbeat_timer: heartbeat_timer} = state) do
     {:ok, state} = rebalance(state)
     {:noreply, state}
   end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -357,7 +357,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     %State{heartbeat_timer: heartbeat_timer} = state
   ) do
     if Process.alive?(heartbeat_timer) do
-      GenServer.stop(heartbeat_timer)
+      :gen_server.stop(heartbeat_timer)
     end
     %State{state | heartbeat_timer: nil}
   end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -6,6 +6,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   use GenServer
 
   alias KafkaEx.ConsumerGroup
+  alias KafkaEx.ConsumerGroup.Heartbeat
   alias KafkaEx.ConsumerGroup.PartitionAssignment
   alias KafkaEx.Protocol.JoinGroup.Request, as: JoinGroupRequest
   alias KafkaEx.Protocol.JoinGroup.Response, as: JoinGroupResponse
@@ -13,7 +14,6 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   alias KafkaEx.Protocol.Metadata.Response, as: MetadataResponse
   alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
   alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
-
   require Logger
 
   defmodule State do
@@ -345,7 +345,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   # messages.
   @spec start_heartbeat_timer(State.t) :: State.t
   defp start_heartbeat_timer(%State{} = state) do
-    {:ok, timer} = KafkaEx.ConsumerGroup.Heartbeat.start_link(state)
+    {:ok, timer} = Heartbeat.start_link(state)
 
     %State{state | heartbeat_timer: timer}
   end


### PR DESCRIPTION
This moves the heartbeat functionality into a separate GenServer so that
even if the worker startup takes a long time, such as over high latency
connections, the broker won't remove the consumer from the group.

This seems to solve issues we've had where we were getting
:unknown_member_id errors back.

The heartbeat notifies the manager of a need for rebalance by exiting
with a reason of `:rebalance`. The Manager starts a rebalance upon
receiving that message.

I added a number of specs to the Manager, which I can remove if we wish - I was mainly doing this because I kept mixing up which functions return `{:ok, State.t}` vs `State.t`