### PR TITLE
Allow consumer group to retry join

### DIFF
--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -435,11 +435,14 @@ defmodule KafkaEx.New.Client do
           coordinator.node_id
         )
 
-      error ->
+      {:ok,
+       %Kayrock.FindCoordinator.V1.Response{
+         error_code: error_code
+       }} ->
         Logger.warn(
           "Unable to find consumer group coordinator for " <>
             "#{inspect(consumer_group)}: Error " <>
-            "#{Kayrock.ErrorCode.code_to_atom(error)}"
+            "#{Kayrock.ErrorCode.code_to_atom(error_code)}"
         )
 
         updated_state


### PR DESCRIPTION
When a worker tries to join a consumer group that doesn't exist, it
takes a few seconds for the cluster to create the consumer group.

@joshuawscott this should fix the error you were seeing.