### PR TITLE
Translate int size values into module attributes

### DIFF
--- a/lib/kafka_ex/protocol/common.ex
+++ b/lib/kafka_ex/protocol/common.ex
@@ -7,7 +7,7 @@ defmodule KafkaEx.Protocol.Common do
   @doc """
   Generate the wire representation for a list of topics.
   """
-  def topic_data([]), do: ""
+  def topic_data([]), do: <<>>
 
   def topic_data([topic | topics]) do
     <<byte_size(topic)::16-signed, topic::binary>> <> topic_data(topics)

--- a/test/protocol/delete_topics_test.exs
+++ b/test/protocol/delete_topics_test.exs
@@ -1,0 +1,35 @@
+defmodule KafkaEx.Protocol.DeleteTopicsTest do
+  use ExUnit.Case, async: true
+
+  describe "create_request/4" do
+    test "creates a request to delete a single topic" do
+      expected_request = <<20::16, 0::16, 999::32, 13::16, "the-client-id"::binary, 1::32-signed, 6::16, "topic1"::binary, 100::32-signed>>
+      delete_request = %KafkaEx.Protocol.DeleteTopics.Request{topics: ["topic1"], timeout: 100}
+
+      delete_response = KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 0)
+
+      assert expected_request == delete_response
+    end
+
+    test "creates a request to delete a multiple topic" do
+      expected_response = <<20::16, 0::16, 999::32, 13::16, "the-client-id"::binary, 3::32-signed, 6::16, "topic3"::binary, 6::16, "topic2"::binary, 6::16, "topic1"::binary, 100::32-signed>>
+
+      delete_request = %KafkaEx.Protocol.DeleteTopics.Request{topics: ["topic1", "topic2", "topic3"], timeout: 100}
+      delete_response = KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 0)
+
+      assert expected_response == delete_response
+    end
+
+    test "raise error when non-zero api_version is sent" do
+      delete_request = %KafkaEx.Protocol.DeleteTopics.Request{topics: ["topic1"], timeout: 100}
+
+      assert_raise FunctionClauseError,
+        "no function clause matching in KafkaEx.Protocol.DeleteTopics.create_request/4",
+        fn -> KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 1) end
+    end
+  end
+
+  describe "api_version/1" do
+
+  end
+end

--- a/test/protocol/delete_topics_test.exs
+++ b/test/protocol/delete_topics_test.exs
@@ -28,8 +28,4 @@ defmodule KafkaEx.Protocol.DeleteTopicsTest do
         fn -> KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 1) end
     end
   end
-
-  describe "api_version/1" do
-
-  end
 end


### PR DESCRIPTION
This commit aim to review possible uses of binary concatenation rather
than iolist concat that according with outcomes from issues #231 and #290
had proofed to be more efficient

In the end no other binary concat were found, but some small changes will
be proposed as follows:

1. Translate literal size values to meaningful module attributes
2. The `KafkaEx.Protocol.Common` module was returning a empty string instead of empty iolist on `topic_data([])` fun, there is not big improvements here but a normalization among protocol modules
3. Added missing test cases for ` KafkaEx.Protocol.DeleteTopics`