### PR TITLE
FIX: Partition assignment when topic doesn't exist

### DIFF
--- a/lib/kafka_ex/default_partitioner.ex
+++ b/lib/kafka_ex/default_partitioner.ex
@@ -70,10 +70,19 @@ defmodule KafkaEx.DefaultPartitioner do
        ) do
     hash = Murmur.umurmur2(key)
 
-    partitions_count =
-      metadata |> MetadataResponse.partitions_for_topic(topic) |> length()
+    partitions = metadata |> MetadataResponse.partitions_for_topic(topic)
 
-    partition_id = rem(hash, partitions_count)
+    partition_id =
+      case partitions do
+        # Topic doesn't exist yet, no partitions
+        [] ->
+          0
+
+        xs ->
+          partitions_count = xs |> length()
+          rem(hash, partitions_count)
+      end
+
     %{request | partition: partition_id}
   end
 end

--- a/test/kafka_ex/default_partitioner_test.exs
+++ b/test/kafka_ex/default_partitioner_test.exs
@@ -54,6 +54,18 @@ defmodule KafkaEx.DefaultPartitionerTest do
     assert partition >= 0 and partition < 5
   end
 
+  test "key based assignment when topic does not exist yet" do
+    request = %ProduceRequest{
+      topic: "other_topic",
+      partition: nil,
+      messages: [
+        %ProduceMessage{key: "key", value: "message"}
+      ]
+    }
+
+    %{partition: 0} = DefaultPartitioner.assign_partition(request, metadata(0))
+  end
+
   test "key based assignment" do
     request = %ProduceRequest{
       topic: "test_topic",


### PR DESCRIPTION
Fixes an issue when having a key and the topic does not exist.
Previously this would cause the genserver to terminate:

mfa=:gen_server.error_info/7 [error] GenServer :greeks_worker_4 terminating
** (ArithmeticError) bad argument in arithmetic expression
    :erlang.rem(2111275913, 0)
    (kafka_ex 0.12.1) lib/workers/greeks/greek_server.ex:418: KafkaEx.DefaultPartitioner.assign_partition_with_key/3
    (kafka_ex 0.12.1) lib/kafka_ex/server.ex:400: KafkaEx.Server0P10AndLater.kafka_server_produce/2
    (stdlib 3.17) gen_server.erl:721: :gen_server.try_handle_call/4
    (stdlib 3.17) gen_server.erl:750: :gen_server.handle_msg/6
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3