### PR TITLE
Fix handle_cast fake return value

### DIFF
--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -285,49 +285,56 @@ defmodule KafkaEx.GenConsumer do
 
       def handle_call(msg, _from, consumer_state) do
         # taken from the GenServer handle_call implementation
-        proc = case Process.info(self(), :registered_name) do
-          {_, []}   -> self()
-          {_, name} -> name
-        end
+        proc =
+          case Process.info(self(), :registered_name) do
+            {_, []} -> self()
+            {_, name} -> name
+          end
 
         # We do this to trick Dialyzer to not complain about non-local returns.
         case :erlang.phash2(1, 1) do
           0 ->
-            raise "attempted to call KafkaEx.GenConsumer #{inspect proc} " <>
-              "but no handle_call/3 clause was provided"
-          1 -> {:reply, {:bad_call, msg}, consumer_state}
+            raise "attempted to call KafkaEx.GenConsumer #{inspect(proc)} " <>
+                    "but no handle_call/3 clause was provided"
+
+          1 ->
+            {:reply, {:bad_call, msg}, consumer_state}
         end
       end
 
       def handle_cast(msg, consumer_state) do
         # taken from the GenServer handle_cast implementation
-        proc = case Process.info(self(), :registered_name) do
-          {_, []}   -> self()
-          {_, name} -> name
-        end
+        proc =
+          case Process.info(self(), :registered_name) do
+            {_, []} -> self()
+            {_, name} -> name
+          end
 
         # We do this to trick Dialyzer to not complain about non-local returns.
         case :erlang.phash2(1, 1) do
           0 ->
             raise "attempted to cast KafkaEx.GenConsumer #{inspect(proc)} " <>
-              " but no handle_cast/2 clause was provided"
-          1 -> {:noreply, {:bad_cast, msg}, consumer_state}
+                    " but no handle_cast/2 clause was provided"
+
+          1 ->
+            {:noreply, consumer_state}
         end
       end
 
       def handle_info(msg, consumer_state) do
         # taken from the GenServer handle_info implementation
-        proc = case Process.info(self(), :registered_name) do
-          {_, []} -> self()
-          {_, name} -> name
-        end
+        proc =
+          case Process.info(self(), :registered_name) do
+            {_, []} -> self()
+            {_, name} -> name
+          end
 
         pattern = '~p ~p received unexpected message in handle_info/2: ~p~n'
         :error_logger.error_msg(pattern, [__MODULE__, proc, msg])
         {:noreply, consumer_state}
       end
 
-      defoverridable [init: 2, handle_call: 3, handle_cast: 2, handle_info: 2]
+      defoverridable init: 2, handle_call: 3, handle_cast: 2, handle_info: 2
     end
   end
 


### PR DESCRIPTION
Make dialyzer happy

Fixes #295 

Substantive change:
https://github.com/kafkaex/kafka_ex/compare/fix_dialyzer?expand=1#diff-ea0f264471158a5b4d2686ee693cc8ffR320 

The rest is formatting the __using__ function with `mix format`