### PR TITLE
Release 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ TL;DR:
 *   Version 1.0 of KafkaEx will be based on Kayrock and have a cleaner API - you
     can start testing this API by using modules from the `KafkaEx.New` namespace.
     See below for details.
+*   Version 0.11.0+ of KafkaEx is required to use Kayrock.
 
 To support some oft-requested features (offset storage in Kafka, message
 timestamps), we have integrated KafkaEx with
@@ -105,7 +106,7 @@ defmodule MyApp.Mixfile do
   defp deps do
     [
       # add to your existing deps
-      {:kafka_ex, "~> 0.10"},
+      {:kafka_ex, "~> 0.11"},
       # if using snappy compression
       {:snappy, git: "https://github.com/fdmanana/snappy-erlang-nif"}
     ]
@@ -114,28 +115,6 @@ end
 ```
 
 Then run `mix deps.get` to fetch dependencies.
-
-### Adding the kafka_ex application
-
-When using elixir < 1.4, you will need to add kafka_ex to the applications list of your mix.exs file.
-
-```elixir
-# mix.exs
-defmodule MyApp.Mixfile do
-  # ...
-
-  def application do
-    [
-      mod: {MyApp, []},
-      applications: [
-        # add to existing apps - :logger, etc..
-        :kafka_ex,
-        :snappy # if using snappy compression
-      ]
-    ]
-  end
-end
-```
 
 ## Configuration
 
@@ -457,8 +436,6 @@ mix test --include integration --include server_0_p_8_p_0
 ```
 
 ### Static analysis
