### PR TITLE
Attempt of better connection error handling / reconnect

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,6 +52,8 @@ config :kafka_ex,
   # Threshold number of messages consumed for GenConsumer to commit offsets
   # to the broker.
   commit_threshold: 100,
+  # Interval in milliseconds to wait before reconnect to kafka
+  sleep_for_reconnect: 400,
   # This is the flag that enables use of ssl
   use_ssl: true,
   # see SSL OPTION DESCRIPTIONS - CLIENT SIDE at http://erlang.org/doc/man/ssl.html

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -349,7 +349,7 @@ defmodule KafkaEx.ConsumerGroup do
       )
     ]
 
-    supervise(children, strategy: :one_for_all)
+    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
   end
 
   defp call_manager(supervisor_pid, call) do

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -79,6 +79,11 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
       %HeartbeatResponse{error_code: error_code} ->
         Logger.warn("Heartbeat failed, got error code #{error_code}")
         {:stop, {:shutdown, {:error, error_code}}, state}
+
+      {:error, reason} ->
+        Logger.warn("Heartbeat failed, got error reason #{inspect reason}")
+        {:stop, {:shutdown, {:error, reason}}, state}
+
     end
   end
 end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -192,15 +192,30 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
+  # If the heartbeat gets an unrecoverable error.
+  def handle_info(
+        {:EXIT, _heartbeat_timer, {:shutdown, {:error, _reason}}},
+        %State{} = state
+      ) do
+    {:noreply, state}
+  end
+
   # When terminating, inform the group coordinator that this member is leaving
   # the group so that the group can rebalance without waiting for a session
   # timeout.
-  def terminate(_reason, %State{generation_id: nil, member_id: nil}), do: :ok
+  def terminate(_reason, %State{generation_id: nil, member_id: nil} = state) do
+    Process.unlink(state.worker_name)
+    KafkaEx.stop_worker(state.worker_name)
+  end
 
   def terminate(_reason, %State{} = state) do
     {:ok, _state} = leave(state)
     Process.unlink(state.worker_name)
     KafkaEx.stop_worker(state.worker_name)
+
+    # should be at end because of race condition (stop heartbeat while it is shutting down)
+    # if race condition happens, worker will be abandoned
+    stop_heartbeat_timer(state)
   end
 
   ### Helpers
@@ -244,9 +259,14 @@ defmodule KafkaEx.ConsumerGroup.Manager do
 
     # crash the worker if we recieve an error, but do it with a meaningful
     # error message
-    if join_response.error_code != :no_error do
-      raise "Error joining consumer group #{group_name}: " <>
-              "#{inspect(join_response.error_code)}"
+    case join_response do
+      %{error_code: :no_error} -> :ok
+      %{error_code: error_code} ->
+        raise "Error joining consumer group #{group_name}: " <>
+                "#{inspect(error_code)}"
+      {:error, reason} ->
+        raise "Error joining consumer group #{group_name}: " <>
+                "#{inspect(reason)}"
     end
 
     Logger.debug(fn -> "Joined consumer group #{group_name}" end)
@@ -331,7 +351,6 @@ defmodule KafkaEx.ConsumerGroup.Manager do
            member_id: member_id
          } = state
        ) do
-    stop_heartbeat_timer(state)
 
     leave_request = %LeaveGroupRequest{
       group_name: group_name,
@@ -341,13 +360,19 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     leave_group_response =
       KafkaEx.leave_group(leave_request, worker_name: worker_name)
 
-    if leave_group_response.error_code == :no_error do
-      Logger.debug(fn -> "Left consumer group #{group_name}" end)
-    else
-      Logger.warn(fn ->
-        "Received error #{inspect(leave_group_response.error_code)}, " <>
-          "consumer group manager will exit regardless."
-      end)
+    case leave_group_response do
+      %{error_code: :no_error} ->
+        Logger.debug(fn -> "Left consumer group #{group_name}" end)
+      %{error_code: error_code} ->
+        Logger.warn(fn ->
+          "Received error #{inspect(error_code)}, " <>
+            "consumer group manager will exit regardless."
+        end)
+      {:error, reason} ->
+        Logger.warn(fn ->
+          "Received error #{inspect(reason)}, " <>
+            "consumer group manager will exit regardless."
+        end)
     end
 
     {:ok, state}

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -194,10 +194,10 @@ defmodule KafkaEx.ConsumerGroup.Manager do
 
   # If the heartbeat gets an unrecoverable error.
   def handle_info(
-        {:EXIT, _heartbeat_timer, {:shutdown, {:error, _reason}}},
+        {:EXIT, _heartbeat_timer, {:shutdown, {:error, reason}}},
         %State{} = state
       ) do
-    {:noreply, state}
+    {:stop, {:shutdown, {:error, reason}}, state}
   end
 
   # When terminating, inform the group coordinator that this member is leaving

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -96,6 +96,10 @@ defmodule KafkaEx.NetworkClient do
     response
   end
 
+  def send_sync_request(nil, _, _) do
+    {:error, :no_broker}
+  end
+
   @spec format_host(binary) :: [char] | :inet.ip_address()
   def format_host(host) do
     case Regex.scan(~r/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/, host) do

--- a/lib/kafka_ex/protocol/api_versions.ex
+++ b/lib/kafka_ex/protocol/api_versions.ex
@@ -70,6 +70,10 @@ defmodule KafkaEx.Protocol.ApiVersions do
     }
   end
 
