### PR TITLE
Add telemetry for offset lag

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule KafkaEx.Mixfile do
   defp deps do
     main_deps = [
       {:kayrock, "~> 0.1.12"},
+      {:telemetry, "~> 1.0"},
       {:credo, "~> 1.1", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.7", only: :test, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,7 @@
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "e8907ee8e37cfa07d933a070669a88798082c3d7", []},
   "snappyer": {:hex, :snappyer, "1.2.8", "201ce9067a33c71a6a5087c0c3a49a010b17112d461e6df696c722dcb6d0934a", [:rebar3], [], "hexpm", "35518e79a28548b56d8fd6aee2f565f12f51c2d3d053f9cfa817c83be88c4f3d"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
   "varint": {:hex, :varint, "1.2.0", "61bffd9dcc2d5242d59f75694506b4d4013bb103f6a23e34b94f89cebb0c1ab3", [:mix], [], "hexpm", "d94941ed8b9d1a5fdede9103a5e52035bd0aaf35081d44e67713a36799927e47"},
 }


### PR DESCRIPTION
### What is the goal? how is it being implemented?

Open a PR to gather feedback about a feature that our team needs.

We are interested in the metrics from the point of view of the application about the status of the offsets of a topic and partition.

Our motivation is to have apart from visibility, alerts on this metric.

These metrics can be gathered from the broker, but there is no way to extend them with proper application context information, and for our use case it would be nice.

Please, I didn't write the test yet or the readme because I'm not sure if you will accept PRs like this (I saw no telemetry in the project, and maybe is there a reason for it) and also the approach itself, maybe due my lack of knowledge on the library I wrote the code in the wrong place.

Thanks!
