### PR TITLE
Include topic and partition in message struct

### DIFF
--- a/lib/kafka_ex/protocol/common.ex
+++ b/lib/kafka_ex/protocol/common.ex
@@ -22,7 +22,7 @@ defmodule KafkaEx.Protocol.Common do
         mod
       ) do
     struct_module = Module.concat(mod, Response)
-    {partitions, topics_data} = mod.parse_partitions(partitions_size, rest, [])
+    {partitions, topics_data} = mod.parse_partitions(partitions_size, rest, [], topic)
 
     [
       %{

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -119,7 +119,6 @@ defmodule KafkaEx.Protocol.Fetch do
           topic
        ) do
     {:ok, message} = parse_message(%Message{offset: offset, topic: topic}, msg_data)
-    IO.inspect(message)
     parse_message_set(append_messages(message, list), rest, topic)
   end
 

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -45,14 +45,15 @@ defmodule KafkaEx.Protocol.Fetch do
 
   defmodule Message do
     @moduledoc false
-    defstruct attributes: 0, crc: nil, offset: nil, key: nil, value: nil
+    defstruct attributes: 0, crc: nil, offset: nil, key: nil, value: nil, topic: nil
 
     @type t :: %Message{
             attributes: integer,
             crc: integer,
             offset: integer,
             key: binary,
-            value: binary
+            value: binary,
+            topic: binary
           }
   end
 
@@ -83,16 +84,17 @@ defmodule KafkaEx.Protocol.Fetch do
     parse_topics(topics_size, rest, __MODULE__)
   end
 
-  def parse_partitions(0, rest, partitions), do: {partitions, rest}
+  def parse_partitions(0, rest, partitions, _topic), do: {partitions, rest}
 
   def parse_partitions(
         partitions_size,
         <<partition::32-signed, error_code::16-signed,
           hw_mark_offset::64-signed, msg_set_size::32-signed,
           msg_set_data::size(msg_set_size)-binary, rest::binary>>,
-        partitions
+        partitions,
+        topic
       ) do
-    {:ok, message_set, last_offset} = parse_message_set([], msg_set_data)
+    {:ok, message_set, last_offset} = parse_message_set([], msg_set_data, topic)
 
     parse_partitions(partitions_size - 1, rest, [
       %{
@@ -103,29 +105,32 @@ defmodule KafkaEx.Protocol.Fetch do
         last_offset: last_offset
       }
       | partitions
-    ])
+    ], topic)
   end
 
-  defp parse_message_set([], <<>>) do
+  defp parse_message_set([], <<>>, _topic) do
     {:ok, [], nil}
   end
 
   defp parse_message_set(
          list,
          <<offset::64, msg_size::32, msg_data::size(msg_size)-binary,
-           rest::binary>>
+           rest::binary>>,
+          topic
        ) do
-    {:ok, message} = parse_message(%Message{offset: offset}, msg_data)
-    parse_message_set(append_messages(message, list), rest)
+    {:ok, message} = parse_message(%Message{offset: offset, topic: topic}, msg_data)
+    IO.inspect(message)
+    parse_message_set(append_messages(message, list), rest, topic)
   end
 
-  defp parse_message_set([last | _] = list, _) do
+  defp parse_message_set([last | _] = list, _, _topic) do
     {:ok, Enum.reverse(list), last.offset}
   end
 
   defp parse_message_set(
          _,
-         <<offset::64, msg_size::32, partial_message_data::binary>>
+         <<offset::64, msg_size::32, partial_message_data::binary>>,
+         _topic
        )
        when byte_size(partial_message_data) < msg_size do
     raise RuntimeError,
@@ -158,10 +163,10 @@ defmodule KafkaEx.Protocol.Fetch do
     parse_key(message, rest)
   end
 
-  defp maybe_decompress(%Message{attributes: attributes}, rest) do
+  defp maybe_decompress(%Message{attributes: attributes, topic: topic}, rest) do
     <<-1::32-signed, value_size::32, value::size(value_size)-binary>> = rest
     decompressed = Compression.decompress(attributes, value)
-    {:ok, msg_set, _offset} = parse_message_set([], decompressed)
+    {:ok, msg_set, _offset} = parse_message_set([], decompressed, topic)
     {:ok, msg_set}
   end
 

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -58,14 +58,15 @@ defmodule KafkaEx.Protocol.OffsetFetch do
     parse_topics(topics_size, topics_data, __MODULE__)
   end
 
