### PR TITLE
Fix quota crash

### DIFF
--- a/lib/kafka_ex/new/adapter.ex
+++ b/lib/kafka_ex/new/adapter.ex
@@ -205,11 +205,10 @@ defmodule KafkaEx.New.Adapter do
      ], last_offset}
   end
 
-  def fetch_response(bad_response) do
+  def fetch_response(%{responses: []}) do
     Logger.log(
       :error,
-      "Not able to retrieve the last offset, the kafka server is probably throttling your requests, got response: " <>
-        inspect(bad_response)
+      "Not able to retrieve the last offset, the kafka server is probably throttling your requests"
     )
 
     {[], nil}

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -279,11 +279,10 @@ defmodule KafkaEx.Server0P8P2 do
             [%{partitions: [%{last_offset: last_offset} | _]} | _] ->
               last_offset
 
-            bad_response ->
+            [] ->
               Logger.log(
                 :error,
-                "Not able to retrieve the last offset, the kafka server is probably throttling your requests, got response: " <>
-                  inspect(bad_response)
+                "Not able to retrieve the last offset, the kafka server is probably throttling your requests"
               )
 
               nil


### PR DESCRIPTION
When quota is enabled in kafka and a client exceeds its quota, Kafka server can throttle the response. In FetchResponse superior to version 0, throttle time is specified and the client should throttle the request accordingly. Associated to the throttle time, the server will not serve any response, the  FetchResponse is then an empty array. The current code does not handle this situation properly, this PR fix the client so it does not crash however it does not handle the throttling time.

Fix #346