### PR TITLE
Update README to mention newest released kafka_ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ defmodule MyApp.Mixfile do
   defp deps do
     [
       # add to your existing deps
-      {:kafka_ex, "~> 0.9.0"},
+      {:kafka_ex, "~> 0.10"},
       # if using snappy compression
       {:snappy, git: "https://github.com/fdmanana/snappy-erlang-nif"}
     ]


### PR DESCRIPTION
I was surprised I didn't get the latest release following the
instructions from the README.  Seems reasonable to loosen the
recommended `~>` in the README to just be on the minor version number so
that if that if the README doesn't get updated for the next minor
release it will still install the latest version.