### PR TITLE
Honor compression option on produce

### DIFF
--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -362,13 +362,14 @@ defmodule KafkaEx do
     key = Keyword.get(opts, :key, "")
     required_acks = Keyword.get(opts, :required_acks, 0)
     timeout = Keyword.get(opts, :timeout, 100)
+    compression = Keyword.get(opts, :compression, :none)
 
     produce_request = %ProduceRequest{
       topic: topic,
       partition: partition,
       required_acks: required_acks,
       timeout: timeout,
-      compression: :none,
+      compression: compression,
       messages: [%Message{key: key, value: value}]
     }
 


### PR DESCRIPTION
This is embarassing.  It doesn't look like this option was ever wired up
to the produce function.  The version of the function that takes a
`%Produce.Request` does honor compression, though.