### PR TITLE
modify brokers parsing to allow runtime variables

### DIFF
--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -48,10 +48,9 @@ defmodule KafkaEx.Config do
       |> brokers()
   end
 
-  defp brokers(nil),
-    do: nil
-  defp brokers(list) when is_list(list),
-    do: list
+  defp brokers(nil), do: nil
+  defp brokers({:system, env_variable}), do: brokers(System.get_env(env_variable))
+  defp brokers(list) when is_list(list), do: list
   defp brokers(csv) when is_binary(csv) do
     for line <- String.split(csv, ","), into: [] do
       case line |> trim() |> String.split(":") do

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -7,6 +7,7 @@ defmodule KafkaEx.ConfigTest do
     # reset application env after each test
     env_before = Application.get_all_env(:kafka_ex)
     on_exit fn ->
+      System.delete_env("KAFKAEX_BROKERS")
       # this is basically Application.put_all_env
       for {k, v} <- env_before do
         Application.put_env(:kafka_ex, k, v)
@@ -42,6 +43,19 @@ defmodule KafkaEx.ConfigTest do
     # should also get an error if ssl_options is not a list
     Application.put_env(:kafka_ex, :ssl_options, %{cacertfile: "/ssl/ca-cert"})
     assert_raise(ArgumentError, ~r/invalid ssl_options/, &Config.ssl_options/0)
+  end
+
+  test "brokers supports runtime environmental variables" do
+    System.put_env("KAFKAEX_BROKERS", "example.com:3452,one.example.com:4534,two.example.com:9999")
+    Application.put_env(:kafka_ex, :brokers, {:system, "KAFKAEX_BROKERS"})
+
+    brokers = [
+      {"example.com", 3452},
+      {"one.example.com", 4534},
+      {"two.example.com", 9999}
+    ]
+
+    assert brokers == Config.brokers()
   end
 
   test "brokers with list of hosts" do


### PR DESCRIPTION
Added a parser for {:system, NAME} that allows brokers to be passed in at runtime, using standard elixir pattern for managing this.