### PR TITLE
Use IO lists instead of binary concatenation for protocol requests

### DIFF
--- a/lib/kafka_ex/protocol/common.ex
+++ b/lib/kafka_ex/protocol/common.ex
@@ -7,10 +7,10 @@ defmodule KafkaEx.Protocol.Common do
   @doc """
   Generate the wire representation for a list of topics.
   """
-  def topic_data([]), do: <<>>
+  def topic_data([]), do: []
 
   def topic_data([topic | topics]) do
-    <<byte_size(topic)::16-signed, topic::binary>> <> topic_data(topics)
+    [<<byte_size(topic)::16-signed, topic::binary>> | topic_data(topics)]
   end
 
   def parse_topics(0, _, _), do: []

--- a/lib/kafka_ex/protocol/consumer_metadata.ex
+++ b/lib/kafka_ex/protocol/consumer_metadata.ex
@@ -35,11 +35,14 @@ defmodule KafkaEx.Protocol.ConsumerMetadata do
 
   @spec create_request(integer, binary, binary) :: binary
   def create_request(correlation_id, client_id, consumer_group) do
-    KafkaEx.Protocol.create_request(
-      :consumer_metadata,
-      correlation_id,
-      client_id
-    ) <> <<byte_size(consumer_group)::16-signed, consumer_group::binary>>
+    [
+      KafkaEx.Protocol.create_request(
+        :consumer_metadata,
+        correlation_id,
+        client_id
+      ),
+      <<byte_size(consumer_group)::16-signed, consumer_group::binary>>
+    ]
   end
 
   @spec parse_response(binary) :: Response.t()

--- a/lib/kafka_ex/protocol/delete_topics.ex
+++ b/lib/kafka_ex/protocol/delete_topics.ex
@@ -53,9 +53,11 @@ defmodule KafkaEx.Protocol.DeleteTopics do
       )
 
   def create_request(correlation_id, client_id, delete_topics_request, 0) do
-    Protocol.create_request(:delete_topics, correlation_id, client_id) <>
-      encode_topics(delete_topics_request.topics) <>
+    [
+      Protocol.create_request(:delete_topics, correlation_id, client_id),
+      encode_topics(delete_topics_request.topics),
       <<delete_topics_request.timeout::32-signed>>
+    ]
   end
 
   @spec encode_topics([String.t()]) :: binary

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -75,11 +75,12 @@ defmodule KafkaEx.Protocol.Fetch do
 
   @spec create_request(Request.t()) :: binary
   def create_request(fetch_request) do
