### PR TITLE
Add `dwell_on_empty` option for GenConsumer

### DIFF
--- a/test/integration/consumer_group_implementation_test.exs
+++ b/test/integration/consumer_group_implementation_test.exs
@@ -141,6 +141,7 @@ defmodule KafkaEx.ConsumerGroupImplementationTest do
         [@topic_name],
         heartbeat_interval: 100,
         partition_assignment_callback: &TestPartitioner.assign_partitions/2,
+        dwell_on_empty: 10,
         session_timeout_padding: 30000
       )
 
@@ -151,6 +152,7 @@ defmodule KafkaEx.ConsumerGroupImplementationTest do
         [@topic_name],
         heartbeat_interval: 100,
         partition_assignment_callback: &TestPartitioner.assign_partitions/2,
+        dwell_on_empty: 10,
         session_timeout_padding: 30000
       )
 

--- a/test/integration/kayrock/compatibility_consumer_group_implementation_test.exs
+++ b/test/integration/kayrock/compatibility_consumer_group_implementation_test.exs
@@ -181,6 +181,7 @@ defmodule KafkaEx.KayrockCompatibilityConsumerGroupImplementationTest do
         heartbeat_interval: 100,
         partition_assignment_callback: &TestPartitioner.assign_partitions/2,
         session_timeout_padding: 30000,
+        dwell_on_empty: 10,
         api_versions: %{fetch: 3, offset_fetch: 3, offset_commit: 3}
       )
 
@@ -192,6 +193,7 @@ defmodule KafkaEx.KayrockCompatibilityConsumerGroupImplementationTest do
         heartbeat_interval: 100,
         partition_assignment_callback: &TestPartitioner.assign_partitions/2,
         session_timeout_padding: 30000,
+        dwell_on_empty: 10,
         api_versions: %{fetch: 3, offset_fetch: 3, offset_commit: 3}
       )
 


### PR DESCRIPTION
I noticed that I was getting timeouts when testing consumer groups
locally.  I think this is due to the test consumer overwhelming my test
kafka cluster (running in docker).  I noticed that when we handle an
empty message set, we immediately poll again for new messages.  This is
probably what many, if not most, users want but I can also see where it
could be an issue for some users.  I added an option for GenConsumer
(which is passed through by ConsumerGroup options) to specify a number
of milliseconds to dwell if we receive an empty message set.  The
default is zero, which is equivalent to the existing behavior.