-  def parse_partitions(0, rest, partitions), do: {partitions, rest}
+  def parse_partitions(0, rest, partitions, _topic), do: {partitions, rest}
 
   def parse_partitions(
         partitions_size,
         <<partition::32-signed, offset::64-signed, metadata_size::16-signed,
           metadata::size(metadata_size)-binary, error_code::16-signed,
           rest::binary>>,
-        partitions
+        partitions,
+        topic
       ) do
     parse_partitions(partitions_size - 1, rest, [
       %{
@@ -75,6 +76,6 @@ defmodule KafkaEx.Protocol.OffsetFetch do
         error_code: Protocol.error(error_code)
       }
       | partitions
-    ])
+    ], topic)
   end
 end

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -124,13 +124,14 @@ defmodule KafkaEx.Protocol.Produce do
     end
   end
 
-  def parse_partitions(0, rest, partitions), do: {partitions, rest}
+  def parse_partitions(0, rest, partitions, _topic), do: {partitions, rest}
 
   def parse_partitions(
         partitions_size,
         <<partition::32-signed, error_code::16-signed, offset::64,
           rest::binary>>,
-        partitions
+        partitions,
+        topic
       ) do
     parse_partitions(partitions_size - 1, rest, [
       %{
@@ -139,6 +140,6 @@ defmodule KafkaEx.Protocol.Produce do
         offset: offset
       }
       | partitions
-    ])
+    ], topic)
   end
 end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -283,6 +283,7 @@ defmodule KafkaEx.Integration.Test do
 
     message = fetch_response.partitions |> hd |> Map.get(:message_set) |> hd
 
+    assert message.partition == 0
     assert message.topic == topic_name
     assert message.value == "hey foo"
     assert message.offset == offset

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -268,21 +268,22 @@ defmodule KafkaEx.Integration.Test do
   end
 
   test "fetch works" do
-    random_string = generate_random_string()
+    topic_name = generate_random_string()
 
     {:ok, offset} =
       KafkaEx.produce(%Proto.Produce.Request{
-        topic: random_string,
+        topic: topic_name,
         partition: 0,
         required_acks: 1,
         messages: [%Proto.Produce.Message{value: "hey foo"}]
       })
 
     fetch_response =
-      KafkaEx.fetch(random_string, 0, offset: 0, auto_commit: false) |> hd
+      KafkaEx.fetch(topic_name, 0, offset: 0, auto_commit: false) |> hd
 
     message = fetch_response.partitions |> hd |> Map.get(:message_set) |> hd
 
+    assert message.topic == topic_name
     assert message.value == "hey foo"
     assert message.offset == offset
   end

--- a/test/protocol/fetch_test.exs
+++ b/test/protocol/fetch_test.exs
@@ -23,10 +23,14 @@ defmodule KafkaEx.Protocol.Fetch.Test do
   end
 
   test "parse_response correctly parses a valid response with a key and a value" do
+    topic = "baz"
+    key = "foo"
+    value = "bar"
+
     response =
-      <<0::32, 1::32, 3::16, "bar"::binary, 1::32, 0::32, 0::16, 10::64, 32::32,
-        1::64, 20::32, 0::32, 0::8, 0::8, 3::32, "foo"::binary, 3::32,
-        "bar"::binary>>
+      <<0::32, 1::32, 3::16, topic::binary, 1::32, 0::32, 0::16, 10::64, 32::32,
+        1::64, 20::32, 0::32, 0::8, 0::8, 3::32, key::binary, 3::32,
+        value::binary>>
 
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
@@ -39,15 +43,16 @@ defmodule KafkaEx.Protocol.Fetch.Test do
               %Message{
                 attributes: 0,
                 crc: 0,
-                key: "foo",
+                key: key,
                 offset: 1,
-                value: "bar"
+                value: value,
+                topic: topic
               }
             ],
             partition: 0
           }
         ],
-        topic: "bar"
+        topic: topic
       }
     ]
 
@@ -77,21 +82,24 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 crc: 4_264_455_069,
                 key: nil,
                 offset: 0,
-                value: "hey"
+                value: "hey",
+                topic: "food"
               },
               %Message{
                 attributes: 0,
                 crc: 4_264_455_069,
                 key: nil,
                 offset: 1,
-                value: "hey"
+                value: "hey",
+                topic: "food"
               },
               %Message{
                 attributes: 0,
                 crc: 4_264_455_069,
                 key: nil,
                 offset: 2,
-                value: "hey"
+                value: "hey",
+                topic: "food"
               }
             ],
             partition: 0