-    KafkaEx.Protocol.create_request(
-      :fetch,
-      fetch_request.correlation_id,
-      fetch_request.client_id
-    ) <>
+    [
+      KafkaEx.Protocol.create_request(
+        :fetch,
+        fetch_request.correlation_id,
+        fetch_request.client_id
+      ),
       <<
         -1::32-signed,
         fetch_request.wait_time::32-signed,
@@ -92,6 +93,7 @@ defmodule KafkaEx.Protocol.Fetch do
         fetch_request.offset::64,
         fetch_request.max_bytes::32
       >>
+    ]
   end
 
   def parse_response(

--- a/lib/kafka_ex/protocol/heartbeat.ex
+++ b/lib/kafka_ex/protocol/heartbeat.ex
@@ -24,10 +24,12 @@ defmodule KafkaEx.Protocol.Heartbeat do
 
   @spec create_request(integer, binary, Request.t()) :: binary
   def create_request(correlation_id, client_id, request) do
-    KafkaEx.Protocol.create_request(:heartbeat, correlation_id, client_id) <>
+    [
+      KafkaEx.Protocol.create_request(:heartbeat, correlation_id, client_id),
       <<byte_size(request.group_name)::16-signed, request.group_name::binary,
         request.generation_id::32-signed,
         byte_size(request.member_id)::16-signed, request.member_id::binary>>
+    ]
   end
 
   @spec parse_response(binary) :: Response.t()

--- a/lib/kafka_ex/protocol/leave_group.ex
+++ b/lib/kafka_ex/protocol/leave_group.ex
@@ -21,9 +21,11 @@ defmodule KafkaEx.Protocol.LeaveGroup do
 
   @spec create_request(integer, binary, Request.t()) :: binary
   def create_request(correlation_id, client_id, request) do
-    KafkaEx.Protocol.create_request(:leave_group, correlation_id, client_id) <>
+    [
+      KafkaEx.Protocol.create_request(:leave_group, correlation_id, client_id),
       <<byte_size(request.group_name)::16-signed, request.group_name::binary,
         byte_size(request.member_id)::16-signed, request.member_id::binary>>
+    ]
   end
 
   def parse_response(<<_correlation_id::32-signed, error_code::16-signed>>) do

--- a/lib/kafka_ex/protocol/metadata.ex
+++ b/lib/kafka_ex/protocol/metadata.ex
@@ -159,12 +159,15 @@ defmodule KafkaEx.Protocol.Metadata do
   def create_request(correlation_id, client_id, "", api_version) do
     topic_count = if 0 == api_version, do: 0, else: -1
 
-    KafkaEx.Protocol.create_request(
-      :metadata,
-      correlation_id,
-      client_id,
-      api_version
-    ) <> <<topic_count::32-signed>>
+    [
+      KafkaEx.Protocol.create_request(
+        :metadata,
+        correlation_id,
+        client_id,
+        api_version
+      ),
+      <<topic_count::32-signed>>
+    ]
   end
 
   def create_request(correlation_id, client_id, topic, api_version)
@@ -174,12 +177,16 @@ defmodule KafkaEx.Protocol.Metadata do
 
   def create_request(correlation_id, client_id, topics, api_version)
       when is_list(topics) do
-    KafkaEx.Protocol.create_request(
-      :metadata,
-      correlation_id,
-      client_id,
-      api_version
-    ) <> <<length(topics)::32-signed, topic_data(topics)::binary>>
+    [
+      KafkaEx.Protocol.create_request(
+        :metadata,
+        correlation_id,
+        client_id,
+        api_version
+      ),
+      <<length(topics)::32-signed>>,
+      topic_data(topics)
+    ]
   end
 
   def parse_response(data), do: parse_response(data, @default_api_version)

--- a/lib/kafka_ex/protocol/offset.ex
+++ b/lib/kafka_ex/protocol/offset.ex
@@ -34,9 +34,11 @@ defmodule KafkaEx.Protocol.Offset do
   end
 
   def create_request(correlation_id, client_id, topic, partition, time) do
-    KafkaEx.Protocol.create_request(:offset, correlation_id, client_id) <>
+    [
+      KafkaEx.Protocol.create_request(:offset, correlation_id, client_id),
       <<-1::32-signed, 1::32-signed, byte_size(topic)::16-signed, topic::binary,
         1::32-signed, partition::32-signed, parse_time(time)::64, 1::32>>
+    ]
   end
 
   def parse_response(

--- a/lib/kafka_ex/protocol/offset_commit.ex
+++ b/lib/kafka_ex/protocol/offset_commit.ex
@@ -38,7 +38,8 @@ defmodule KafkaEx.Protocol.OffsetCommit do
 
   @spec create_request(integer, binary, Request.t()) :: binary
   def create_request(correlation_id, client_id, offset_commit_request) do
-    Protocol.create_request(:offset_commit, correlation_id, client_id) <>
+    [
+      Protocol.create_request(:offset_commit, correlation_id, client_id),
       <<byte_size(offset_commit_request.consumer_group)::16-signed,
         offset_commit_request.consumer_group::binary, 1::32-signed,
         byte_size(offset_commit_request.topic)::16-signed,
@@ -47,6 +48,7 @@ defmodule KafkaEx.Protocol.OffsetCommit do
         offset_commit_request.offset::64,
         byte_size(offset_commit_request.metadata)::16-signed,
         offset_commit_request.metadata::binary>>
+    ]
   end
 
   @spec parse_response(binary) :: [] | [Response.t()]

--- a/lib/kafka_ex/protocol/offset_fetch.ex
+++ b/lib/kafka_ex/protocol/offset_fetch.ex
@@ -48,12 +48,14 @@ defmodule KafkaEx.Protocol.OffsetFetch do
   end
 
   def create_request(correlation_id, client_id, offset_fetch_request) do
-    KafkaEx.Protocol.create_request(:offset_fetch, correlation_id, client_id) <>
+    [
+      KafkaEx.Protocol.create_request(:offset_fetch, correlation_id, client_id),
       <<byte_size(offset_fetch_request.consumer_group)::16-signed,
         offset_fetch_request.consumer_group::binary, 1::32-signed,
         byte_size(offset_fetch_request.topic)::16-signed,
         offset_fetch_request.topic::binary, 1::32-signed,
         offset_fetch_request.partition::32>>
+    ]
   end
 
   def parse_response(

--- a/lib/kafka_ex/protocol/sync_group.ex
+++ b/lib/kafka_ex/protocol/sync_group.ex
@@ -39,12 +39,14 @@ defmodule KafkaEx.Protocol.SyncGroup do
 
   @spec create_request(integer, binary, Request.t()) :: binary
   def create_request(correlation_id, client_id, %Request{} = request) do
-    KafkaEx.Protocol.create_request(:sync_group, correlation_id, client_id) <>
+    [
+      KafkaEx.Protocol.create_request(:sync_group, correlation_id, client_id),
       <<byte_size(request.group_name)::16-signed, request.group_name::binary,
         request.generation_id::32-signed,
         byte_size(request.member_id)::16-signed, request.member_id::binary,
         length(request.assignments)::32-signed,
         group_assignment_data(request.assignments, "")::binary>>
+    ]
   end
 
   @spec parse_response(binary) :: Response.t()

--- a/test/protocol/consumer_metadata_test.exs
+++ b/test/protocol/consumer_metadata_test.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.ConsumerMetadata.Test do
   test "create_request creates a valid consumer metadata request" do
     good_request = <<10::16, 0::16, 1::32, 3::16, "foo", 2::16, "we">>
     request = KafkaEx.Protocol.ConsumerMetadata.create_request(1, "foo", "we")
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response correctly parses a valid response" do

--- a/test/protocol/delete_topics_test.exs
+++ b/test/protocol/delete_topics_test.exs
@@ -8,7 +8,7 @@ defmodule KafkaEx.Protocol.DeleteTopicsTest do
 
       delete_response = KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 0)
 
-      assert expected_request == delete_response
+      assert expected_request == :erlang.iolist_to_binary(delete_response)
     end
 
     test "creates a request to delete a multiple topic" do
@@ -17,7 +17,7 @@ defmodule KafkaEx.Protocol.DeleteTopicsTest do
       delete_request = %KafkaEx.Protocol.DeleteTopics.Request{topics: ["topic1", "topic2", "topic3"], timeout: 100}
       delete_response = KafkaEx.Protocol.DeleteTopics.create_request(999, "the-client-id", delete_request, 0)
 
-      assert expected_response == delete_response
+      assert expected_response == :erlang.iolist_to_binary(delete_response)
     end
 
     test "raise error when non-zero api_version is sent" do

--- a/test/protocol/fetch_test.exs
+++ b/test/protocol/fetch_test.exs
@@ -19,7 +19,7 @@ defmodule KafkaEx.Protocol.Fetch.Test do
     }
 
     request = KafkaEx.Protocol.Fetch.create_request(fetch_request)
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response correctly parses a valid response with a key and a value" do

--- a/test/protocol/heartbeat_test.exs
+++ b/test/protocol/heartbeat_test.exs
@@ -31,7 +31,7 @@ defmodule KafkaEx.Protocol.Heartbeat.Test do
         heartbeat_request
       )
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse success response correctly" do

