### PR TITLE
Update metadata before topic creation

### DIFF
--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -586,7 +586,11 @@ defmodule KafkaEx.Server do
             state.api_versions
           )
 
-        updated_state = %{state | correlation_id: correlation_id}
+          updated_state = %{
+            state
+            | metadata: metadata,
+              correlation_id: correlation_id
+          }
 
         {:reply, metadata, updated_state}
       end

--- a/lib/kafka_ex/server_0_p_10_and_later.ex
+++ b/lib/kafka_ex/server_0_p_10_and_later.ex
@@ -163,29 +163,6 @@ defmodule KafkaEx.Server0P10AndLater do
     {:ok, state}
   end
 
-  def kafka_server_metadata(topic, state) do
-    {correlation_id, metadata} =
-      retrieve_metadata(
-        state.brokers,
-        state.correlation_id,
-        config_sync_timeout(),
-        topic,
-        state.api_versions
-      )
-
-    updated_state = %{
-      state
-      | metadata: metadata,
-        correlation_id: correlation_id
-    }
-
-    {:reply, metadata, updated_state}
-  end
-
-  def kafka_server_update_metadata(state) do
-    {:noreply, update_metadata(state)}
-  end
-
   def kafka_server_api_versions(state) do
     response =
       state.correlation_id


### PR DESCRIPTION
We have infrequently gotten in production the following errors while trying to create a topic:

```
(MatchError) no match of right hand side value: {:error, :not_controller}
```

From reading the code of KafkaEx, it seems to me that this could possibly happen if we haven't updated the metadata in a while. It's hard to confirm, but it seems coherent with what I've read from the code and what we experienced.

In this PR, I propose to systematically update the metadata before selecting the controller broker to create the topic.

Additionally, for older versions of Kafka we didn't update our metadata in the state when we fetched metadata for the user in `kafka_server_metadata`. I changed that.