### PR TITLE
Iolist cleanup

### DIFF
--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -9,16 +9,40 @@ defmodule KafkaEx.Protocol.Produce do
 
   defmodule Request do
     @moduledoc """
-    - require_acks: indicates how many acknowledgements the servers should receive before responding to the request. If it is 0 the server will not send any response (this is the only case where the server will not reply to a request). If it is 1, the server will wait the data is written to the local log before sending a response. If it is -1 the server will block until the message is committed by all in sync replicas before sending a response. For any number > 1 the server will block waiting for this number of acknowledgements to occur (but the server will never wait for more acknowledgements than there are in-sync replicas), default is 0
-    - timeout: provides a maximum time in milliseconds the server can await the receipt of the number of acknowledgements in RequiredAcks, default is 100 milliseconds
+    - require_acks: indicates how many acknowledgements the servers should
+    receive before responding to the request. If it is 0 the server will not
+    send any response (this is the only case where the server will not reply
+    to a request). If it is 1, the server will wait the data is written to the
+    local log before sending a response. If it is -1 the server will block until
+    the message is committed by all in sync replicas before sending a response.
+    For any number > 1 the server will block waiting for this number of
+    acknowledgements to occur (but the server will never wait for more
+    acknowledgements than there are in-sync replicas), default is 0
+    - timeout: provides a maximum time in milliseconds the server can await the
+    receipt of the number of acknowledgements in RequiredAcks, default is 100
+    milliseconds
     """
-    defstruct topic: nil, partition: nil, required_acks: 0, timeout: 0, compression: :none, messages: []
-    @type t :: %Request{topic: binary, partition: integer, required_acks: integer, timeout: integer, compression: atom, messages: list}
+    defstruct topic: nil,
+              partition: nil,
+              required_acks: 0,
+              timeout: 0,
+              compression: :none,
+              messages: []
+
+    @type t :: %Request{
+            topic: binary,
+            partition: integer,
+            required_acks: integer,
+            timeout: integer,
+            compression: atom,
+            messages: list
+          }
   end
 
   defmodule Message do
     @moduledoc """
-    - key: is used for partition assignment, can be nil, when none is provided it is defaulted to nil
+    - key: is used for partition assignment, can be nil, when none is provided
+    it is defaulted to nil
     - value: is the message to be written to kafka logs.
     """
     defstruct key: nil, value: nil
@@ -31,19 +55,30 @@ defmodule KafkaEx.Protocol.Produce do
     @type t :: %Response{topic: binary, partitions: list}
   end
 
-  def create_request(
-    correlation_id,
-    client_id,
-    %Request{topic: topic, partition: partition, required_acks: required_acks, timeout: timeout, compression: compression, messages: messages}
-    ) do
+  def create_request(correlation_id, client_id, %Request{
+        topic: topic,
+        partition: partition,
+        required_acks: required_acks,
+        timeout: timeout,
+        compression: compression,
+        messages: messages
+      }) do
     {message_set, mssize} = create_message_set(messages, compression)
-    [KafkaEx.Protocol.create_request(:produce, correlation_id, client_id),
-      << required_acks :: 16-signed, timeout :: 32-signed, 1 :: 32-signed >>,
-      << byte_size(topic) :: 16-signed, topic :: binary, 1 :: 32-signed, partition :: 32-signed, mssize :: 32-signed >>,
-      message_set]
+
+    [
+      KafkaEx.Protocol.create_request(:produce, correlation_id, client_id),
+      <<required_acks::16-signed, timeout::32-signed, 1::32-signed>>,
+      <<byte_size(topic)::16-signed, topic::binary, 1::32-signed,
+        partition::32-signed, mssize::32-signed>>,
+      message_set
+    ]
   end
 
-  def parse_response(<< _correlation_id :: 32-signed, num_topics :: 32-signed, rest :: binary >>), do: parse_topics(num_topics, rest, __MODULE__)
+  def parse_response(
+        <<_correlation_id::32-signed, num_topics::32-signed, rest::binary>>
+      ),
+      do: parse_topics(num_topics, rest, __MODULE__)
+
   def parse_response(unknown), do: unknown
 
   defp create_message_set([], _compression_type), do: {"", 0}
@@ -79,8 +114,20 @@ defmodule KafkaEx.Protocol.Produce do
   end
 
   def parse_partitions(0, rest, partitions), do: {partitions, rest}
-  def parse_partitions(partitions_size, << partition :: 32-signed, error_code :: 16-signed, offset :: 64, rest :: binary >>, partitions) do
-    parse_partitions(partitions_size - 1, rest, [%{partition: partition, error_code: Protocol.error(error_code), offset: offset} | partitions])
-  end
 
+  def parse_partitions(
+        partitions_size,
+        <<partition::32-signed, error_code::16-signed, offset::64,
+          rest::binary>>,
+        partitions
+      ) do
+    parse_partitions(partitions_size - 1, rest, [
+      %{
+        partition: partition,
+        error_code: Protocol.error(error_code),
+        offset: offset
+      }
+      | partitions
+    ])
+  end
 end

--- a/test/protocol/produce_test.exs
+++ b/test/protocol/produce_test.exs
@@ -46,7 +46,8 @@ defmodule KafkaEx.Protocol.Produce.Test do
       messages: messages
     }
 
-    request = KafkaEx.Protocol.Produce.create_request(1, client_id, produce)
+    iolist_request = KafkaEx.Protocol.Produce.create_request(1, client_id, produce)
+    request = :erlang.iolist_to_binary(iolist_request)
 
     # The exact binary contents of the message can change as zlib changes,
     # but they should remain compatible.  We test this by splitting the binary


### PR DESCRIPTION
Replaces #231 

This just handles the merge conflicts and I will also clean up ebert complaints

## Original description:
This change makes using iolist instead of contiguous binary when building packet being compressed and/or sent.

P.S. Unit tests & dialyzer passed successfully but I'm failed to wait for finish integration tests, they just hanging without any log messages. Anyway, I making this PR, in case someone find time to run all integration tests.

