### PR TITLE
Increment attempt number instead of decrement when joining a consumer group

### DIFF
--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -281,7 +281,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
         on_successful_join(state, join_response)
 
       {:error, :no_broker} ->
-        if attempt_number == @max_join_retries do
+        if attempt_number >= @max_join_retries do
           raise "Unable to join consumer group #{state.group_name} after " <>
                   "#{@max_join_retries} attempts"
         end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -292,7 +292,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
         )
 
         :timer.sleep(1000)
-        join(state, attempt_number - 1)
+        join(state, attempt_number + 1)
 
       %{error_code: error_code} ->
         raise "Error joining consumer group #{group_name}: " <>


### PR DESCRIPTION
Two things this fixes:

1. The output of `Unable to join consumer group "consumer_group".  Will sleep 1 second and try again (attempt number x)` should be less confusing, as it would start to become a negative number.

2. `attempt_number` is used to raise an error when `@max_join_retries` is reached. This would never be reached when `attempt_number` is decrementing.