### PR TITLE
Use api versions for new api calls (depends on #319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ The 0.9 client includes functionality that cannot be tested with older
 clusters.
 
 ```
-mix test --include integration --include consumer_group --include server_0_p_10_p_1  --include server_0_p_9_p_0 --include server_0_p_8_p_0
+./all_tests.sh
 ```
 
 ##### Kafka >= 0.9.0

--- a/all_tests.sh
+++ b/all_tests.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+# WARN: when changing something here, there should probably also be a change in scripts/ci_tests.sh
+
+mix test --include integration --include consumer_group --include server_0_p_10_and_later  --include server_0_p_9_p_0 --include server_0_p_8_p_0

--- a/lib/kafka_ex/api_versions.ex
+++ b/lib/kafka_ex/api_versions.ex
@@ -1,0 +1,25 @@
+defmodule KafkaEx.ApiVersions do
+
+  def api_versions_map(api_versions) do
+    api_versions
+      |> Enum.map(fn version -> {version.api_key, version} end)
+      |> Map.new
+  end
+
+  def find_api_version(api_versions_map, message_type, {min_implemented_version, max_implemented_version}) do
+    if api_versions_map == [:unsupported] do
+      {:ok, min_implemented_version}
+    else
+      case KafkaEx.Protocol.api_key(message_type) do
+        nil -> :unknown_message_for_client
+        api_key ->  case api_versions_map[api_key] do
+                      %{min_version: min} when min > max_implemented_version -> :no_version_supported
+                      %{max_version: max} when max < min_implemented_version -> :no_version_supported
+                      %{max_version: max} -> {:ok, Enum.min([max_implemented_version, max])}
+                      _ -> :unknown_message_for_server
+                    end
+      end
+    end
+
+  end
+end

--- a/lib/kafka_ex/api_versions.ex
+++ b/lib/kafka_ex/api_versions.ex
@@ -2,9 +2,11 @@ defmodule KafkaEx.ApiVersions do
 
   def api_versions_map(api_versions) do
     api_versions
-      |> Enum.map(fn version -> {version.api_key, version} end)
-      |> Map.new
+    |> Enum.reduce(%{}, fn version, version_map ->
+        version_map |> Map.put(version.api_key, version)
+      end)
   end
+
 
   def find_api_version(api_versions_map, message_type, {min_implemented_version, max_implemented_version}) do
     if api_versions_map == [:unsupported] do

--- a/lib/kafka_ex/api_versions.ex
+++ b/lib/kafka_ex/api_versions.ex
@@ -20,6 +20,5 @@ defmodule KafkaEx.ApiVersions do
                     end
       end
     end
-
   end
 end

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -81,7 +81,7 @@ defmodule KafkaEx.Config do
   defp server("0.8.0"), do: KafkaEx.Server0P8P0
   defp server("0.8.2"), do: KafkaEx.Server0P8P2
   defp server("0.9.0"), do: KafkaEx.Server0P9P0
-  defp server(_), do: KafkaEx.Server0P10P1
+  defp server(_), do: KafkaEx.Server0P10AndLater
 
 
   # ssl_options should be an empty list by default if use_ssl is false

--- a/lib/kafka_ex/protocol.ex
+++ b/lib/kafka_ex/protocol.ex
@@ -1,81 +1,33 @@
 defmodule KafkaEx.Protocol do
   @moduledoc false
 
-  @produce_request           0
-  @fetch_request             1
-  @offset_request            2
-  @metadata_request          3
-  @offset_commit_request     8
-  @offset_fetch_request      9
-  @consumer_metadata_request 10
-  @join_group_request        11
-  @heartbeat_request         12
-  @leave_group_request       13
-  @sync_group_request        14
-  @api_versions_request      18
-  @create_topics_request     19
+  @message_type_to_api_key %{
+    produce:           0,
+    fetch:             1,
+    offset:            2,
+    metadata:          3,
+    offset_commit:     8,
+    offset_fetch:      9,
+    consumer_metadata: 10,
+    join_group:        11,
+    heartbeat:         12,
+    leave_group:       13,
+    sync_group:        14,
+    api_versions:      18,
+    create_topics:     19,
+  }
+
   # DescribeConfigs	32
   # AlterConfigs	33 Valid resource types are "Topic" and "Broker".
 
-  @api_version  0
+  @default_api_version  0
 
-  defp api_key(:produce) do
-    @produce_request
+  @spec api_key(atom) :: integer | nil
+  def api_key(type) do
+    Map.get(@message_type_to_api_key, type, nil)
   end
 
-  defp api_key(:fetch) do
-    @fetch_request
-  end
-
-  defp api_key(:offset) do
-    @offset_request
-  end
-
-  defp api_key(:metadata) do
-    @metadata_request
-  end
-
-  defp api_key(:offset_commit) do
-    @offset_commit_request
-  end
-
-  defp api_key(:offset_fetch) do
-    @offset_fetch_request
-  end
-
-  defp api_key(:consumer_metadata) do
-    @consumer_metadata_request
-  end
-
-  defp api_key(:join_group) do
-    @join_group_request
-  end
-
-  defp api_key(:heartbeat) do
-    @heartbeat_request
-  end
-
-  defp api_key(:leave_group) do
-    @leave_group_request
-  end
-
-  defp api_key(:sync_group) do
-    @sync_group_request
-  end
-
-  defp api_key(:api_versions) do
-    @api_versions_request
-  end
-
-  defp api_key(:create_topics) do
-    @create_topics_request
-  end
-
-  def create_request(type, correlation_id, client_id) do
-    create_request(type, correlation_id, client_id, @api_version)
-  end
-
-  def create_request(type, correlation_id, client_id, api_version) do
+  def create_request(type, correlation_id, client_id, api_version \\ @default_api_version) do
     << api_key(type) :: 16, api_version :: 16, correlation_id :: 32,
        byte_size(client_id) :: 16, client_id :: binary >>
   end

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -101,6 +101,11 @@ defmodule KafkaEx.Protocol.Metadata do
   def api_version(api_versions) do
     case KafkaEx.ApiVersions.find_api_version(api_versions, :metadata, @supported_versions_range) do
       {:ok, version} -> version
+      # those three should never happen since :metadata is part of the protocol since the beginning.
+      # they are left here as this will server as reference implementation
+      # :unknown_message_for_server ->
+      # :unknown_message_for_client ->
+      # :no_version_supported ->
       _ -> @default_api_version
     end
   end

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -2,6 +2,7 @@ defmodule KafkaEx.Protocol.Metadata do
   alias KafkaEx.Protocol
   import KafkaEx.Protocol.Common
 
+  @supported_versions_range {0, 1}
   @default_api_version 0
 
   @moduledoc """
@@ -97,7 +98,18 @@ defmodule KafkaEx.Protocol.Metadata do
     }
   end
 
+  def api_version(api_versions) do
+    case KafkaEx.ApiVersions.find_api_version(api_versions, :metadata, @supported_versions_range) do
+      {:ok, version} -> version
+      _ -> @default_api_version
+    end
+  end
+
   def create_request(correlation_id, client_id, topics, api_version \\ @default_api_version)
+
+  def create_request(correlation_id, client_id, nil, api_version) do
+    create_request(correlation_id, client_id, "", api_version)
+  end
 
   def create_request(correlation_id, client_id, "", api_version) do
     topic_count = if 0 == api_version, do: 0, else: -1

--- a/lib/kafka_ex/server_0_p_10_and_later.ex
+++ b/lib/kafka_ex/server_0_p_10_and_later.ex
@@ -125,8 +125,6 @@ defmodule KafkaEx.Server0P10AndLater do
       _ -> raise "CreateTopic is not supported in this version of Kafka, or the versions supported by the client do not match the ones supported by the server."
     end
 
-    IO.puts "API version for create_topics: #{api_version}"
-
     create_topics_request = %CreateTopics.Request{
       create_topic_requests: requests,
       timeout: network_timeout

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -53,7 +53,16 @@ defmodule KafkaEx.Server0P8P2 do
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port)} end)
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, config_sync_timeout())
-    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name}
+    state = %State{
+      metadata: metadata,
+      brokers: brokers,
+      correlation_id: correlation_id,
+      consumer_group: consumer_group,
+      metadata_update_interval: metadata_update_interval,
+      consumer_group_update_interval: consumer_group_update_interval,
+      worker_name: name,
+      api_versions: [:unsupported]
+    }
     # Get the initial "real" broker list and start a regular refresh cycle.
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -69,7 +69,18 @@ defmodule KafkaEx.Server0P9P0 do
 
     brokers = Enum.map(uris, fn({host, port}) -> %Broker{host: host, port: port, socket: NetworkClient.create_socket(host, port, ssl_options, use_ssl)} end)
     {correlation_id, metadata} = retrieve_metadata(brokers, 0, config_sync_timeout())
-    state = %State{metadata: metadata, brokers: brokers, correlation_id: correlation_id, consumer_group: consumer_group, metadata_update_interval: metadata_update_interval, consumer_group_update_interval: consumer_group_update_interval, worker_name: name, ssl_options: ssl_options, use_ssl: use_ssl}
+    state = %State{
+      metadata: metadata,
+      brokers: brokers,
+      correlation_id: correlation_id,
+      consumer_group: consumer_group,
+      metadata_update_interval: metadata_update_interval,
+      consumer_group_update_interval: consumer_group_update_interval,
+      worker_name: name,
+      ssl_options: ssl_options,
+      use_ssl: use_ssl,
+      api_versions: [:unsupported]
+    }
     # Get the initial "real" broker list and start a regular refresh cycle.
     state = update_metadata(state)
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -16,7 +16,7 @@ else
   TEST_COMMAND=test
 fi
 
-INCLUDED_TESTS="--include integration --include consumer_group --include server_0_p_10_p_1  --include server_0_p_9_p_0 --include server_0_p_8_p_0"
+INCLUDED_TESTS="--include integration --include consumer_group --include server_0_p_10_and_later  --include server_0_p_9_p_0 --include server_0_p_8_p_0"
 
 mix "$TEST_COMMAND" $INCLUDED_TESTS
 

--- a/test/integration/server0_p_10_and_later_test.exs
+++ b/test/integration/server0_p_10_and_later_test.exs
@@ -1,0 +1,43 @@
+defmodule KafkaEx.Server0P10P1AndLater.Test do
+  use ExUnit.Case
+  import TestHelper
+
+  @moduletag :server_0_p_10_and_later
+
+  @tag :create_topic
+  test "can create a topic" do
+    name = "create_topic_#{:rand.uniform(2000000)}"
+
+    request = %{
+      topic: name,
+      num_partitions: 10,
+      replication_factor: 1,
+      replica_assignment: [],
+      config_entries: [
+        %{config_name: "cleanup.policy", config_value: "compact"},
+        %{config_name: "min.compaction.lag.ms", config_value: "0"}
+      ]}
+
+    resp = KafkaEx.create_topics([request], timeout: 2000)
+    assert {:no_error, name} == parse_create_topic_resp(resp)
+
+    resp = KafkaEx.create_topics([request], timeout: 2000)
+    assert {:topic_already_exists, name} == parse_create_topic_resp(resp)
+
+    wait_for(fn ->
+      topics = KafkaEx.metadata.topic_metadatas |> Enum.map(&(&1.topic))
+      assert Enum.member?(topics, name)
+    end)
+  end
+
+  def parse_create_topic_resp(response) do
+    %KafkaEx.Protocol.CreateTopics.Response{
+      topic_errors: [
+        %KafkaEx.Protocol.CreateTopics.TopicError{
+          error_code: error_code,
+          topic_name: topic_name
+        }
+      ]} = response
+    {error_code, topic_name}
+  end
+end

--- a/test/integration/server0_p_10_p_1_test.exs
+++ b/test/integration/server0_p_10_p_1_test.exs
@@ -1,46 +1,10 @@
 defmodule KafkaEx.Server0P10P1.Test do
   use ExUnit.Case
-  import TestHelper
 
+  @moduletag :server_0_p_10_and_later
   @moduletag :server_0_p_10_p_1
 
-  @tag :create_topic
-  test "can create a topic" do
-    name = "create_topic_#{:rand.uniform(2000000)}"
-
-    request = %{
-      topic: name,
-      num_partitions: 10,
-      replication_factor: 1,
-      replica_assignment: [],
-      config_entries: [
-        %{config_name: "cleanup.policy", config_value: "compact"},
-        %{config_name: "min.compaction.lag.ms", config_value: "0"}
-      ]}
-
-    resp = KafkaEx.create_topics([request], timeout: 2000)
-    assert {:no_error, name} == parse_create_topic_resp(resp)
-
-    resp = KafkaEx.create_topics([request], timeout: 2000)
-    assert {:topic_already_exists, name} == parse_create_topic_resp(resp)
-
-    wait_for(fn ->
-      topics = KafkaEx.metadata.topic_metadatas |> Enum.map(&(&1.topic))
-      assert Enum.member?(topics, name)
-    end)
-  end
-
-  def parse_create_topic_resp(response) do
-    %KafkaEx.Protocol.CreateTopics.Response{
-      topic_errors: [
-        %KafkaEx.Protocol.CreateTopics.TopicError{
-          error_code: error_code,
-          topic_name: topic_name
-        }
-      ]} = response
-    {error_code, topic_name}
-  end
-
+  # specific to this server version because we want to test that the api_versions list is exact
   @tag :api_version
   test "can retrieve api versions" do
 

--- a/test/kafka_ex/api_versions_test.exs
+++ b/test/kafka_ex/api_versions_test.exs
@@ -1,0 +1,42 @@
+defmodule ApiVersionsTest do
+  use ExUnit.Case
+  @api_versions %{
+    0 => %KafkaEx.Protocol.ApiVersions.ApiVersion {
+      api_key: 0,
+      min_version: 0,
+      max_version: 3,
+    },
+    1 => %KafkaEx.Protocol.ApiVersions.ApiVersion {
+      api_key: 1,
+      min_version: 7,
+      max_version: 8,
+    },
+    3 => %KafkaEx.Protocol.ApiVersions.ApiVersion {
+      api_key: 3,
+      min_version: 2,
+      max_version: 4,
+    }
+  }
+
+  test "can correctly determine the adequate api version when api versions is not support" do
+    assert {:ok, 1} == KafkaEx.ApiVersions.find_api_version([:unsupported], :metadata, {1, 3})
+  end
+
+  test "KafkaEx.ApiVersions can correctly determine the adequate api version when a match exists" do
+    assert {:ok, 3} == KafkaEx.ApiVersions.find_api_version(@api_versions, :metadata, {1, 3})
+    assert {:ok, 0} == KafkaEx.ApiVersions.find_api_version(@api_versions, :produce, {0, 0})
+  end
+
+  test "KafkaEx.ApiVersions replies an error when there's no version match" do
+    assert :no_version_supported == KafkaEx.ApiVersions.find_api_version(@api_versions, :fetch, {0, 6})
+  end
+
+  test "KafkaEx.ApiVersions replies an error when the api_key is unknown to the server" do
+    assert :unknown_message_for_server == KafkaEx.ApiVersions.find_api_version(@api_versions, :create_topics, {0, 1})
+  end
+
+  test "KafkaEx.ApiVersions replies an error when the api_key is unknown to the client" do
+    assert :unknown_message_for_client == KafkaEx.ApiVersions.find_api_version(@api_versions, :this_does_not_exist, {0, 1})
+  end
+end
+


### PR DESCRIPTION
See #318.

This MR replaces `server_0_p_10_p_1.ex` by `server_0_10_or_later.ex` and uses api versions to handle the API calls implemented in it.

This would mean that from here on out, all messages of the API can be implemented without assuming the version of the server. All that is needed is to refer to the `api_versions` to check which is the greatest version of the message supported both by the server and the client.

Follow-up to https://github.com/kafkaex/kafka_ex/pull/319