### PR TITLE
Expose rebalance function

### DIFF
--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -231,7 +231,11 @@ defmodule KafkaEx.ConsumerGroup do
     call_manager(supervisor_pid, :am_leader, timeout)
   end
 
-  @spec rebalance(Supervisor.supervisor(), timeout) :: boolean
+  @doc """
+  Rebalance the consumer group partitions.
+  This is useful to update the partitions been consumed after partitioning changes.
+  """
+  @spec rebalance(Supervisor.supervisor(), timeout) :: :ok
   def rebalance(supervisor_pid, timeout \\ 5000) do
     call_manager(supervisor_pid, :rebalance, timeout)
   end

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -233,7 +233,7 @@ defmodule KafkaEx.ConsumerGroup do
 
   @spec rebalance(Supervisor.supervisor(), timeout) :: boolean
   def rebalance(supervisor_pid, timeout \\ 5000) do
-    call_manager(supervisor_pid, :relance, timeout)
+    call_manager(supervisor_pid, :rebalance, timeout)
   end
 
   @doc """

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -231,6 +231,11 @@ defmodule KafkaEx.ConsumerGroup do
     call_manager(supervisor_pid, :am_leader, timeout)
   end
 
+  @spec rebalance(Supervisor.supervisor(), timeout) :: boolean
+  def rebalance(supervisor_pid, timeout \\ 5000) do
+    call_manager(supervisor_pid, :relance, timeout)
+  end
+
   @doc """
   Returns a list of topic and partition assignments for which this consumer is
   responsible.

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -217,6 +217,10 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     {:stop, {:shutdown, {:error, reason}}, state}
   end
 
+  def handle_info({:EXIT, _from, :normal}, state) do
+    {:stop, :normal, state}
+  end
+
   # When terminating, inform the group coordinator that this member is leaving
   # the group so that the group can rebalance without waiting for a session
   # timeout.

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -181,6 +181,11 @@ defmodule KafkaEx.ConsumerGroup.Manager do
     {:reply, state.group_name, state}
   end
 
+  def handle_call(:rebalance, _from, state) do
+    {:ok, state} = rebalance(state)
+    {:reply, :ok, state}
+  end
+
   ######################################################################
 
   # If `member_id` and `generation_id` aren't set, we haven't yet joined the


### PR DESCRIPTION
### Motivation

Consumer groups do not rebalance automatically when partitioning changes, so we need a way to trigger this rebalance.

### Proposed solution

We already have a internal rebalance function, by exposing it to consumer group API we may be able to trigger a rebalance whenever we think is appropriate.

Right now, in my setup I have been using a genserver that periodically checks for the number of partitions of the given topic, if the number changes the rebalance is triggered so the consumers.

I may need some help with the unit tests for this function. Also, I don't know if this functions is going in the right direction, if that's so we may want to also include in the library itself a poller like the one I have been using, and trigger the rebalance automatically inside the library.

Related to #226 