### PR TITLE
Do not update metadata cache on metadata call

### DIFF
--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -582,11 +582,7 @@ defmodule KafkaEx.Server do
             state.api_versions
           )
 
-        updated_state = %{
-          state
-          | metadata: metadata,
-            correlation_id: correlation_id
-        }
+        updated_state = %{state | correlation_id: correlation_id}
 
         {:reply, metadata, updated_state}
       end


### PR DESCRIPTION
The call to `metadata` can include a list of topics.  If it does, the
metadata we receive will include metadata only for the specified topics.

We don't want to replace our cache of all-topic metadata with a
topic-specific response.  We should leave the cache as-is.

A slightly more optimal way to do this would be to update the metadata
cache only if the metadata request did not specify any topics, but that
seems a bit more effort than it's worth.