### PR TITLE
Fix deprecation warning about Supervisor.terminate_child with PID

### DIFF
--- a/lib/kafka_ex/supervisor.ex
+++ b/lib/kafka_ex/supervisor.ex
@@ -20,7 +20,7 @@ defmodule KafkaEx.Supervisor do
   end
 
   def stop_child(child) do
-    Supervisor.terminate_child(__MODULE__, child)
+    DynamicSupervisor.terminate_child(__MODULE__, child)
   end
 
   def init([max_restarts, max_seconds]) do


### PR DESCRIPTION
Hello!

When using KafkaEx with Elixir 1.11, this warning appears very frequently:

```
warning: Supervisor.terminate_child/2 with a PID is deprecated, please use DynamicSupervisor instead
  (elixir 1.11.2) lib/supervisor.ex:857: Supervisor.terminate_child/2
  (stdlib 3.14) gen_server.erl:727: :gen_server.try_terminate/3
  (stdlib 3.14) gen_server.erl:912: :gen_server.terminate/10
  (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

This PR removes those deprecation warnings by applying the fix suggested in the message.