### PR TITLE
Fix socket close error

### DIFF
--- a/lib/kafka_ex/new/broker.ex
+++ b/lib/kafka_ex/new/broker.ex
@@ -22,5 +22,5 @@ defmodule KafkaEx.New.Broker do
   end
 
   def has_socket?(%__MODULE__{socket: %Socket{socket: socket}}, socket), do: true
-  def has_socket?(_), do: false
+  def has_socket?(_, _), do: false
 end

--- a/lib/kafka_ex/new/broker.ex
+++ b/lib/kafka_ex/new/broker.ex
@@ -20,4 +20,7 @@ defmodule KafkaEx.New.Broker do
   def connected?(%__MODULE__{} = broker) do
     broker.socket != nil && Socket.open?(broker.socket)
   end
+
+  def has_socket?(%__MODULE__{socket: %Socket{socket: socket}}, socket), do: true
+  def has_socket?(_), do: false
 end

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -700,7 +700,7 @@ defmodule KafkaEx.New.Client do
 
   defp close_broker_by_socket(state, socket) do
     State.update_brokers(state, fn broker ->
-      if Broker.has_socket?(socket) do
+      if Broker.has_socket?(broker, socket) do
         Logger.log(
           :debug,
           "Broker #{inspect(broker.host)}:#{inspect(broker.port)} closed connection"

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -700,7 +700,7 @@ defmodule KafkaEx.New.Client do
 
   defp close_broker_by_socket(state, socket) do
     State.update_brokers(state, fn broker ->
-      if broker.socket.socket == socket do
+      if Broker.has_socket?(socket) do
         Logger.log(
           :debug,
           "Broker #{inspect(broker.host)}:#{inspect(broker.port)} closed connection"


### PR DESCRIPTION
I think I introduced this error in #406 -

```
** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function nil.socket/0 is undefined
            nil.socket()
            (kafka_ex) lib/kafka_ex/new/client.ex:703: anonymous fn/2 in KafkaEx.New.Client.close_broker_by_socket/2
            (kafka_ex) lib/kafka_ex/new/cluster_metadata.ex:228: anonymous fn/2 in KafkaEx.New.ClusterMetadata.update_brokers/2
            (elixir) lib/map.ex:216: Map.new_transform/3
            (kafka_ex) lib/kafka_ex/new/cluster_metadata.ex:227: KafkaEx.New.ClusterMetadata.update_brokers/2
            (kafka_ex) lib/kafka_ex/new/client/state.ex:76: KafkaEx.New.Client.State.update_brokers/2
            (kafka_ex) lib/kafka_ex/new/client.ex:184: KafkaEx.New.Client.handle_info/2
            (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
```