-
-This requires Elixir 1.5+.
 
 ```
 mix dialyzer

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KafkaEx.Mixfile do
   def project do
     [
       app: :kafka_ex,
-      version: "0.10.0",
+      version: "0.11.0",
       elixir: "~> 1.5",
       dialyzer: [
         plt_add_deps: :transitive,

--- a/test/integration/kayrock/timestamp_test.exs
+++ b/test/integration/kayrock/timestamp_test.exs
@@ -111,7 +111,7 @@ defmodule KafkaEx.KayrockTimestampTest do
   test "log with append time - v0", %{client: client} do
     topic = "test_log_append_timestamp_#{:rand.uniform(2_000_000)}"
 
-    {:ok, topic} =
+    {:ok, ^topic} =
       TestHelper.ensure_append_timestamp_topic(
         client,
         topic
@@ -148,7 +148,7 @@ defmodule KafkaEx.KayrockTimestampTest do
   test "log with append time - v3", %{client: client} do
     topic = "test_log_append_timestamp_#{:rand.uniform(2_000_000)}"
 
-    {:ok, topic} =
+    {:ok, ^topic} =
       TestHelper.ensure_append_timestamp_topic(
         client,
         topic
@@ -186,7 +186,7 @@ defmodule KafkaEx.KayrockTimestampTest do
   test "log with append time - v5", %{client: client} do
     topic = "test_log_append_timestamp_#{:rand.uniform(2_000_000)}"
 
-    {:ok, topic} =
+    {:ok, ^topic} =
       TestHelper.ensure_append_timestamp_topic(
         client,
         topic

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -116,7 +116,7 @@ defmodule TestHelper do
        topic_errors: [%{error_code: error_code}]
      }} = resp
 
-     wait_for_topic_to_appear(client, topic_name)
+    wait_for_topic_to_appear(client, topic_name)
 
     if error_code in [0, 36] do
       {:ok, topic_name}
@@ -128,15 +128,20 @@ defmodule TestHelper do
 
   defp wait_for_topic_to_appear(_client, _topic_name, attempts \\ 10)
 
-  defp wait_for_topic_to_appear(_client, _topic_name, attempts) when attempts <= 0 do
+  defp wait_for_topic_to_appear(_client, _topic_name, attempts)
+       when attempts <= 0 do
     raise "Timeout while waiting for topic to appear"
   end
 
   defp wait_for_topic_to_appear(client, topic_name, attempts) do
     {:ok, %{topic_metadata: topic_metadata}} =
-      Client.send_request(client, %Kayrock.Metadata.V0.Request{}, NodeSelector.controller())
+      Client.send_request(
+        client,
+        %Kayrock.Metadata.V0.Request{},
+        NodeSelector.topic_partition(topic_name, 0)
+      )
 
-    topics = topic_metadata |> Enum.map(&(&1.topic))
+    topics = topic_metadata |> Enum.map(& &1.topic)
 
     unless topic_name in topics do
       wait_for_topic_to_appear(client, topic_name, attempts - 1)


### PR DESCRIPTION
I cleaned up a couple of things in the README that were out of date.

Proposed release notes follow.
--------------------------------

KafkaEx 0.11.0 is a large improvement to KafkaEx that sees the introduction of the Kayrock client, numerous stability fixes, and a critical fix that eliminates double-consuming messages when experiencing network failures under load.

# Breaking changes

* Drop support for Elixir < 1.5
* Partitioner has been fixed to match the behavior of the Java client. This will cause key assignment to differ. To keep the old behavior, use the KafkaEx.LegacyPartitioner module. (#399)

# Fixes

* Numerous fixes to error handling especially for networking connections (#347, #351 )
* Metadata is refreshed after topic create/delete(#349)
* Compression actually works for producing now 😬  (#362)
* Don't crash when throttled by quotas (#402)
* Default partitioner works the same way as the Java client now (#399)
* When fetching metadata for a subset of topics, don't remove the metadata for the unfetched topics. (#409)

# Improvements

* Any GenServer can be used as a KafkaEx.GenConsumer (#339)
* Can specify wait time before attempting reconnect (#347)
* KafkaEx.stream/3 now uses the KafkaEx.Server interface, which inherits the sync_timeout setting. This avoids timeouts when sync_timeout needs to be greater than default. (#354)
* KafkaEx can now use [Kayrock](https://github.com/dantswain/kayrock) as the client implementation. This is a large change, and is pushing toward the improvements we want in 1.0 to allow the library to easily support new versions of the Kafka protocol. (#356, #359, #364, #366, #367, #369, #370, #374, #375, #377, #379, #387,  #406, #408, )
* `KafkaEx.Protocol.Fetch.Message` includes the topic and partition, allowing consumers to know which topic and partition they consumed from.
* Add `KafkaEx.start_link_worker/1-2` to start a working and link it to the current process.
* Allow setting the client_id for the application - supports better monitoring, debugging, and quotas. (#388)
* Send metadata requests to a random broker rather than the same one each time (#395)
* Retry joining a consumer group 6 times rather than failing (#375, #403)

## Kayrock client

See [Kayrock and the Future of KafkaEx](https://github.com/kafkaex/kafka_ex#important---kayrock-and-the-future-of-kafkaex)

Note that the Kayrock implementation doesn't support Kafka < 0.11

Improvements over default client:
* Can specify message API versions for the `KafkaEx.stream/3` API
* Can specify message API versions for the consumer group API - NOTE that if you specify OffsetCommit API version >= 2, it will attempt to store the offsets in kafka, which will have no data about the topic unless you migrate the data. This could result in losing or reprocessing data. Migration can be done out of band, or can be done via the appropriate API calls within KafkaEx.
* Allow specifying OffsetCommit API version in KafkaEx.fetch

# Misc

* Test suite uses KafkaEx 0.11 now in preparation for fully supporting Kafka API versions.
* KafkaEx.Protocol.Produce cleaned up (#380) 
* Documentation improvements (#383, #384)
* Test against Elixir 1.9 (#394)
* Use OTP 22.3.3+ for OTP 22.2 testing to avoid SSL bug. (#405)

# Thanks
Thanks to @gerbal, @ukrbublik, @jbruggem, @thulio, @dantswain, @thiamsantos, @kennethito, @habutre, @davidrusu, @getong, @shamilish, @adrienmo, @mjparrott, @richardlarocque  for their contributions!