### PR TITLE
Fix default partitioner for kayrock

### DIFF
--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -159,18 +159,10 @@ defmodule KafkaEx.New.Client do
   end
 
   def handle_call({:topic_metadata, topics, allow_topic_creation}, _from, state) do
-    allow_auto_topic_creation = state.allow_auto_topic_creation
+    {topic_metadata, updated_state} =
+      fetch_topics_metadata(state, topics, allow_topic_creation)
 
-    updated_state =
-      update_metadata(
-        %{state | allow_auto_topic_creation: allow_topic_creation},
-        topics
-      )
-
-    topic_metadata = State.topics_metadata(updated_state, topics)
-
-    {:reply, {:ok, topic_metadata},
-     %{updated_state | allow_auto_topic_creation: allow_auto_topic_creation}}
+    {:reply, {:ok, topic_metadata}, updated_state}
   end
 
   def handle_call({:kayrock_request, request, node_selector}, _from, state) do
@@ -678,5 +670,20 @@ defmodule KafkaEx.New.Client do
           System.stacktrace()
         )
     end
+  end
+
+  defp fetch_topics_metadata(state, topics, allow_topic_creation) do
+    allow_auto_topic_creation = state.allow_auto_topic_creation
+
+    updated_state =
+      update_metadata(
+        %{state | allow_auto_topic_creation: allow_topic_creation},
+        topics
+      )
+
+    topic_metadata = State.topics_metadata(updated_state, topics)
+
+    {topic_metadata,
+     %{updated_state | allow_auto_topic_creation: allow_auto_topic_creation}}
   end
 end

--- a/test/integration/kayrock/compatibility_test.exs
+++ b/test/integration/kayrock/compatibility_test.exs
@@ -617,4 +617,9 @@ defmodule KafkaEx.KayrockCompatibilityTest do
     KafkaEx.stream(random_string, 0, offset: 0, worker_name: client)
     KafkaEx.stream(random_string, 0, offset: 0, worker_name: client)
   end
+
+  test "produce with the default partitioner works", %{client: client} do
+    topic = TestHelper.generate_random_string()
+    :ok = KafkaEx.produce(topic, nil, "hello", worker_name: client)
+  end
 end


### PR DESCRIPTION
As reported on slack by @bartek - the default partitioner (really any
partitioner) needs to know how many partitions a topic has.  In the
Kayrock-based client, we don't automatically fetch metadata for every
topic.  So it becomes a problem if anyone tries to produce to a topic
that the client doesn't know about yet.

This should fix that by ensuring we have topic metadata for any topic
to which we produce.