### PR TITLE
CI retry failed tests only

### DIFF
--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -26,4 +26,4 @@ export TEST_COMMAND
 ALL_TESTS=${PROJECT_DIR}/scripts/all_tests.sh
 
 # Retry if it doesn't work the first time
-${ALL_TESTS} || ${ALL_TESTS}
+${ALL_TESTS} || ${ALL_TESTS} --failed


### PR DESCRIPTION
Tests fail randomly. Different tests could fail in both runs. Instead only run failed ones.