### PR TITLE
Elixir 1.8.1 warnings could be removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - _build
 matrix:
   include:
+    - elixir: 1.8.1
+      otp_release: 21.1
     - elixir: 1.7.4
       otp_release: 21.1
     - elixir: 1.6.6

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,9 +57,9 @@ config :kafka_ex,
   # see SSL OPTION DESCRIPTIONS - CLIENT SIDE at http://erlang.org/doc/man/ssl.html
   # for supported options
   ssl_options: [
-    cacertfile: System.cwd() <> "/ssl/ca-cert",
-    certfile: System.cwd() <> "/ssl/cert.pem",
-    keyfile: System.cwd() <> "/ssl/key.pem"
+    cacertfile: File.cwd!() <> "/ssl/ca-cert",
+    certfile: File.cwd!() <> "/ssl/cert.pem",
+    keyfile: File.cwd!() <> "/ssl/key.pem"
   ],
   # set this to the version of the kafka broker that you are using
   # include only major.minor.patch versions.  must be at least 0.8.0

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -232,7 +232,7 @@ defmodule KafkaEx.Server do
   @spec call(
           GenServer.server(),
           atom | tuple,
-          nil | number | opts :: Keyword.t()
+          nil | number | (opts :: Keyword.t())
         ) :: term
   def call(server, request, opts \\ [])
 


### PR DESCRIPTION
I get some warnings using 1.8.1:

    warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: nil | number | opts :: Keyword.t()
      lib/kafka_ex/server.ex:232

and

    warning: System.cwd/0 is deprecated. Use File.cwd/0 instead
      config/config.exs:60

    warning: System.cwd/0 is deprecated. Use File.cwd/0 instead
      config/config.exs:61

    warning: System.cwd/0 is deprecated. Use File.cwd/0 instead
      config/config.exs:62

this would remove them but dunno what it does on other Elixir versions.