### PR TITLE
fix some details in KafkaEx.GenConsumer.Manager

### DIFF
--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -331,8 +331,8 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   # synchronized during the join/sync phase, each member pauses its consumers
   # and commits its offsets before rejoining the group.
   defp rebalance(%State{} = state) do
-    {:ok, state} = stop_heartbeat_timer(state),
-    {:ok, state} = stop_consumer(state),
+    {:ok, state} = stop_heartbeat_timer(state)
+    {:ok, state} = stop_consumer(state)
     join(state)
   end
 

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -160,10 +160,8 @@ defmodule KafkaEx.ConsumerGroup.Manager do
 
   # If the heartbeat gets an error, we need to rebalance.
   def handle_info({:EXIT, heartbeat_timer, {:shutdown, :rebalance}}, %State{heartbeat_timer: heartbeat_timer} = state) do
-    case rebalance(state) do
-      {:ok, state} -> {:noreply, state}
-      {:error, error} -> raise "failed to rebalance with error #{inspect error}"
-    end
+    {:ok, state} = rebalance(state)
+    {:noreply, state}
   end
 
   # When terminating, inform the group coordinator that this member is leaving
@@ -276,8 +274,6 @@ defmodule KafkaEx.ConsumerGroup.Manager do
         worker_name: worker_name,
         timeout: session_timeout + @session_timeout_padding
       )
-
-    unpacked_assignments = unpack_assignments(assignments)
 
     case error_code do
       :no_error ->


### PR DESCRIPTION
This changes the state-returning private functions to return {:ok, state}. This will allow us to catch and handle errors better moving forward, and also makes it a little easier to keep track of what the private functions are doing.