### PR TITLE
Support DeleteTopics message (API#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ clusters.
 ./all_tests.sh
 ```
 
-##### Kafka >= 0.9.0
+##### Kafka = 0.9.0
 
 The 0.9 client includes functionality that cannot be tested with older
 clusters.

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -24,6 +24,8 @@ defmodule KafkaEx do
   alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
   alias KafkaEx.Protocol.CreateTopics.Request, as: CreateTopicsRequest
   alias KafkaEx.Protocol.CreateTopics.Response, as: CreateTopicsResponse
+  alias KafkaEx.Protocol.DeleteTopics.Request, as: DeleteTopicsRequest
+  alias KafkaEx.Protocol.DeleteTopics.Response, as: DeleteTopicsResponse
   alias KafkaEx.Protocol.ApiVersions.Response, as: ApiVersionsResponse
   alias KafkaEx.Server
   alias KafkaEx.Stream
@@ -616,6 +618,17 @@ defmodule KafkaEx do
     worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
     timeout = Keyword.get(opts, :timeout, 4000)
     Server.call(worker_name, {:create_topics, requests, timeout})
+  end
+
+  @doc """
+  Delete topics. Must provide a list of topic names.
+  """
+  @spec delete_topics([DeleteTopicsRequest.t()], Keyword.t()) ::
+          DeleteTopicsResponse.t()
+  def delete_topics(requests, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
+    timeout = Keyword.get(opts, :timeout, 4000)
+    Server.call(worker_name, {:delete_topics, requests, timeout})
   end
 
   # OTP API

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -623,12 +623,12 @@ defmodule KafkaEx do
   @doc """
   Delete topics. Must provide a list of topic names.
   """
-  @spec delete_topics([DeleteTopicsRequest.t()], Keyword.t()) ::
+  @spec delete_topics([String.t()], Keyword.t()) ::
           DeleteTopicsResponse.t()
-  def delete_topics(requests, opts \\ []) do
+  def delete_topics(topics, opts \\ []) do
     worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
     timeout = Keyword.get(opts, :timeout)
-    Server.call(worker_name, {:delete_topics, requests, timeout})
+    Server.call(worker_name, {:delete_topics, topics, timeout})
   end
 
   # OTP API

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -24,7 +24,6 @@ defmodule KafkaEx do
   alias KafkaEx.Protocol.SyncGroup.Response, as: SyncGroupResponse
   alias KafkaEx.Protocol.CreateTopics.Request, as: CreateTopicsRequest
   alias KafkaEx.Protocol.CreateTopics.Response, as: CreateTopicsResponse
-  alias KafkaEx.Protocol.DeleteTopics.Request, as: DeleteTopicsRequest
   alias KafkaEx.Protocol.DeleteTopics.Response, as: DeleteTopicsResponse
   alias KafkaEx.Protocol.ApiVersions.Response, as: ApiVersionsResponse
   alias KafkaEx.Server

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -616,7 +616,7 @@ defmodule KafkaEx do
           CreateTopicsResponse.t()
   def create_topics(requests, opts \\ []) do
     worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
-    timeout = Keyword.get(opts, :timeout, 4000)
+    timeout = Keyword.get(opts, :timeout)
     Server.call(worker_name, {:create_topics, requests, timeout})
   end
 
@@ -627,7 +627,7 @@ defmodule KafkaEx do
           DeleteTopicsResponse.t()
   def delete_topics(requests, opts \\ []) do
     worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
-    timeout = Keyword.get(opts, :timeout, 4000)
+    timeout = Keyword.get(opts, :timeout)
     Server.call(worker_name, {:delete_topics, requests, timeout})
   end
 

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -250,9 +250,12 @@ defmodule KafkaEx.GenConsumer do
   Any other return value will cause the `start_link/5` to return `{:error,
   error}` and the process to exit.
   """
-  @callback init(topic :: binary, partition :: non_neg_integer, extra_args :: map()) ::
-    {:ok, state :: term}
-
+  @callback init(
+              topic :: binary,
+              partition :: non_neg_integer,
+              extra_args :: map()
+            ) ::
+              {:ok, state :: term}
 
   @doc """
   Invoked for each message set consumed from a Kafka topic partition.
@@ -367,7 +370,11 @@ defmodule KafkaEx.GenConsumer do
         {:noreply, consumer_state}
       end
 
-      defoverridable init: 2, init: 3, handle_call: 3, handle_cast: 2, handle_info: 2
+      defoverridable init: 2,
+                     init: 3,
+                     handle_call: 3,
+                     handle_cast: 2,
+                     handle_info: 2
     end
   end
 
@@ -518,13 +525,15 @@ defmodule KafkaEx.GenConsumer do
         Application.get_env(:kafka_ex, :auto_offset_reset, @auto_offset_reset)
       )
 
-    extra_consumer_args = 
+    extra_consumer_args =
       Keyword.get(
         opts,
         :extra_consumer_args
       )
 
-    {:ok, consumer_state} = consumer_module.init(topic, partition, extra_consumer_args)
+    {:ok, consumer_state} =
+      consumer_module.init(topic, partition, extra_consumer_args)
+
     worker_opts = Keyword.take(opts, [:uris])
 
     {:ok, worker_name} =

--- a/lib/kafka_ex/protocol.ex
+++ b/lib/kafka_ex/protocol.ex
@@ -14,7 +14,8 @@ defmodule KafkaEx.Protocol do
     leave_group: 13,
     sync_group: 14,
     api_versions: 18,
-    create_topics: 19
+    create_topics: 19,
+    delete_topics: 20
   }
 
   # DescribeConfigs	32

--- a/lib/kafka_ex/protocol/common.ex
+++ b/lib/kafka_ex/protocol/common.ex
@@ -43,4 +43,28 @@ defmodule KafkaEx.Protocol.Common do
     {items, data_after_array} = read_array(num_items - 1, rest, read_one)
     {[item | items], data_after_array}
   end
+
+  @spec encode_nullable_string(String.t()) :: binary
+  def encode_nullable_string(text) do
+    case text do
+      nil -> <<-1::16-signed>>
+      _ -> encode_string(text)
+    end
+  end
+
+  @spec encode_string(String.t()) :: binary
+  def encode_string(text) do
+    <<byte_size(text)::16-signed, text::binary>>
+  end
+
+  def map_encode(elems, function) do
+    if nil == elems or [] == elems do
+      <<0::32-signed>>
+    else
+      <<length(elems)::32-signed>> <>
+        (elems
+         |> Enum.map(function)
+         |> Enum.reduce(&(&1 <> &2)))
+    end
+  end
 end

--- a/lib/kafka_ex/protocol/create_topics.ex
+++ b/lib/kafka_ex/protocol/create_topics.ex
@@ -1,5 +1,6 @@
 defmodule KafkaEx.Protocol.CreateTopics do
   alias KafkaEx.Protocol
+  import KafkaEx.Protocol.Common
   @supported_versions_range {0, 0}
 
   @moduledoc """
@@ -124,30 +125,6 @@ defmodule KafkaEx.Protocol.CreateTopics do
   defp encode_config_entry(config_entry) do
     encode_string(config_entry.config_name) <>
       encode_nullable_string(config_entry.config_value)
-  end
-
-  @spec encode_nullable_string(String.t()) :: binary
-  defp encode_nullable_string(text) do
-    case text do
-      nil -> <<-1::16-signed>>
-      _ -> encode_string(text)
-    end
-  end
-
-  @spec encode_string(String.t()) :: binary
-  defp encode_string(text) do
-    <<byte_size(text)::16-signed, text::binary>>
-  end
-
-  defp map_encode(elems, function) do
-    if nil == elems or [] == elems do
-      <<0::32-signed>>
-    else
-      <<length(elems)::32-signed>> <>
-        (elems
-         |> Enum.map(function)
-         |> Enum.reduce(&(&1 <> &2)))
-    end
   end
 
   @spec parse_response(binary, integer) :: [] | Response.t()

--- a/lib/kafka_ex/protocol/delete_topics.ex
+++ b/lib/kafka_ex/protocol/delete_topics.ex
@@ -1,0 +1,93 @@
+defmodule KafkaEx.Protocol.DeleteTopics do
+  alias KafkaEx.Protocol
+  import KafkaEx.Protocol.Common
+  @supported_versions_range {0, 0}
+
+  @moduledoc """
+  Implementation of the Kafka DeleteTopics request and response APIs
+
+  See: https://kafka.apache.org/protocol.html#The_Messages_DeleteTopics
+  """
+
+  # DeleteTopics Request (Version: 0) => [topics] timeout
+  #   topics => STRING
+  #   timeout => INT32
+
+  # DeleteTopics Response (Version: 0) => [topic_error_codes]
+  #   topic_error_codes => topic error_code
+  #     topic => STRING
+  #     error_code => INT16
+
+  defmodule Request do
+    @moduledoc false
+    defstruct topics: nil, timeout: nil
+    @type t :: %Request{topics: [String.t()], timeout: integer}
+  end
+
+  defmodule TopicError do
+    @moduledoc false
+    defstruct topic_name: nil, error_code: nil
+    @type t :: %TopicError{topic_name: binary, error_code: atom}
+  end
+
+  defmodule Response do
+    @moduledoc false
+    defstruct topic_errors: nil
+    @type t :: %Response{topic_errors: [TopicError]}
+  end
+
+  def api_version(api_versions) do
+    KafkaEx.ApiVersions.find_api_version(
+      api_versions,
+      :delete_topics,
+      @supported_versions_range
+    )
+  end
+
+  @spec create_request(integer, binary, Request.t(), integer) :: binary
+  def create_request(
+        correlation_id,
+        client_id,
+        delete_topics_request,
+        api_version
+      )
+
+  def create_request(correlation_id, client_id, delete_topics_request, 0) do
+    Protocol.create_request(:delete_topics, correlation_id, client_id) <>
+      encode_topics(delete_topics_request.topics) <>
+      <<delete_topics_request.timeout::32-signed>>
+  end
+
+  @spec encode_topics([String.t()]) :: binary
+  defp encode_topics(topics) do
+    topics |> map_encode(&encode_string/1)
+  end
+
+  @spec parse_response(binary, integer) :: [] | Response.t()
+  def parse_response(
+        <<_correlation_id::32-signed, topic_errors_count::32-signed,
+          topic_errors::binary>>,
+        0
+      ) do
+    %Response{
+      topic_errors: parse_topic_errors(topic_errors_count, topic_errors)
+    }
+  end
+
+  @spec parse_topic_errors(integer, binary) :: [TopicError.t()]
+  defp parse_topic_errors(0, _), do: []
+
+  defp parse_topic_errors(
+         topic_errors_count,
+         <<topic_name_size::16-signed, topic_name::size(topic_name_size)-binary,
+           error_code::16-signed, rest::binary>>
+       ) do
+    [
+      %TopicError{
+        topic_name: topic_name,
+        error_code: Protocol.error(error_code)
+      }
+      | parse_topic_errors(topic_errors_count - 1, rest)
+    ]
+  end
+end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -839,8 +839,27 @@ defmodule KafkaEx.Server do
                 config_sync_timeout()
               )
               |> case do
-                {:error, reason} -> {:error, reason}
-                response -> module.parse_response(response)
+                {:error, reason} ->
+                  {:error, reason}
+
+                response ->
+                  try do
+                    module.parse_response(response)
+                  rescue
+                    _ ->
+                      Logger.error(
+                        "Failed to parse a response from the server: #{
+                          inspect(response)
+                        }"
+                      )
+
+                      Kernel.reraise(
+                        "Parse error during #{inspect(module)}.parse_response. Couldn't parse: #{
+                          inspect(response)
+                        }",
+                        __STACKTRACE__
+                      )
+                  end
               end
 
             state_out = State.increment_correlation_id(updated_state)

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -18,6 +18,7 @@ defmodule KafkaEx.Server do
   alias KafkaEx.Protocol.Produce.Request, as: ProduceRequest
   alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
   alias KafkaEx.Protocol.CreateTopics.Request, as: CreateTopicsRequest
+  alias KafkaEx.Protocol.DeleteTopics.Request, as: DeleteTopicsRequest
   alias KafkaEx.Socket
 
   defmodule State do
@@ -212,6 +213,12 @@ defmodule KafkaEx.Server do
               state :: State.t()
             ) :: {:reply, reply, new_state}
             when reply: term, new_state: term
+  @callback kafka_delete_topics(
+              [DeleteTopicsRequest.t()],
+              network_timeout :: integer,
+              state :: State.t()
+            ) :: {:reply, reply, new_state}
+            when reply: term, new_state: term
   @callback kafka_api_versions(state :: State.t()) :: {:reply, reply, new_state}
             when reply: term, new_state: term
   @callback kafka_server_update_metadata(state :: State.t()) ::
@@ -332,6 +339,10 @@ defmodule KafkaEx.Server do
 
       def handle_call({:create_topics, requests, network_timeout}, _from, state) do
         kafka_create_topics(requests, network_timeout, state)
+      end
+
+      def handle_call({:delete_topics, topics, network_timeout}, _from, state) do
+        kafka_delete_topics(topics, network_timeout, state)
       end
 
       def handle_call({:api_versions}, _from, state) do
@@ -857,7 +868,7 @@ defmodule KafkaEx.Server do
                         "Parse error during #{inspect(module)}.parse_response. Couldn't parse: #{
                           inspect(response)
                         }",
-                        __STACKTRACE__
+                        System.stacktrace()
                       )
                   end
               end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -214,7 +214,7 @@ defmodule KafkaEx.Server do
             ) :: {:reply, reply, new_state}
             when reply: term, new_state: term
   @callback kafka_delete_topics(
-              [DeleteTopicsRequest.t()],
+              [String.t()],
               network_timeout :: integer,
               state :: State.t()
             ) :: {:reply, reply, new_state}

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -18,7 +18,6 @@ defmodule KafkaEx.Server do
   alias KafkaEx.Protocol.Produce.Request, as: ProduceRequest
   alias KafkaEx.Protocol.SyncGroup.Request, as: SyncGroupRequest
   alias KafkaEx.Protocol.CreateTopics.Request, as: CreateTopicsRequest
-  alias KafkaEx.Protocol.DeleteTopics.Request, as: DeleteTopicsRequest
   alias KafkaEx.Socket
 
   defmodule State do

--- a/lib/kafka_ex/server_0_p_10_and_later.ex
+++ b/lib/kafka_ex/server_0_p_10_and_later.ex
@@ -196,7 +196,7 @@ defmodule KafkaEx.Server0P10AndLater do
         @client_id,
         %DeleteTopics.Request{
           topics: topics,
-          timeout: network_timeout
+          timeout: config_sync_timeout(network_timeout)
         },
         api_version
       )
@@ -239,7 +239,7 @@ defmodule KafkaEx.Server0P10AndLater do
 
     create_topics_request = %CreateTopics.Request{
       create_topic_requests: requests,
-      timeout: network_timeout
+      timeout: config_sync_timeout(network_timeout)
     }
 
     main_request =

--- a/lib/kafka_ex/server_0_p_10_and_later.ex
+++ b/lib/kafka_ex/server_0_p_10_and_later.ex
@@ -4,6 +4,7 @@ defmodule KafkaEx.Server0P10AndLater do
   """
   use KafkaEx.Server
   alias KafkaEx.Protocol.CreateTopics
+  alias KafkaEx.Protocol.DeleteTopics
   alias KafkaEx.Protocol.ApiVersions
   alias KafkaEx.Server0P8P2
   alias KafkaEx.Server0P9P0
@@ -177,6 +178,53 @@ defmodule KafkaEx.Server0P10AndLater do
       |> ApiVersions.parse_response()
 
     {:reply, response, %{state | correlation_id: state.correlation_id + 1}}
+  end
+
+  def kafka_delete_topics(topics, network_timeout, state) do
+    api_version =
+      case DeleteTopics.api_version(state.api_versions) do
+        {:ok, api_version} ->
+          api_version
+
+        _ ->
+          raise "DeleteTopic is not supported in this version of Kafka, or the versions supported by the client do not match the ones supported by the server."
+      end
+
+    main_request =
+      DeleteTopics.create_request(
+        state.correlation_id,
+        @client_id,
+        %DeleteTopics.Request{
+          topics: topics,
+          timeout: network_timeout
+        },
+        api_version
+      )
+
+    broker = state.brokers |> Enum.find(& &1.is_controller)
+
+    {response, state} =
+      case broker do
+        nil ->
+          Logger.log(:error, "Coordinator for topic is not available")
+          {:topic_not_found, state}
+
+        _ ->
+          response =
+            broker
+            |> NetworkClient.send_sync_request(
+              main_request,
+              config_sync_timeout()
+            )
+            |> case do
+              {:error, reason} -> {:error, reason}
+              response -> DeleteTopics.parse_response(response, api_version)
+            end
+
+          {response, %{state | correlation_id: state.correlation_id + 1}}
+      end
+
+    {:reply, response, state}
   end
 
   def kafka_create_topics(requests, network_timeout, state) do

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -15,6 +15,7 @@ defmodule KafkaEx.Server0P8P0 do
     {:nowarn_function, kafka_server_offset_commit: 2},
     {:nowarn_function, kafka_server_offset_fetch: 2},
     {:nowarn_function, kafka_create_topics: 3},
+    {:nowarn_function, kafka_delete_topics: 3},
     {:nowarn_function, kafka_api_versions: 1}
   ]
 
@@ -93,6 +94,9 @@ defmodule KafkaEx.Server0P8P0 do
 
   def kafka_create_topics(_, _, _state),
     do: raise("CreateTopic is not supported in 0.8.0 version of kafka")
+
+  def kafka_delete_topics(_, _, _state),
+    do: raise("DeleteTopic is not supported in 0.8.0 version of kafka")
 
   defp fetch(request, state) do
     case network_request(request, Fetch, state) do

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -10,6 +10,7 @@ defmodule KafkaEx.Server0P8P2 do
     {:nowarn_function, kafka_server_join_group: 3},
     {:nowarn_function, kafka_server_leave_group: 3},
     {:nowarn_function, kafka_create_topics: 3},
+    {:nowarn_function, kafka_delete_topics: 3},
     {:nowarn_function, kafka_api_versions: 1}
   ]
 
@@ -198,6 +199,9 @@ defmodule KafkaEx.Server0P8P2 do
 
   def kafka_create_topics(_, _, _state),
     do: raise("CreateTopic is not supported in 0.8.2 version of kafka")
+
+  def kafka_delete_topics(_, _, _state),
+    do: raise("DeleteTopic is not supported in 0.8.2 version of kafka")
 
   defp update_consumer_metadata(state),
     do: update_consumer_metadata(state, @retry_count, 0)

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -7,6 +7,7 @@ defmodule KafkaEx.Server0P9P0 do
   # these functions aren't implemented for 0.9.0
   @dialyzer [
     {:nowarn_function, kafka_create_topics: 3},
+    {:nowarn_function, kafka_delete_topics: 3},
     {:nowarn_function, kafka_api_versions: 1}
   ]
 
@@ -53,6 +54,9 @@ defmodule KafkaEx.Server0P9P0 do
   defdelegate kafka_api_versions(state), to: Server0P8P2
 
   defdelegate kafka_create_topics(requests, network_timeout, state),
+    to: Server0P8P2
+
+  defdelegate kafka_delete_topics(requests, network_timeout, state),
     to: Server0P8P2
 
   def kafka_server_init([args]) do

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -51,13 +51,15 @@ defmodule KafkaEx.Server0P9P0 do
 
   defdelegate kafka_server_consumer_group_metadata(state), to: Server0P8P2
   defdelegate kafka_server_update_consumer_metadata(state), to: Server0P8P2
-  defdelegate kafka_api_versions(state), to: Server0P8P2
 
-  defdelegate kafka_create_topics(requests, network_timeout, state),
-    to: Server0P8P2
+  def kafka_api_versions(_state),
+    do: raise("ApiVersions is not supported in 0.9.0 version of kafka")
 
-  defdelegate kafka_delete_topics(requests, network_timeout, state),
-    to: Server0P8P2
+  def kafka_create_topics(_, _, _state),
+    do: raise("CreateTopic is not supported in 0.9.0 version of kafka")
+
+  def kafka_delete_topics(_, _, _state),
+    do: raise("DeleteTopic is not supported in 0.9.0 version of kafka")
 
   def kafka_server_init([args]) do
     kafka_server_init([args, self()])

--- a/server.properties
+++ b/server.properties
@@ -120,3 +120,6 @@ zookeeper.connect=localhost:2181
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=6000
+
+# Allow deletion of topics
+delete.topic.enable=true

--- a/test/integration/server0_p_10_and_later_test.exs
+++ b/test/integration/server0_p_10_and_later_test.exs
@@ -8,30 +8,46 @@ defmodule KafkaEx.Server0P10P1AndLater.Test do
   test "can create a topic" do
     name = "create_topic_#{:rand.uniform(2_000_000)}"
 
-    request = %{
-      topic: name,
-      num_partitions: 10,
-      replication_factor: 1,
-      replica_assignment: [],
-      config_entries: [
-        %{config_name: "cleanup.policy", config_value: "compact"},
-        %{config_name: "min.compaction.lag.ms", config_value: "0"}
-      ]
-    }
+    config = [
+      %{config_name: "cleanup.policy", config_value: "compact"},
+      %{config_name: "min.compaction.lag.ms", config_value: "0"}
+    ]
 
-    resp = KafkaEx.create_topics([request], timeout: 2000)
+    resp = create_topic(name, config)
     assert {:no_error, name} == parse_create_topic_resp(resp)
 
-    resp = KafkaEx.create_topics([request], timeout: 2000)
+    resp = create_topic(name, config)
     assert {:topic_already_exists, name} == parse_create_topic_resp(resp)
 
     wait_for(fn ->
-      topics = KafkaEx.metadata().topic_metadatas |> Enum.map(& &1.topic)
-      assert Enum.member?(topics, name)
+      Enum.member?(existing_topics(), name)
     end)
+
+    assert Enum.member?(existing_topics(), name)
   end
 
-  def parse_create_topic_resp(response) do
+  @tag :delete_topic
+  test "can delete a topic" do
+    name = "delete_topic_#{:rand.uniform(2_000_000)}"
+
+    resp = create_topic(name, [])
+    assert {:no_error, name} == parse_create_topic_resp(resp)
+
+    wait_for(fn ->
+      Enum.member?(existing_topics(), name)
+    end)
+
+    resp = KafkaEx.delete_topics([name], timeout: 5_000)
+    assert {:no_error, name} = parse_delete_topic_resp(resp)
+
+    wait_for(fn ->
+      not Enum.member?(existing_topics(), name)
+    end)
+
+    assert not Enum.member?(existing_topics(), name)
+  end
+
+  defp parse_create_topic_resp(response) do
     %KafkaEx.Protocol.CreateTopics.Response{
       topic_errors: [
         %KafkaEx.Protocol.CreateTopics.TopicError{
@@ -42,5 +58,37 @@ defmodule KafkaEx.Server0P10P1AndLater.Test do
     } = response
 
     {error_code, topic_name}
+  end
+
+  defp parse_delete_topic_resp(response) do
+    %KafkaEx.Protocol.DeleteTopics.Response{
+      topic_errors: [
+        %KafkaEx.Protocol.DeleteTopics.TopicError{
+          error_code: error_code,
+          topic_name: topic_name
+        }
+      ]
+    } = response
+
+    {error_code, topic_name}
+  end
+
+  defp create_topic(name, config) do
+    KafkaEx.create_topics(
+      [
+        %{
+          topic: name,
+          num_partitions: 10,
+          replication_factor: 1,
+          replica_assignment: [],
+          config_entries: config
+        }
+      ],
+      timeout: 5_000
+    )
+  end
+
+  defp existing_topics() do
+    KafkaEx.metadata().topic_metadatas |> Enum.map(& &1.topic)
   end
 end

--- a/test/integration/server0_p_10_p_1_test.exs
+++ b/test/integration/server0_p_10_p_1_test.exs
@@ -2,9 +2,10 @@ defmodule KafkaEx.Server0P10P1.Test do
   use ExUnit.Case
 
   @moduletag :server_0_p_10_and_later
-  @moduletag :server_0_p_10_p_1
 
   # specific to this server version because we want to test that the api_versions list is exact
+  @moduletag :server_0_p_10_p_1
+
   @tag :api_version
   test "can retrieve api versions" do
     # api_key, max_version, min_version

--- a/test/protocol/join_group_test.exs
+++ b/test/protocol/join_group_test.exs
@@ -3,43 +3,42 @@ defmodule KafkaEx.Protocol.JoinGroup.Test do
   alias KafkaEx.Protocol.JoinGroup
 
   test "create_request creates a valid join group request" do
-    good_request =
-      <<
-        # Preamble
-        11::16,
-        0::16,
-        42::32,
-        9::16,
-        "client_id"::binary,
-        # GroupId
-        5::16,
-        "group"::binary,
-        # SessionTimeout
-        3600::32,
-        # MemberId
-        9::16,
-        "member_id"::binary,
-        # ProtocolType
-        8::16,
-        "consumer"::binary,
-        # GroupProtocols array size
-        1::32,
-        # Basic strategy, "roundrobin" has some restrictions
-        6::16,
-        "assign"::binary,
-        # length of metadata
-        32::32,
-        # v0
-        0::16,
-        # Topics array
-        2::32,
-        9::16,
-        "topic_one"::binary,
-        9::16,
-        "topic_two"::binary,
-        # UserData
-        0::32
-      >>
+    good_request = <<
+      # Preamble
+      11::16,
+      0::16,
+      42::32,
+      9::16,
+      "client_id"::binary,
+      # GroupId
+      5::16,
+      "group"::binary,
+      # SessionTimeout
+      3600::32,
+      # MemberId
+      9::16,
+      "member_id"::binary,
+      # ProtocolType
+      8::16,
+      "consumer"::binary,
+      # GroupProtocols array size
+      1::32,
+      # Basic strategy, "roundrobin" has some restrictions
+      6::16,
+      "assign"::binary,
+      # length of metadata
+      32::32,
+      # v0
+      0::16,
+      # Topics array
+      2::32,
+      9::16,
+      "topic_one"::binary,
+      9::16,
+      "topic_two"::binary,
+      # UserData
+      0::32
+    >>
 
     request =
       JoinGroup.create_request(42, "client_id", %JoinGroup.Request{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,6 +6,7 @@ ExUnit.configure(
     integration: true,
     consumer_group: true,
     server_0_p_10_p_1: true,
+    server_0_p_10_and_later: true,
     server_0_p_9_p_0: true,
     server_0_p_8_p_0: true
   ]


### PR DESCRIPTION
This implements the DeleteTopics message.

See: https://kafka.apache.org/protocol.html#The_Messages_DeleteTopics

I also took the opportunity to add a try/rescue around `module.parse_response(response)` in `network_request` because we often end up seeing stacktraces with arity errors when we have network problem, when actually it's simply a parsing error on a garbled message.