### PR TITLE
Fix KafkaEx.Protocol.Produce.Request moduledoc "require_acks" typo

### DIFF
--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -9,7 +9,7 @@ defmodule KafkaEx.Protocol.Produce do
 
   defmodule Request do
     @moduledoc """
-    - require_acks: indicates how many acknowledgements the servers should
+    - required_acks: indicates how many acknowledgements the servers should
     receive before responding to the request. If it is 0 the server will not
     send any response (this is the only case where the server will not reply
     to a request). If it is 1, the server will wait the data is written to the


### PR DESCRIPTION
Looks like the actual parameter name the code takes is `required_acks`, so this fixes that typo.