### PR TITLE
Support setting api versions for consumer groups

### DIFF
--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -27,6 +27,17 @@ defmodule KafkaEx.ConsumerGroup do
   implements the `KafkaEx.GenConsumer` behaviour and start a
   `KafkaEx.ConsumerGroup` configured to use that module.
 
+  The api versions of some of the underlying messages can be specified in the
+  `:api_versions` option.  Note that these will be ignored (api version 0 used)
+  unless you have `kafka_version: "kayrock"` set in the KafkaEx application
+  config.  The following versions can be specified:
+
+  * `:fetch` - Fetch requests - use v2+ for newer versions of Kafka
+  * `:offset_fetch` - Offset fetch requests - use v1+ for offsets stored in
+    Kafka (as opposed to zookeeper)
+  * `:offset_commit` - Offset commit requests - use v1+ to store offsets in
+    Kafka (as opposed to zookeeper)
+
   ## Example
 
   Suppose we want to consume from a topic called `"example_topic"` with a

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -285,7 +285,10 @@ defmodule KafkaEx.ConsumerGroup.Manager do
                 "#{inspect(reason)}"
     end
 
-    Logger.debug(fn -> "Joined consumer group #{group_name}" end)
+    Logger.debug(fn ->
+      "Joined consumer group #{group_name} generation " <>
+        "#{join_response.generation_id} as #{join_response.member_id}"
+    end)
 
     new_state = %State{
       state
@@ -439,10 +442,19 @@ defmodule KafkaEx.ConsumerGroup.Manager do
            gen_consumer_module: gen_consumer_module,
            consumer_opts: consumer_opts,
            group_name: group_name,
+           member_id: member_id,
+           generation_id: generation_id,
            supervisor_pid: pid
          } = state,
          assignments
        ) do