@@ -105,9 +113,12 @@ defmodule KafkaEx.Protocol.Fetch.Test do
   end
 
   test "parse_response correctly parses a valid response with a nil key and a value" do
+    topic = "foo"
+    value = "bar"
+
     response =
-      <<0::32, 1::32, 3::16, "bar"::binary, 1::32, 0::32, 0::16, 10::64, 29::32,
-        1::64, 17::32, 0::32, 0::8, 0::8, -1::32, 3::32, "bar"::binary>>
+      <<0::32, 1::32, 3::16, topic::binary, 1::32, 0::32, 0::16, 10::64, 29::32,
+        1::64, 17::32, 0::32, 0::8, 0::8, -1::32, 3::32, value::binary>>
 
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
@@ -117,12 +128,12 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar"}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: value, topic: topic}
             ],
             partition: 0
           }
         ],
-        topic: "bar"
+        topic: topic
       }
     ]
 
@@ -130,9 +141,12 @@ defmodule KafkaEx.Protocol.Fetch.Test do
   end
 
   test "parse_response correctly parses a valid response with a key and a nil value" do
+    topic = "bar"
+    key = "foo"
+
     response =
-      <<0::32, 1::32, 3::16, "bar"::binary, 1::32, 0::32, 0::16, 10::64, 29::32,
-        1::64, 17::32, 0::32, 0::8, 0::8, 3::32, "foo"::binary, -1::32>>
+      <<0::32, 1::32, 3::16, topic::binary, 1::32, 0::32, 0::16, 10::64, 29::32,
+        1::64, 17::32, 0::32, 0::8, 0::8, 3::32, key::binary, -1::32>>
 
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
@@ -142,12 +156,12 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: "foo", offset: 1, value: nil}
+              %Message{attributes: 0, crc: 0, key: key, offset: 1, value: nil, topic: topic}
             ],
             partition: 0
           }
         ],
-        topic: "bar"
+        topic: topic
       }
     ]
 
@@ -156,7 +170,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
 
   test "parse_response correctly parses a valid response with multiple messages" do
     response =
-      <<0::32, 1::32, 3::16, "bar"::binary, 1::32, 0::32, 0::16, 10::64, 58::32,
+      <<0::32, 1::32, 3::16, "foo"::binary, 1::32, 0::32, 0::16, 10::64, 58::32,
         1::64, 17::32, 0::32, 0::8, 0::8, -1::32, 3::32, "bar"::binary, 2::64,
         17::32, 0::32, 0::8, 0::8, -1::32, 3::32, "baz"::binary>>
 
@@ -173,14 +187,22 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 crc: 0,
                 key: nil,
                 offset: 1,
-                value: "bar"
+                value: "bar",
+                topic: "foo"
               },
-              %Message{attributes: 0, crc: 0, key: nil, offset: 2, value: "baz"}
+              %Message{
+                attributes: 0,
+                crc: 0,
+                key: nil,
+                offset: 2,
+                value: "baz",
+                topic: "foo"
+              }
             ],
             partition: 0
           }
         ],
-        topic: "bar"
+        topic: "foo"
       }
     ]
 
@@ -188,8 +210,10 @@ defmodule KafkaEx.Protocol.Fetch.Test do
   end
 
   test "parse_response correctly parses a valid response with multiple partitions" do
+    topic = "foo"
+
     response =
-      <<0::32, 1::32, 3::16, "bar"::binary, 2::32, 0::32, 0::16, 10::64, 29::32,
+      <<0::32, 1::32, 3::16, topic::binary, 2::32, 0::32, 0::16, 10::64, 29::32,
         1::64, 17::32, 0::32, 0::8, 0::8, -1::32, 3::32, "bar"::binary, 1::32,
         0::16, 10::64, 29::32, 1::64, 17::32, 0::32, 0::8, 0::8, -1::32, 3::32,
         "baz"::binary>>
@@ -202,7 +226,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "baz"}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "baz", topic: topic}
             ],
             partition: 1
           },
@@ -211,12 +235,12 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar"}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar", topic: topic}
             ],
             partition: 0
           }
         ],
-        topic: "bar"
+        topic: topic
       }
     ]
 
@@ -238,7 +262,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "foo"}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "foo", topic: "bar"}
             ],
             partition: 0
           }
@@ -252,7 +276,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar"}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar", topic: "baz"}
             ],
             partition: 0
           }
@@ -273,12 +297,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
         169, 101, 15, 206, 246, 50, 48, 252, 7, 2, 32, 143, 167, 36, 181, 184,
         68, 33, 55, 181, 184, 56, 49, 61, 21, 0, 10, 31, 112, 82, 38, 0, 0, 0>>
 