--- a/test/protocol/join_group_test.exs
+++ b/test/protocol/join_group_test.exs
@@ -48,7 +48,7 @@ defmodule KafkaEx.Protocol.JoinGroup.Test do
         session_timeout: 3600
       })
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse success response correctly" do

--- a/test/protocol/leave_group_test.exs
+++ b/test/protocol/leave_group_test.exs
@@ -25,7 +25,7 @@ defmodule KafkaEx.Protocol.LeaveGroup.Test do
     request =
       KafkaEx.Protocol.LeaveGroup.create_request(42, "client_id", leave_request)
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response parses successful response correctly" do

--- a/test/protocol/metadata_test.exs
+++ b/test/protocol/metadata_test.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Protocol.Metadata.Test do
   test "create_request with no topics creates a valid metadata request" do
     good_request = <<3::16, 0::16, 1::32, 3::16, "foo"::binary, 0::32>>
     request = KafkaEx.Protocol.Metadata.create_request(1, "foo", [])
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "create_request with a single topic creates a valid metadata request" do
@@ -12,7 +12,7 @@ defmodule KafkaEx.Protocol.Metadata.Test do
       <<3::16, 0::16, 1::32, 3::16, "foo"::binary, 1::32, 3::16, "bar"::binary>>
 
     request = KafkaEx.Protocol.Metadata.create_request(1, "foo", ["bar"])
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "create_request with a multiple topics creates a valid metadata request" do
@@ -23,7 +23,7 @@ defmodule KafkaEx.Protocol.Metadata.Test do
     request =
       KafkaEx.Protocol.Metadata.create_request(1, "foo", ["bar", "baz", "food"])
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response correctly parses a valid response" do

--- a/test/protocol/offset_commit_test.exs
+++ b/test/protocol/offset_commit_test.exs
@@ -24,7 +24,7 @@ defmodule KafkaEx.Protocol.OffsetCommit.Test do
         offset_commit_request
       )
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response correctly parses a valid response" do

--- a/test/protocol/offset_fetch_test.exs
+++ b/test/protocol/offset_fetch_test.exs
@@ -22,7 +22,7 @@ defmodule KafkaEx.Protocol.OffsetFetch.Test do
         offset_commit_request
       )
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse_response correctly parses a valid response" do

--- a/test/protocol/sync_group_test.exs
+++ b/test/protocol/sync_group_test.exs
@@ -77,7 +77,7 @@ defmodule KafkaEx.Protocol.SyncGroup.Test do
     request =
       KafkaEx.Protocol.SyncGroup.create_request(42, "client_id", sync_request)
 
-    assert request == good_request
+    assert :erlang.iolist_to_binary(request) == good_request
   end
 
   test "parse success response correctly" do


### PR DESCRIPTION
Fixes #291 

Seems like there still was some binary concatenation in the protocol modules as far as I could tell, so I followed up on the work done in #290 and made the request for all other protocol call return iolists instead of binaries as well.