### PR TITLE
Allow specifying versions for offset commit and fetch

### DIFF
--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -822,8 +822,16 @@ defmodule KafkaEx.GenConsumer do
       offset: offset
     }
 
-    [%OffsetCommitResponse{topic: ^topic, partitions: [^partition]}] =
+    [%OffsetCommitResponse{topic: ^topic, partitions: [partition_response]}] =
       KafkaEx.offset_commit(worker_name, request)
+
+    # one of these needs to match, depending on which client
+    case partition_response do
+      # old client
+      [^partition] -> :ok
+      # new client
+      %{error_code: :no_error, partition: ^partition} -> :ok
+    end
 
     Logger.debug(fn ->
       "Committed offset #{topic}/#{partition}@#{offset} for #{group}"

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -828,7 +828,7 @@ defmodule KafkaEx.GenConsumer do
     # one of these needs to match, depending on which client
     case partition_response do
       # old client
-      [^partition] -> :ok
+      ^partition -> :ok
       # new client
       %{error_code: :no_error, partition: ^partition} -> :ok
     end

--- a/lib/kafka_ex/new/adapter.ex
+++ b/lib/kafka_ex/new/adapter.ex
@@ -425,8 +425,6 @@ defmodule KafkaEx.New.Adapter do
               _ -> millis_timestamp_now()
             end
 
-          timestamp = -1
-
           [topic] = request.topics
           [partition] = topic.partitions
 
@@ -459,18 +457,16 @@ defmodule KafkaEx.New.Adapter do
   @spec offset_commit_response(%{
           responses: [%{partition_responses: [...], topic: any}, ...]
         }) :: [KafkaEx.Protocol.OffsetCommit.Response.t(), ...]
-  def offset_commit_response(
-        %{
-          responses: [
-            %{
-              topic: topic,
-              partition_responses: [
-                %{partition: partition, error_code: error_code}
-              ]
-            }
-          ]
-        }
-      ) do
+  def offset_commit_response(%{
+        responses: [
+          %{
+            topic: topic,
+            partition_responses: [
+              %{partition: partition, error_code: error_code}
+            ]
+          }
+        ]
+      }) do
     # NOTE kafkaex protocol ignores error code here
     [
       %OffsetCommitResponse{

--- a/lib/kafka_ex/new/adapter.ex
+++ b/lib/kafka_ex/new/adapter.ex
@@ -651,10 +651,6 @@ defmodule KafkaEx.New.Adapter do
   defp minus_one_if_nil(x), do: x
 
   defp millis_timestamp_now do
-    NaiveDateTime.diff(
-      NaiveDateTime.utc_now(),
-      ~N[1970-01-01 00:00:00],
-      :millisecond
-    )
+    :os.system_time(:millisecond)
   end
 end

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -580,23 +580,6 @@ defmodule KafkaEx.New.Client do
   end
 
   defp get_send_request_function(
-         %NodeSelector{strategy: :controller},
-         state,
-         network_timeout,
-         _synchronous
-       ) do
-    {:ok, broker} = State.select_broker(state, NodeSelector.controller())
-
-    {fn wire_request ->
-       NetworkClient.send_sync_request(
-         broker,
-         wire_request,
-         network_timeout
-       )
-     end, state}
-  end
-
-  defp get_send_request_function(
          %NodeSelector{
            strategy: :topic_partition,
            topic: topic,
@@ -654,6 +637,23 @@ defmodule KafkaEx.New.Client do
          network_timeout
        )
      end, updated_state}
+  end
+
+  defp get_send_request_function(
+         node_selector = %NodeSelector{},
+         state,
+         network_timeout,
+         _synchronous
+       ) do
+    {:ok, broker} = State.select_broker(state, node_selector)
+
+    {fn wire_request ->
+       NetworkClient.send_sync_request(
+         broker,
+         wire_request,
+         network_timeout
+       )
+     end, state}
   end
 
   defp deserialize(data, request) do

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -640,7 +640,7 @@ defmodule KafkaEx.New.Client do
   end
 
   defp get_send_request_function(
-         node_selector = %NodeSelector{},
+         %NodeSelector{} = node_selector,
          state,
          network_timeout,
          _synchronous

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -11,20 +11,29 @@ defmodule KafkaEx.Protocol.OffsetCommit do
               topic: nil,
               partition: nil,
               offset: nil,
-              metadata: ""
+              metadata: "",
+              # NOTE api_version, generation_id, member_id, and timestamp only used in new client
+              api_version: 0,
+              generation_id: -1,
+              member_id: "kafkaex",
+              timestamp: 0
 
     @type t :: %Request{
             consumer_group: binary,
             topic: binary,
             partition: integer,
-            offset: integer
+            offset: integer,
+            api_version: integer,
+            generation_id: integer,
+            member_id: binary,
+            timestamp: integer
           }
   end
 
   defmodule Response do
     @moduledoc false
     defstruct partitions: [], topic: nil
-    @type t :: %Response{partitions: [] | [integer], topic: binary}
+    @type t :: %Response{partitions: [] | [integer] | [map], topic: binary}
   end
 
   @spec create_request(integer, binary, Request.t()) :: binary

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -8,12 +8,17 @@ defmodule KafkaEx.Protocol.OffsetFetch do
 
   defmodule Request do
     @moduledoc false
-    defstruct consumer_group: nil, topic: nil, partition: nil
+    defstruct consumer_group: nil,
+              topic: nil,
+              partition: nil,
+              # NOTE api_version only used in new client
+              api_version: 0
 
     @type t :: %Request{
             consumer_group: nil | binary,
             topic: binary,
-            partition: integer
+            partition: integer,
+            api_version: integer
           }
   end
 
@@ -68,14 +73,19 @@ defmodule KafkaEx.Protocol.OffsetFetch do
         partitions,
         topic
       ) do
-    parse_partitions(partitions_size - 1, rest, [
-      %{
-        partition: partition,
-        offset: offset,
-        metadata: metadata,
-        error_code: Protocol.error(error_code)
-      }
-      | partitions
-    ], topic)
+    parse_partitions(
+      partitions_size - 1,
+      rest,
+      [
+        %{
+          partition: partition,
+          offset: offset,
+          metadata: metadata,
+          error_code: Protocol.error(error_code)
+        }
+        | partitions
+      ],
+      topic
+    )
   end
 end

--- a/test/integration/kayrock/compatibility_consumer_group_test.exs
+++ b/test/integration/kayrock/compatibility_consumer_group_test.exs
@@ -219,7 +219,7 @@ defmodule KafkaEx.KayrockCompatibilityConsumerGroupTest do
            ) ==
              [
                %Proto.OffsetCommit.Response{
-                 partitions: [0],
+                 partitions: [%{error_code: :no_error, partition: 0}],
                  topic: random_string
                }
              ]

--- a/test/integration/kayrock/offset_test.exs
+++ b/test/integration/kayrock/offset_test.exs
@@ -1,0 +1,363 @@
+defmodule KafkaEx.KayrockOffsetTest do
+  @moduledoc """
+  Tests for offset commit and fetch API versioning
+  """
+
+  use ExUnit.Case
+
+  alias KafkaEx.New.Client
+  alias KafkaEx.Protocol.OffsetCommit
+  alias KafkaEx.Protocol.OffsetFetch
+
+  @moduletag :new_client
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+
+    {:ok, pid} = Client.start_link(args, :no_name)
+
+    {:ok, %{client: pid}}
+  end
+
+  test "offset commit v0 and fetch v0", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v0_fetch_v0"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 0
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 0
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    assert got_offset == offset
+  end
+
+  test "offset commit v1 and fetch v0", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v1_fetch_v0"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 1
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 0
+      })
+
+    # we get an error code when we commit with v > 0 and fetch with v0
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{
+          error_code: :unknown_topic_or_partition,
+          offset: -1,
+          partition: 0
+        }
+      ]
+    } = resp
+  end
+
+  test "offset commit v1 and fetch v1", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v1_fetch_v1"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 1
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 1
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    assert got_offset == offset
+  end
+
+  test "offset commit v0 and fetch v1", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v0_fetch_v1"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 0
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 1
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    # can't commit with v0 and fetch with v > 0
+    assert got_offset == -1
+  end
+
+  test "offset commit v0 and fetch v2", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v0_fetch_v2"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 0
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 2
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    # can't commit with v0 and fetch with v > 0
+    assert got_offset == -1
+  end
+
+  test "offset commit v0 and fetch v3", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v0_fetch_v3"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 0
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 3
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    # can't commit with v0 and fetch with v > 0
+    assert got_offset == -1
+  end
+
+  test "offset commit v2 and fetch v2", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v2_fetch_v2"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 2
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 2
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    assert got_offset == offset
+  end
+
+  test "offset commit v3 and fetch v3", %{client: client} do
+    topic = "food"
+    consumer_group = "commit_v3_fetch_v3"
+    msg = TestHelper.generate_random_string()
+
+    {:ok, offset} =
+      KafkaEx.produce(
+        topic,
+        0,
+        msg,
+        worker_name: client,
+        required_acks: 1
+      )
+
+    [resp] =
+      KafkaEx.offset_commit(client, %OffsetCommit.Request{
+        consumer_group: consumer_group,
+        topic: topic,
+        partition: 0,
+        offset: offset,
+        api_version: 3
+      })
+
+    %OffsetCommit.Response{partitions: [%{error_code: :no_error}]} = resp
+
+    [resp] =
+      KafkaEx.offset_fetch(client, %OffsetFetch.Request{
+        topic: topic,
+        consumer_group: consumer_group,
+        partition: 0,
+        api_version: 3
+      })
+
+    %KafkaEx.Protocol.OffsetFetch.Response{
+      partitions: [
+        %{error_code: :no_error, offset: got_offset, partition: 0}
+      ]
+    } = resp
+
+    assert got_offset == offset
+  end
+end


### PR DESCRIPTION
I also made a small change in client.ex to allow the node_id node selector to work (and any other that can pass through straight to ClusterMetadata).

Also FWIW I found that if you commit to zookeeper (v0) and try to fetch the same consumer group from kafka (v > 0), you get `:topic_or_partition_not_found`.  If you commit to kafka (v > 0) and try to fetch from zookeeper, you get an offset of -1.  So people who have already been committing to zookeeper will need a migration plan.