+  def parse_response(nil, _this_api_version) do
+    %Response{error_code: :no_response}
+  end
+
   defp parse_rest_of_response(api_versions_count, data, this_api_version) do
     {api_versions, remaining_data} =
       Protocol.Common.read_array(

--- a/lib/kafka_ex/protocol/consumer_metadata.ex
+++ b/lib/kafka_ex/protocol/consumer_metadata.ex
@@ -55,4 +55,10 @@ defmodule KafkaEx.Protocol.ConsumerMetadata do
       error_code: Protocol.error(error_code)
     }
   end
+
+  def parse_response(nil) do
+    %Response{
+      error_code: :no_response
+    }
+  end
 end

--- a/lib/kafka_ex/protocol/heartbeat.ex
+++ b/lib/kafka_ex/protocol/heartbeat.ex
@@ -19,7 +19,7 @@ defmodule KafkaEx.Protocol.Heartbeat do
     # We could just return the error code instead of having the struct, but this
     # keeps the code normalized
     defstruct error_code: nil
-    @type t :: %Response{error_code: atom | integer}
+    @type t :: %Response{error_code: atom | integer} | {:error, atom}
   end
 
   @spec create_request(integer, binary, Request.t()) :: binary

--- a/lib/kafka_ex/protocol/join_group.ex
+++ b/lib/kafka_ex/protocol/join_group.ex
@@ -35,7 +35,7 @@ defmodule KafkaEx.Protocol.JoinGroup do
             leader_id: binary,
             member_id: binary,
             members: [binary]
-          }
+          } | {:error, atom}
 
     def leader?(%__MODULE__{member_id: member_id, leader_id: leader_id}) do
       member_id == leader_id

--- a/lib/kafka_ex/protocol/leave_group.ex
+++ b/lib/kafka_ex/protocol/leave_group.ex
@@ -16,7 +16,7 @@ defmodule KafkaEx.Protocol.LeaveGroup do
 
     @type t :: %Response{
             error_code: atom | integer
-          }
+          } | {:error, atom}
   end
 
   @spec create_request(integer, binary, Request.t()) :: binary

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -72,8 +72,14 @@ defmodule KafkaEx.Server0P8P2 do
         }
       end)
 
-    {correlation_id, metadata} =
+    check_brokers_sockets!(brokers)
+
+    {correlation_id, metadata} = try do
       retrieve_metadata(brokers, 0, config_sync_timeout())
+    rescue e ->
+      sleep_for_reconnect()
+      Kernel.reraise(e, System.stacktrace())
+    end
 
     state = %State{
       metadata: metadata,

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -98,8 +98,14 @@ defmodule KafkaEx.Server0P9P0 do
         }
       end)
 
-    {correlation_id, metadata} =
+    check_brokers_sockets!(brokers)
+
+    {correlation_id, metadata} = try do
       retrieve_metadata(brokers, 0, config_sync_timeout())
+    rescue e ->
+      sleep_for_reconnect()
+      Kernel.reraise(e, System.stacktrace())
+    end
 
     state = %State{
       metadata: metadata,


### PR DESCRIPTION
Related to issues #298, #190 

When kafka connection is lost, handle relative connection errors gracefully.
Currently supervisor tree will try to recreate itself without timeout which leads to quick exhaustion of max restarts and complete shutdown of application :kafka_ex.
I added sleep (config `sleep_for_reconnect`, default 400 ms) in server's `init` at places that throws errors without connection to kafka.

Tested with `docker-compose down && docker-compose up`. 
Application :kafka_ex will not crash but contantly  (with accordingly configured `max_restarts/max_seconds/sleep_for_reconnect`, 3/1/500 for example) tries to reconnect.
Or if configured with `max_restarts/max_seconds/sleep_for_reconnect`, 20/10/400 for example will try to reconnect t Kafka in ~10s and then shutdown.

Tests pass.