### PR TITLE
Don't always send update metadata requests to the same broker

### DIFF
--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -442,7 +442,9 @@ defmodule KafkaEx.New.Client do
   end
 
   defp first_broker_response(request, brokers, timeout) do
-    Enum.find_value(brokers, fn broker ->
+    brokers
+    |> Enum.shuffle()
+    |> Enum.find_value(brokers, fn broker ->
       if Broker.connected?(broker) do
         try_broker(broker, request, timeout)
       end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -974,7 +974,9 @@ defmodule KafkaEx.Server do
       end
 
       defp first_broker_response(request, brokers, timeout) do
-        Enum.find_value(brokers, fn broker ->
+        brokers
+        |> Enum.shuffle()
+        |> Enum.find_value(fn broker ->
           if Broker.connected?(broker) do
             # credo:disable-for-next-line Credo.Check.Refactor.Nesting
             case NetworkClient.send_sync_request(broker, request, timeout) do


### PR DESCRIPTION
We have been trying to use KafkEx with an app that generates high produce rates. 
At first we tried to use one KafkaEx worker (the default one) but found that a few moments after starting the app, produce requests start to timeout. One worker wasn't able to keep up with the rate of produce requests coming in, so its mailbox started to fill up.

So next we tried to use a pool of workers - one per topic and partition like Brod. The app was stable now but we noticed something odd with the brokers. One of the brokers always had significantly higher system load and network traffic (bytes out) than the other brokers. After investigating it was found that the extra load was coming from the periodic metadata update requests made by all the workers. 

For requests like fetching metadata and api_versions, KafkaEx will iterate through every broker that it knows about until it gets a successful response. It will normally try the brokers in the same sequence every time but the first one usually succeeds, so this first broker in the list gets an uneven amount of load. 

In this PR we randomize the broker list before sending any requests in order to spread the load of update metadata requests evenly across all brokers. 

Testing:
All tests passed locally. 
I manually tested the behaviour by logging the broker list in `first_broker_response()`
