### PR TITLE
Allow lazily configuring brokers instead of using a hardcoded config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,9 @@ config :kafka_ex,
   #
   #  * [{"HOST", port}...]
   #  * CSV - `"HOST:PORT,HOST:PORT[,...]"`
+  #  * {mod, fun, args}
+  #  * &arity_zero_fun/0
+  #  * fn -> ... end
   #
   # If you receive :leader_not_available
   # errors when producing messages, it may be necessary to modify "advertised.host.name" in the
@@ -18,6 +21,12 @@ config :kafka_ex,
   #
   # OR:
   # brokers: "localhost:9092,localhost:9093,localhost:9094"
+  #
+  # It may be useful to configure your brokers at runtime, for example if you use
+  # service discovery instead of storing your broker hostnames in a config file.
+  # To do this, you can use `{mod, fun, args}` or a zero-arity function, and `KafkaEx`
+  # will invoke your callback when fetching the `:brokers` configuration.
+  # Note that when using this approach you must return a list of host/port pairs.
   #
   # the default consumer group for worker processes, must be a binary (string)
   #    NOTE if you are on Kafka < 0.8.2 or if you want to disable the use of

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -65,6 +65,12 @@ defmodule KafkaEx.Config do
       end
     end
   end
+  defp brokers({mod, fun, args}) when is_atom(mod) and is_atom(fun) do
+    apply(mod, fun, args)
+  end
+  defp brokers(fun) when is_function(fun, 0) do
+    fun.()
+  end
 
   if Version.match?(System.version, "<1.3.0") do
     defp trim(string), do: String.strip(string)

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -63,4 +63,29 @@ defmodule KafkaEx.ConfigTest do
     Application.put_env(:kafka_ex, :brokers, brokers)
     assert parsed_brokers == Config.brokers()
   end
+
+  test "brokers with lazy configuration using mod, fun, and args" do
+    opts = [port: 8888]
+    brokers = {KafkaEx.ConfigTest, :get_brokers, [opts]}
+    Application.put_env(:kafka_ex, :brokers, brokers)
+
+    assert get_brokers(port: 8888) == Config.brokers()
+  end
+
+  test "brokers with lazy configuration using fun" do
+    brokers =
+      fn ->
+        get_brokers(port: 8888)
+      end
+    Application.put_env(:kafka_ex, :brokers, brokers)
+
+    assert get_brokers(port: 8888) == Config.brokers()
+  end
+
+  def get_brokers(opts) do
+    port = Keyword.get(opts, :port)
+    [
+      {"elixir-lang.org", port}
+    ]
+  end
 end


### PR DESCRIPTION
Our Kafka hosts are not known when we are building a release using Distillery. Instead, we use service discovery to find the hosts and ports to use, and this needs to happen at runtime.

The `:brokers` config entry does not work well with this approach however - we find that we need to start our own Kafka worker processes at runtime and configure them, instead of just using the default application supervision tree.

This PR adds the ability to lazily configure the brokers during application start, instead of at build/release time.