### PR TITLE
Allow manual offset tracking for GenConsumer

### DIFF
--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -59,12 +59,13 @@ defmodule KafkaEx.GenConsumer do
 
   * `{:sync_commit, new_state}` causes synchronous offset commits.
   * `{:async_commit, new_state}` causes asynchronous offset commits.
+  * `{:no_commit, new_state}` disables offset commit.
 
-  Note that with both of the offset commit strategies, only if the final offset
+  Note that with both sync and async commit strategies, only if the final offset
   in the message set is committed and this is done after the messages are
-  consumed.  If you want to commit the offset of every message consumed, use
-  the synchronous offset commit strategy and implement calls to
-  `KafkaEx.offset_commit/2` within your consumer as appropriate.
+  consumed. If you want to commit the offset of every message consumed, use
+  the no_commit strategy and implement calls to `KafkaEx.offset_commit/2`
+  within your consumer as appropriate.
 
   ### Synchronous offset commits
 

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -759,6 +759,10 @@ defmodule KafkaEx.GenConsumer do
     }
   end
 
+  defp handle_commit(:no_commit, %State{acked_offset: offset} = state) do
+    %State{state | committed_offset: offset}
+  end
+
   defp handle_commit(:sync_commit, %State{} = state), do: commit(state)
 
   defp handle_commit(

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -255,8 +255,7 @@ defmodule KafkaEx.GenConsumer do
               topic :: binary,
               partition :: non_neg_integer,
               extra_args :: map()
-            ) ::
-              {:ok, state :: term}
+            ) :: {:ok, state :: term}
 
   @doc """
   Invoked for each message set consumed from a Kafka topic partition.

--- a/scripts/docker_up.sh
+++ b/scripts/docker_up.sh
@@ -49,4 +49,4 @@ done
 docker-compose up -d
 
 # create topics needed for testing
-docker-compose exec kafka3 /bin/bash -c "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181 KAFKA_PORT=9094 KAFKA_CREATE_TOPICS=consumer_group_implementation_test:4:2,test0p8p0:4:2 create-topics.sh"
+docker-compose exec kafka3 /bin/bash -c "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181 KAFKA_PORT=9094 KAFKA_CREATE_TOPICS=consumer_group_implementation_test:4:2,test0p8p0:4:2,gen_consumer_simple_test:1:1 create-topics.sh"

--- a/test/integration/gen_consumer_simple_test.exs
+++ b/test/integration/gen_consumer_simple_test.exs
@@ -1,0 +1,77 @@
+defmodule KafkaEx.GenConsumerSimple.Test do
+  use ExUnit.Case
+  alias KafkaEx.GenConsumer
+  alias KafkaEx.Protocol.OffsetFetch.Request, as: OffsetFetchRequest
+
+  import TestHelper
+
+  require Logger
+
+  @moduletag :integration
+
+  @topic_name "gen_consumer_simple_test"
+  @consumer_group_name "gen_consumer_simple_test_group"
+
+  defmodule TestConsumer do
+    use KafkaEx.GenConsumer
+    alias KafkaEx.GenConsumer
+
+    def message_sets(pid) do
+      GenConsumer.call(pid, :message_sets)
+    end
+
+    def init(_topic, _partition) do
+      {:ok, %{message_sets: []}}
+    end
+
+    def handle_call(:message_sets, _from, state) do
+      {:reply, state.message_sets, state}
+    end
+
+    def handle_message_set(message_set, state) do
+      Logger.debug(fn ->
+        "Consumer #{inspect(self())} handled message set #{inspect(message_set)}"
+      end)
+
+      {
+        :no_commit,
+        %{state | message_sets: state.message_sets ++ [message_set]}
+      }
+    end
+  end
+
+  test "consume data with no_commit strategy" do
+    {:ok, pid} =
+      GenConsumer.start_link(
+        TestConsumer,
+        @consumer_group_name,
+        @topic_name,
+        0,
+        auto_offset_reset: :latest,
+        fetch_options: [offset: -1]
+      )
+
+    assert [] == TestConsumer.message_sets(pid)
+    KafkaEx.produce(@topic_name, 0, "1")
+
+    wait_for(fn ->
+      1 == TestConsumer.message_sets(pid) |> length
+    end)
+
+    assert [[%{value: "1"}]] = TestConsumer.message_sets(pid)
+    KafkaEx.produce(@topic_name, 0, "2")
+
+    wait_for(fn ->
+      2 == TestConsumer.message_sets(pid) |> length
+    end)
+
+    assert [[%{value: "1"}], [%{value: "2"}]] = TestConsumer.message_sets(pid)
+
+    [%{partitions: [%{error_code: :unknown_topic_or_partition}]}] =
+      KafkaEx.offset_fetch(:kafka_ex, %OffsetFetchRequest{
+        consumer_group: @consumer_group_name,
+        topic: @topic_name,
+        partition: 0
+      })
+  end
+end


### PR DESCRIPTION
Allow to specify exact commit offset during startup and allow disable offset commit in handle_message_set of GenConsumer