### PR TITLE
[Kayrock Part 0] Bump elixir to 1.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       matrix:
         pair:
+          - elixir: 1.14
+            otp: 25.2
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
+            otp: 22.3
+          - elixir: 1.8
             otp: 21.3
-          - elixir: 1.6
-            otp: 20.3
 
     steps:
       - name: Cancel previous runs
@@ -72,12 +74,14 @@ jobs:
       fail-fast: false
       matrix:
         pair:
+          - elixir: 1.14
+            otp: 25.2
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
+            otp: 22.3
+          - elixir: 1.8
             otp: 21.3
-          - elixir: 1.6
-            otp: 20.3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
-            otp: 23.3
+            otp: 21.3
           - elixir: 1.8
-            otp: 22.3
+            otp: 20.3
 
     steps:
       - name: Cancel previous runs
@@ -79,9 +79,9 @@ jobs:
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
-            otp: 23.3
+            otp: 21.3
           - elixir: 1.8
-            otp: 22.3
+            otp: 20.3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
-            otp: 22.3
+            otp: 23.3
           - elixir: 1.8
-            otp: 21.3
+            otp: 22.3
 
     steps:
       - name: Cancel previous runs
@@ -79,9 +79,9 @@ jobs:
           - elixir: 1.13
             otp: 24.3
           - elixir: 1.11
-            otp: 22.3
+            otp: 23.3
           - elixir: 1.8
-            otp: 21.3
+            otp: 22.3
 
     steps:
       - uses: actions/checkout@v2

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule KafkaEx.Mixfile do
     [
       app: :kafka_ex,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.8",
       dialyzer: [
         plt_add_deps: :transitive,
         plt_add_apps: [:ssl],
@@ -52,18 +52,11 @@ defmodule KafkaEx.Mixfile do
       {:credo, "~> 1.1", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.7", only: :test, runtime: false},
+      {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:snappy,
        git: "https://github.com/fdmanana/snappy-erlang-nif", only: [:dev, :test]},
       {:snappyer, "~> 1.2", only: [:dev, :test]}
     ]
-
-    # we need a newer version of ex_doc, but it will cause problems on older
-    # versions of elixir
-    if Version.match?(System.version(), ">= 1.7.0") do
-      main_deps ++ [{:ex_doc, "~> 0.23", only: :dev, runtime: false}]
-    else
-      main_deps
-    end
   end
 
   defp description do


### PR DESCRIPTION
## Overview
The current elixir version is 1.14. Soon probably, 1.15 will be released. There are many breaking changes, deprecation warnings & compile issues between different versions. On our road to `v1.0.0`. We will have to fight with all of them. 
Let's bump the version to elixir v1.8.x which will allow us to solve deps & compile warnings, then we can bump higher if we want to. 