+    topic = "gzip_test"
+
     message = %Message{
       attributes: 0,
       crc: 2_799_750_541,
       key: nil,
       offset: 0,
-      value: "test message"
+      value: "test message",
+      topic: topic
     }
 
     partition1 = %{
@@ -292,7 +319,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
         partitions: [partition1],
-        topic: "gzip_test"
+        topic: topic
       }
     ]
 
@@ -315,12 +342,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
         66, 6, 102, 144, 74, 182, 111, 41, 54, 112, 149, 70, 104, 42, 141, 0,
         135, 95, 114, 164, 84, 0, 0, 0>>
 
+    topic = "gzip_batch_test"
+
     message1 = %Message{
       attributes: 0,
       crc: 3_996_946_843,
       key: nil,
       offset: 0,
-      value: "batch test 1"
+      value: "batch test 1",
+      topic: topic
     }
 
     message2 = %Message{
@@ -328,7 +358,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       crc: 2_000_011_297,
       key: nil,
       offset: 1,
-      value: "batch test 2"
+      value: "batch test 2",
+      topic: topic
     }
 
     message3 = %Message{
@@ -336,7 +367,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       crc: 3_429_199_362,
       key: "key1",
       offset: 2,
-      value: "batch test 1"
+      value: "batch test 1",
+      topic: topic
     }
 
     message4 = %Message{
@@ -344,7 +376,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       crc: 116_810_812,
       key: "key2",
       offset: 3,
-      value: "batch test 2"
+      value: "batch test 2",
+      topic: topic
     }
 
     partition1 = %{
@@ -358,7 +391,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
         partitions: [partition1],
-        topic: "gzip_batch_test"
+        topic: topic
       }
     ]
 
@@ -377,12 +410,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
 
     value = "test message"
 
+    topic = "snappy_test"
+
     message = %Message{
       attributes: 0,
       crc: 2_799_750_541,
       key: nil,
       offset: 1,
-      value: value
+      value: value,
+      topic: topic
     }
 
     partition1 = %{
@@ -396,7 +432,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
         partitions: [partition1],
-        topic: "snappy_test"
+        topic: topic
       }
     ]
 
@@ -414,12 +450,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
         98, 97, 116, 99, 104, 32, 116, 101, 115, 116, 32, 1, 16, 1, 1, 32, 1, 0,
         0, 0, 30, 6, 246, 100, 60, 1, 13, 5, 42, 0, 50, 58, 42, 0, 0, 50>>
 
+    topic = "snappy_batch_test"
+
     message1 = %Message{
       attributes: 0,
       crc: 3_429_199_362,
       key: "key1",
       offset: 0,
-      value: "batch test 1"
+      value: "batch test 1",
+      topic: topic
     }
 
     message2 = %Message{
@@ -427,7 +466,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       crc: 116_810_812,
       key: "key2",
       offset: 1,
-      value: "batch test 2"
+      value: "batch test 2",
+      topic: topic
     }
 
     partition1 = %{
@@ -441,7 +481,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     expected_response = [
       %KafkaEx.Protocol.Fetch.Response{
         partitions: [partition1],
-        topic: "snappy_batch_test"
+        topic: topic
       }
     ]
 

--- a/test/protocol/fetch_test.exs
+++ b/test/protocol/fetch_test.exs
@@ -26,6 +26,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     topic = "baz"
     key = "foo"
     value = "bar"
+    partition = 0
 
     response =
       <<0::32, 1::32, 3::16, topic::binary, 1::32, 0::32, 0::16, 10::64, 32::32,
@@ -46,10 +47,11 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: key,
                 offset: 1,
                 value: value,
-                topic: topic
+                topic: topic,
+                partition: partition
               }
             ],
-            partition: 0
+            partition: partition
           }
         ],
         topic: topic
@@ -83,7 +85,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: nil,
                 offset: 0,
                 value: "hey",
-                topic: "food"
+                topic: "food",
+                partition: 0
               },
               %Message{
                 attributes: 0,
@@ -91,7 +94,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: nil,
                 offset: 1,
                 value: "hey",
-                topic: "food"
+                topic: "food",
+                partition: 0
               },
               %Message{
                 attributes: 0,
@@ -99,7 +103,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: nil,
                 offset: 2,
                 value: "hey",
-                topic: "food"
+                topic: "food",
+                partition: 0
               }
             ],
             partition: 0
