### PR TITLE
Use full versions for OTP & Elixir in static checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,8 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       matrix:
-        elixir: ['1.12']
-        otp: ['24.3']
+        elixir: ['1.12.3']
+        otp: ['24.3.4']
 
     steps:
         - name: Cancel previous runs
@@ -64,8 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.12']
-        otp: ['24.3']
+        elixir: ['1.12.3']
+        otp: ['24.3.4']
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
As we are using caching to build PLT, and cache key relay on OTP & Elixir version we have to use full versions there.