+    # add member_id and generation_id to the consumer opts
+    consumer_opts =
+      Keyword.merge(consumer_opts,
+        generation_id: generation_id,
+        member_id: member_id
+      )
+
     {:ok, consumer_supervisor_pid} =
       ConsumerGroup.start_consumer(
         pid,

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -538,7 +538,7 @@ defmodule KafkaEx.GenConsumer do
     member_id = Keyword.get(opts, :member_id)
 
     default_api_versions = %{fetch: 0, offset_fetch: 0, offset_commit: 0}
-    api_versions = Keyword.get(opts, :api_versions)
+    api_versions = Keyword.get(opts, :api_versions, %{})
     api_versions = Map.merge(default_api_versions, api_versions)
 
     {:ok, consumer_state} =

--- a/lib/kafka_ex/new/adapter.ex
+++ b/lib/kafka_ex/new/adapter.ex
@@ -430,10 +430,8 @@ defmodule KafkaEx.New.Adapter do
 
           %{
             request
-            | # offset_commit_request.generation_id,
-              generation_id: -1,
-              # offset_commit_request.member_id,
-              member_id: "",
+            | generation_id: offset_commit_request.generation_id,
+              member_id: offset_commit_request.member_id,
               topics: [
                 %{
                   topic
@@ -445,7 +443,12 @@ defmodule KafkaEx.New.Adapter do
           }
 
         v when v >= 2 ->
-          %{request | generation_id: -1, member_id: "", retention_time: -1}
+          %{
+            request
+            | generation_id: offset_commit_request.generation_id,
+              member_id: offset_commit_request.member_id,
+              retention_time: -1
+          }
 
         _ ->
           request

--- a/test/integration/kayrock/compatibility_0_p_10_and_later_test.exs
+++ b/test/integration/kayrock/compatibility_0_p_10_and_later_test.exs
@@ -48,7 +48,7 @@ defmodule KafkaEx.KayrockCompatibility0p10AndLaterTest do
     resp = create_topic(name, [], client)
     assert {:no_error, name} == parse_create_topic_resp(resp)
 
-    {:ok, [_metadata]} = KafkaExAPI.topics_metadata(client, [name])
+    {:ok, _metadata} = KafkaExAPI.topics_metadata(client, [name])
 
     resp = KafkaEx.delete_topics([name], timeout: 5_000, worker_name: client)
     assert {:no_error, name} = parse_delete_topic_resp(resp)

--- a/test/integration/kayrock/compatibility_0_p_10_and_later_test.exs
+++ b/test/integration/kayrock/compatibility_0_p_10_and_later_test.exs
@@ -38,6 +38,11 @@ defmodule KafkaEx.KayrockCompatibility0p10AndLaterTest do
     resp = create_topic(name, config, client)
     assert {:topic_already_exists, name} == parse_create_topic_resp(resp)
 
+    TestHelper.wait_for(fn ->
+      {:ok, metadatas} = KafkaExAPI.topics_metadata(client, [name])
+      length(metadatas) > 0
+    end)
+
     {:ok, [metadata]} = KafkaExAPI.topics_metadata(client, [name])
     assert @num_partitions == length(metadata.partitions)
   end

--- a/test/integration/kayrock/timestamp_test.exs
+++ b/test/integration/kayrock/timestamp_test.exs
@@ -6,7 +6,6 @@ defmodule KafkaEx.KayrockTimestampTest do
   use ExUnit.Case
 
   alias KafkaEx.New.Client
-  alias KafkaEx.New.NodeSelector
   alias KafkaEx.TimestampNotSupportedError
 
   require Logger
@@ -19,45 +18,6 @@ defmodule KafkaEx.KayrockTimestampTest do
     {:ok, pid} = Client.start_link(args, :no_name)
 
     {:ok, %{client: pid}}
-  end
-
-  defp ensure_append_timestamp_topic(client) do
-    topic_name = "test_log_append_timestamp"
-
-    resp =
-      Client.send_request(
-        client,
-        %Kayrock.CreateTopics.V0.Request{
-          create_topic_requests: [
-            %{
-              topic: topic_name,
-              num_partitions: 4,
-              replication_factor: 1,
-              replica_assignment: [],
-              config_entries: [
-                %{
-                  config_name: "message.timestamp.type",
-                  config_value: "LogAppendTime"
-                }
-              ]
-            }
-          ],
-          timeout: 1000
-        },
-        NodeSelector.controller()
-      )
-
-    {:ok,
-     %Kayrock.CreateTopics.V0.Response{
-       topic_errors: [%{error_code: error_code}]
-     }} = resp
-
-    unless error_code in [0, 36] do
-      Logger.error("Unable to create topic #{topic_name}: #{inspect(resp)}")
-      assert false
-    end
-
-    topic_name
   end
 
   test "fetch timestamp is nil by default on v0 messages", %{client: client} do
@@ -151,7 +111,11 @@ defmodule KafkaEx.KayrockTimestampTest do
   end
 
   test "log with append time - v0", %{client: client} do
-    topic = ensure_append_timestamp_topic(client)
+    {:ok, topic} =
+      TestHelper.ensure_append_timestamp_topic(
+        client,
+        "test_log_append_timestamp"
+      )
 
     msg = TestHelper.generate_random_string()
 
@@ -182,7 +146,11 @@ defmodule KafkaEx.KayrockTimestampTest do
   end
 
   test "log with append time - v3", %{client: client} do
-    topic = ensure_append_timestamp_topic(client)
+    {:ok, topic} =
+      TestHelper.ensure_append_timestamp_topic(
+        client,
+        "test_log_append_timestamp"
+      )
 
     msg = TestHelper.generate_random_string()
 
@@ -214,7 +182,11 @@ defmodule KafkaEx.KayrockTimestampTest do
   end
 
   test "log with append time - v5", %{client: client} do
-    topic = ensure_append_timestamp_topic(client)
+    {:ok, topic} =
+      TestHelper.ensure_append_timestamp_topic(
+        client,
+        "test_log_append_timestamp"
+      )
 
     msg = TestHelper.generate_random_string()
 

--- a/test/integration/server0_p_10_and_later_test.exs
+++ b/test/integration/server0_p_10_and_later_test.exs
@@ -20,7 +20,9 @@ defmodule KafkaEx.Server0P10P1AndLater.Test do
     resp = create_topic(name, config)
     assert {:topic_already_exists, name} == parse_create_topic_resp(resp)
 
-    assert Enum.member?(existing_topics(), name)
+    wait_for(fn ->
+      Enum.member?(existing_topics(), name)
+    end)
 
     assert @num_partitions ==
              KafkaEx.Protocol.Metadata.Response.partitions_for_topic(


### PR DESCRIPTION
With `kafka_version: "kayrock"`, using `ConsumerGroup.start_link(...... api_versions: %{fetch: 3, offset_fetch: 3, offset_commit: 3})` will

* Use the modern record batch message format (including timestamps)
* Store offsets in zookeeper

Note I intentionally _did not_ make this configurable globally because I think that's probably not a good idea for users.  These settings should be considered on a consumer group basis.

I also snuck in a couple fixes for flakey tests.