### PR TITLE
Doc: Auto offset reset config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -54,6 +54,12 @@ config :kafka_ex,
   # Threshold number of messages consumed for GenConsumer to commit offsets
   # to the broker.
   commit_threshold: 100,
+  # The policy for resetting offsets when an :offset_out_of_range error occurs
+  # Options:
+  # - `:earliest` - Will move to the offset to the oldest available
+  # - `:latest` - Will move the offset to the most recent.
+  # - `:none` - The error will simply be raised
+  auto_offset_reset: :none,
   # Interval in milliseconds to wait before reconnect to kafka
   sleep_for_reconnect: 400,
   # This is the flag that enables use of ssl

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -443,9 +443,9 @@ defmodule KafkaEx.GenConsumer do
     implemented, the default implementation calls to `init/2`, dropping the extra
     arguments.
 
-  Both `:commit_interval` and `:commit_threshold` default to the application
-  config (e.g., `Application.get_env/2`) if that value is present, or the
-  stated default if the application config is not present.
+  **NOTE** `:commit_interval`, `auto_commit_reset` and `:commit_threshold` default to the
+  application config (e.g., `Application.get_env/2`) if that value is present, or the stated
+  default if the application config is not present.
 
   Any valid options for `GenServer.start_link/3` can also be specified.
 


### PR DESCRIPTION
Just noticed from code that gen_consumer does read this value from
`Application.get_env`

- https://github.com/kafkaex/kafka_ex/pull/266/files#diff-9f53b507b041f2f34715479b07a51764495fd9c64b594578c25fe4a978eed017R400-R404

This adds information about how to set `auto_offset_reset` policy from
config