### PR TITLE
Make KafkaEx.stream/3 use KafkaEx.Server

### DIFF
--- a/lib/kafka_ex/stream.ex
+++ b/lib/kafka_ex/stream.ex
@@ -1,6 +1,7 @@
 defmodule KafkaEx.Stream do
   @moduledoc false
 
+  alias KafkaEx.Server
   alias KafkaEx.Protocol.OffsetCommit.Request, as: OffsetCommitRequest
   alias KafkaEx.Protocol.Fetch.Request, as: FetchRequest
   alias KafkaEx.Protocol.Fetch.Response, as: FetchResponse
@@ -126,7 +127,7 @@ defmodule KafkaEx.Stream do
     end
 
     defp commit_offset(%KafkaEx.Stream{} = stream_data, offset) do
-      GenServer.call(stream_data.worker_name, {
+      Server.call(stream_data.worker_name, {
         :offset_commit,
         %OffsetCommitRequest{
           consumer_group: stream_data.consumer_group,
@@ -145,7 +146,7 @@ defmodule KafkaEx.Stream do
       req = data.fetch_request
 
       data.worker_name
-      |> GenServer.call({:fetch, %{req | offset: offset}})
+      |> Server.call({:fetch, %{req | offset: offset}})
       |> FetchResponse.partition_messages(req.topic, req.partition)
     end
   end


### PR DESCRIPTION
Currently, `KafkaEx.stream/3` makes direct `GenServer.call/2` calls. This way, `sync_timeout` is not used and can lead to `GenServer` timeouts if Kafka server takes more than 5 seconds to reply