### PR TITLE
Fix compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ doc
 
 .elixir_ls
 cover
+
+# Dialyzer's Persistent Lookup Table
+priv/plts/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ KafkaEx
 [![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](http://hexdocs.pm/kafka_ex/)
 
 KafkaEx is an Elixir client for [Apache Kafka](http://kafka.apache.org/) with
-support for Kafka versions 0.8.0 and newer.  KafkaEx requires Elixir 1.5+ and
+support for Kafka versions 0.8.0 and newer. KafkaEx requires Elixir 1.6+ and
 Erlang OTP 19+.
 
 See [http://hexdocs.pm/kafka_ex/](http://hexdocs.pm/kafka_ex/) for
@@ -18,7 +18,7 @@ documentation,
  [https://github.com/kafkaex/kafka_ex/](https://github.com/kafkaex/kafka_ex/)
  for code.
 
-KakfaEx supports the following Kafka features:
+KafkaEx supports the following Kafka features:
 
 *   Broker and Topic Metadata
 *   Produce Messages

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -297,11 +297,9 @@ defmodule KafkaEx.ConsumerGroup do
   def active?(supervisor_pid, timeout \\ 5000) do
     consumer_supervisor = consumer_supervisor_pid(supervisor_pid, timeout)
 
-    if consumer_supervisor && Process.alive?(consumer_supervisor) do
+    consumer_supervisor &&
+      Process.alive?(consumer_supervisor) &&
       GenConsumer.Supervisor.active?(consumer_supervisor)
-    else
-      false
-    end
   end
 
   @doc """

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -334,9 +334,17 @@ defmodule KafkaEx.ConsumerGroup do
         opts
       ) do
     child =
-      supervisor(
-        KafkaEx.GenConsumer.Supervisor,
-        [{gen_consumer_module, consumer_module}, group_name, assignments, opts],
+      Supervisor.child_spec(
+        {
+          KafkaEx.GenConsumer.Supervisor,
+          %{
+            gen_consumer_module: gen_consumer_module,
+            consumer_module: consumer_module,
+            group_name: group_name,
+            assignments: assignments,
+            opts: opts
+          }
+        },
         id: :consumer
       )
 

--- a/lib/kafka_ex/consumer_group.ex
+++ b/lib/kafka_ex/consumer_group.ex
@@ -363,10 +363,8 @@ defmodule KafkaEx.ConsumerGroup do
     opts = Keyword.put(opts, :supervisor_pid, self())
 
     children = [
-      worker(
-        KafkaEx.ConsumerGroup.Manager,
-        [{gen_consumer_module, consumer_module}, group_name, topics, opts]
-      )
+      {KafkaEx.ConsumerGroup.Manager,
+       {{gen_consumer_module, consumer_module}, group_name, topics, opts}}
     ]
 
     Supervisor.init(children,

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -53,18 +53,18 @@ defmodule KafkaEx.ConsumerGroup.Manager do
 
   @doc false
   # use `KafkaEx.ConsumerGroup.start_link/4` instead
-  @spec start_link(
+  @spec start_link({
           {module, module},
           binary,
           [binary],
           KafkaEx.GenConsumer.options()
-        ) :: GenServer.on_start()
-  def start_link(
+        }) :: GenServer.on_start()
+  def start_link({
         {gen_consumer_module, consumer_module},
         group_name,
         topics,
-        opts \\ []
-      ) do
+        opts
+      }) do
     gen_server_opts = Keyword.get(opts, :gen_server_opts, [])
     consumer_opts = Keyword.drop(opts, [:gen_server_opts])
 


### PR DESCRIPTION
The usage of `child_spec/1` addresses #390. 