### PR TITLE
Use DynamicSupervisor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
       otp_release: 22.3.3
     - elixir: 1.6.6
       otp_release: 20.3
-    - elixir: 1.5.3
-      otp_release: 19.3
 services:
   - docker
 env:

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -89,9 +89,11 @@ defmodule KafkaEx do
   @spec create_worker(atom, KafkaEx.worker_init()) ::
           Supervisor.on_start_child()
   def create_worker(name, worker_init \\ []) do
+    server_impl = Config.server_impl()
+
     case build_worker_options(worker_init) do
       {:ok, worker_init} ->
-        KafkaEx.Supervisor.start_child([worker_init, name])
+        KafkaEx.Supervisor.start_child(server_impl, [worker_init, name])
 
       {:error, error} ->
         {:error, error}
@@ -707,7 +709,6 @@ defmodule KafkaEx do
 
     {:ok, pid} =
       KafkaEx.Supervisor.start_link(
-        Config.server_impl(),
         max_restarts,
         max_seconds
       )

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -366,7 +366,11 @@ defmodule KafkaEx.ConsumerGroup do
       )
     ]
 
-    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
+    Supervisor.init(children,
+      strategy: :one_for_all,
+      max_restarts: 0,
+      max_seconds: 1
+    )
   end
 
   defp call_manager(supervisor_pid, call, timeout) do

--- a/lib/kafka_ex/supervisor.ex
+++ b/lib/kafka_ex/supervisor.ex
@@ -1,35 +1,31 @@
 defmodule KafkaEx.Supervisor do
   @moduledoc false
 
-  use Supervisor
+  use DynamicSupervisor
 
-  def start_link(server, max_restarts, max_seconds) do
+  def start_link(max_restarts, max_seconds) do
     {:ok, pid} =
-      Supervisor.start_link(
+      DynamicSupervisor.start_link(
         __MODULE__,
-        [server, max_restarts, max_seconds],
+        [max_restarts, max_seconds],
         name: __MODULE__
       )
 
     {:ok, pid}
   end
 
-  def start_child(opts) do
-    Supervisor.start_child(__MODULE__, opts)
+  def start_child(impl, args) when is_atom(impl) and is_list(args) do
+    spec = %{id: impl, start: {impl, :start_link, args}}
+    DynamicSupervisor.start_child(__MODULE__, spec)
   end
 
   def stop_child(child) do
     Supervisor.terminate_child(__MODULE__, child)
   end
 
-  def init([server, max_restarts, max_seconds]) do
-    children = [
-      worker(server, [])
-    ]
-
-    supervise(
-      children,
-      strategy: :simple_one_for_one,
+  def init([max_restarts, max_seconds]) do
+    DynamicSupervisor.init(
+      strategy: :one_for_one,
       max_restarts: max_restarts,
       max_seconds: max_seconds
     )


### PR DESCRIPTION
I want to get Elixir 1.10 and 1.11 compatibility.  @jbruggem did a lot of good work in #400 but I think it sort of ended up being a big can of worms, so I'm trying to bite off smaller pieces of it.

This PR just addresses the warnings that `:simple_one_for_one` is deprecated and other related Supervisor warnings.

NOTE this removes Elixir 1.5 compatibility by using DynamicSupervisor.