### PR TITLE
Remove Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - elixir: 1.9.4
       otp_release: 22.3.3
-      env: COVERALLS=true CREDO=true
+      env: CREDO=true
     - elixir: 1.8.2
       otp_release: 22.3.3
     - elixir: 1.7.4
@@ -21,7 +21,6 @@ services:
   - docker
 env:
   global:
-    - COVERALLS=false
     - CREDO=false
 before_script:
   - ./scripts/docker_up.sh

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -19,13 +19,7 @@ then
   MIX_ENV=dev mix credo
 fi
 
-if [ "${COVERALLS}" = true ]
-then
-  echo "Coveralls will be reported"
-  TEST_COMMAND=coveralls.travis
-else
-  TEST_COMMAND=test
-fi
+TEST_COMMAND=test
 
 export TEST_COMMAND
 


### PR DESCRIPTION
We're not really paying attention to it and it causes spurrious test
failures

I left the coveralls dependency because it generates a nice coverage report locally and personally I do find that useful.