@@ -128,7 +133,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: value, topic: topic}
+              %Message{
+                attributes: 0,
+                crc: 0,
+                key: nil,
+                offset: 1,
+                value: value,
+                topic: topic,
+                partition: 0
+              }
             ],
             partition: 0
           }
@@ -156,7 +169,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: key, offset: 1, value: nil, topic: topic}
+              %Message{attributes: 0, crc: 0, key: key, offset: 1, value: nil, topic: topic, partition: 0}
             ],
             partition: 0
           }
@@ -188,7 +201,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: nil,
                 offset: 1,
                 value: "bar",
-                topic: "foo"
+                topic: "foo",
+                partition: 0
               },
               %Message{
                 attributes: 0,
@@ -196,7 +210,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
                 key: nil,
                 offset: 2,
                 value: "baz",
-                topic: "foo"
+                topic: "foo",
+                partition: 0
               }
             ],
             partition: 0
@@ -226,7 +241,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "baz", topic: topic}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "baz", topic: topic, partition: 1}
             ],
             partition: 1
           },
@@ -235,7 +250,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar", topic: topic}
+              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar", topic: topic, partition: 0}
             ],
             partition: 0
           }
@@ -262,7 +277,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "foo", topic: "bar"}
+              %Message{
+                attributes: 0,
+                crc: 0,
+                key: nil,
+                offset: 1,
+                value: "foo",
+                topic: "bar",
+                partition: 0
+              }
             ],
             partition: 0
           }
@@ -276,7 +299,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
             hw_mark_offset: 10,
             last_offset: 1,
             message_set: [
-              %Message{attributes: 0, crc: 0, key: nil, offset: 1, value: "bar", topic: "baz"}
+              %Message{
+                attributes: 0,
+                crc: 0,
+                key: nil,
+                offset: 1,
+                value: "bar",
+                topic: "baz",
+                partition: 0
+              }
             ],
             partition: 0
           }
@@ -305,7 +336,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: nil,
       offset: 0,
       value: "test message",
-      topic: topic
+      topic: topic,
+      partition: 0
     }
 
     partition1 = %{
@@ -343,6 +375,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
         135, 95, 114, 164, 84, 0, 0, 0>>
 
     topic = "gzip_batch_test"
+    partition_id = 0
 
     message1 = %Message{
       attributes: 0,
@@ -350,7 +383,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: nil,
       offset: 0,
       value: "batch test 1",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     message2 = %Message{
@@ -359,7 +393,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: nil,
       offset: 1,
       value: "batch test 2",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     message3 = %Message{
@@ -368,7 +403,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: "key1",
       offset: 2,
       value: "batch test 1",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     message4 = %Message{
@@ -377,14 +413,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: "key2",
       offset: 3,
       value: "batch test 2",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     partition1 = %{
       error_code: :no_error,
       hw_mark_offset: 4,
       last_offset: 3,
-      partition: 0,
+      partition: partition_id,
       message_set: [message1, message2, message3, message4]
     }
 
@@ -418,7 +455,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: nil,
       offset: 1,
       value: value,
-      topic: topic
+      topic: topic,
+      partition: 1
     }
 
     partition1 = %{
@@ -440,6 +478,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
   end
 
   test "parse_response correctly parses a valid response with batched snappy-encoded messages" do
+    partition_id = 0
     response =
       <<0, 0, 0, 14, 0, 0, 0, 1, 0, 17, 115, 110, 97, 112, 112, 121, 95, 98, 97,
         116, 99, 104, 95, 116, 101, 115, 116, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
@@ -458,7 +497,8 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: "key1",
       offset: 0,
       value: "batch test 1",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     message2 = %Message{
@@ -467,14 +507,15 @@ defmodule KafkaEx.Protocol.Fetch.Test do
       key: "key2",
       offset: 1,
       value: "batch test 2",
-      topic: topic
+      topic: topic,
+      partition: partition_id
     }
 
     partition1 = %{
       error_code: :no_error,
       hw_mark_offset: 2,
       last_offset: 1,
-      partition: 0,
+      partition: partition_id,
       message_set: [message1, message2]
     }
 


### PR DESCRIPTION
## Motivation

- In our current use case, we want to consume multiple topics, with the consumer group supervisor. To do that we need a way to identify the message to each topic reaching the handler.

## Proposed solution

- Include the topic key in the `Protocol.Fetch.Message ` struct of the response.
- Include the partition key in the `Protocol.Fetch.Message ` struct of the response.

## Related

#358 
