### PR TITLE
Add missing opening backquote in doc

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -475,7 +475,7 @@ defmodule KafkaEx do
   Builds options to be used with workers
 
   Merges the given options with defaults from the application env config.
-  Returns p{:error, :invalid_consumer_options}` if the consumer group
+  Returns `{:error, :invalid_consumer_options}` if the consumer group
   configuation is invalid, and `{:ok, merged_options}` otherwise.
 
   Note this happens automatically when using `KafkaEx.create_worker`.


### PR DESCRIPTION
Hello, 

I've just stumbled on this typo while reading the docs. It's a really quick fix, so here it is :) 

Cheers and thanks for the work on KafkaEx 💪