### PR TITLE
Clean warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :kafka_ex,
   # A list of brokers to connect to. This can be in either of the following formats

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -649,7 +649,7 @@ defmodule KafkaEx do
          topic,
          worker_name,
          api_version,
-         consumer_group \\ nil
+         consumer_group
        )
 
   defp current_offset(

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -66,7 +66,7 @@ defmodule KafkaEx.Config do
       case line |> trim() |> String.split(":") do
         [host] ->
           msg = "Port not set for Kafka broker #{host}"
-          Logger.warn(msg)
+          Logger.warning(msg)
           raise msg
 
         [host, port] ->
@@ -102,7 +102,7 @@ defmodule KafkaEx.Config do
   #   (this is not a fatal error and can occur if one disables ssl in the
   #    default option set)
   defp ssl_options(false, options) do
-    Logger.warn(
+    Logger.warning(
       "Ignoring ssl_options #{inspect(options)} because " <>
         "use_ssl is false.  If you do not intend to use ssl and want to " <>
         "remove this warning, set `ssl_options: []` in the KafkaEx config."

--- a/lib/kafka_ex/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer_group/heartbeat.ex
@@ -78,11 +78,11 @@ defmodule KafkaEx.ConsumerGroup.Heartbeat do
         {:stop, {:shutdown, :rebalance}, state}
 
       %HeartbeatResponse{error_code: error_code} ->
-        Logger.warn("Heartbeat failed, got error code #{error_code}")
+        Logger.warning("Heartbeat failed, got error code #{error_code}")
         {:stop, {:shutdown, {:error, error_code}}, state}
 
       {:error, reason} ->
-        Logger.warn("Heartbeat failed, got error reason #{inspect(reason)}")
+        Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")
         {:stop, {:shutdown, {:error, reason}}, state}
     end
   end

--- a/lib/kafka_ex/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer_group/manager.ex
@@ -285,7 +285,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
                   "#{@max_join_retries} attempts"
         end
 
-        Logger.warn(
+        Logger.warning(
           "Unable to join consumer group #{inspect(group_name)}.  " <>
             "Will sleep 1 second and try again (attempt number #{attempt_number})"
         )
@@ -402,13 +402,13 @@ defmodule KafkaEx.ConsumerGroup.Manager do
         Logger.debug(fn -> "Left consumer group #{group_name}" end)
 
       %{error_code: error_code} ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           "Received error #{inspect(error_code)}, " <>
             "consumer group manager will exit regardless."
         end)
 
       {:error, reason} ->
-        Logger.warn(fn ->
+        Logger.warning(fn ->
           "Received error #{inspect(reason)}, " <>
             "consumer group manager will exit regardless."
         end)
@@ -523,7 +523,7 @@ defmodule KafkaEx.ConsumerGroup.Manager do
   end
 
   defp warn_if_no_partitions([], group_name, topic) do
-    Logger.warn(fn ->
+    Logger.warning(fn ->
       "Consumer group #{group_name} encountered nonexistent topic #{topic}"
     end)
   end

--- a/lib/kafka_ex/default_partitioner.ex
+++ b/lib/kafka_ex/default_partitioner.ex
@@ -33,7 +33,7 @@ defmodule KafkaEx.DefaultPartitioner do
         assign_partition_with_key(request, metadata, key)
 
       {:error, reason} ->
-        Logger.warn("#{__MODULE__}: couldn't assign partition due to #{inspect(reason)}")
+        Logger.warning("#{__MODULE__}: couldn't assign partition due to #{inspect(reason)}")
 
         assign_partition_randomly(request, metadata)
     end

--- a/lib/kafka_ex/legacy_partitioner.ex
+++ b/lib/kafka_ex/legacy_partitioner.ex
@@ -34,7 +34,7 @@ defmodule KafkaEx.LegacyPartitioner do
         assign_partition_with_key(request, metadata, key)
 
       {:error, reason} ->
-        Logger.warn("#{__MODULE__}: couldn't assign partition due to #{inspect(reason)}")
+        Logger.warning("#{__MODULE__}: couldn't assign partition due to #{inspect(reason)}")
 
         assign_partition_randomly(request, metadata)
     end

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -123,7 +123,7 @@ defmodule KafkaEx.New.Client do
       rescue
         e ->
           sleep_for_reconnect()
-          Kernel.reraise(e, System.stacktrace())
+          Kernel.reraise(e, __STACKTRACE__)
       end
 
     {:ok, _} = :timer.send_interval(state.metadata_update_interval, :update_metadata)
@@ -435,7 +435,7 @@ defmodule KafkaEx.New.Client do
        %Kayrock.FindCoordinator.V1.Response{
          error_code: error_code
        }} ->
-        Logger.warn(
+        Logger.warning(
           "Unable to find consumer group coordinator for " <>
             "#{inspect(consumer_group)}: Error " <>
             "#{Kayrock.ErrorCode.code_to_atom(error_code)}"
@@ -458,7 +458,7 @@ defmodule KafkaEx.New.Client do
   defp try_broker(broker, request, timeout) do
     case NetworkClient.send_sync_request(broker, request, timeout) do
       {:error, error} ->
-        Logger.warn("Network call resulted in error: #{inspect(error)}")
+        Logger.warning("Network call resulted in error: #{inspect(error)}")
         nil
 
       response ->
@@ -672,7 +672,7 @@ defmodule KafkaEx.New.Client do
         Kernel.reraise(
           "Parse error during #{inspect(request)} response deserializer. " <>
             "Couldn't parse: #{inspect(data)}",
-          System.stacktrace()
+          __STACKTRACE__
         )
     end
   end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -767,7 +767,7 @@ defmodule KafkaEx.Server do
           rescue
             e ->
               sleep_for_reconnect()
-              Kernel.reraise(e, System.stacktrace())
+              Kernel.reraise(e, __STACKTRACE__)
           end
 
         state = %State{
@@ -885,7 +885,7 @@ defmodule KafkaEx.Server do
 
                       Kernel.reraise(
                         "Parse error during #{inspect(module)}.parse_response. Couldn't parse: #{inspect(response)}",
-                        System.stacktrace()
+                        __STACKTRACE__
                       )
                   end
               end

--- a/lib/kafka_ex/server_0_p_10_and_later.ex
+++ b/lib/kafka_ex/server_0_p_10_and_later.ex
@@ -122,7 +122,7 @@ defmodule KafkaEx.Server0P10AndLater do
       rescue
         e ->
           sleep_for_reconnect()
-          Kernel.reraise(e, System.stacktrace())
+          Kernel.reraise(e, __STACKTRACE__)
       end
 
     state = %State{

--- a/lib/kafka_ex/server_0_p_8_p_0.ex
+++ b/lib/kafka_ex/server_0_p_8_p_0.ex
@@ -29,7 +29,7 @@ defmodule KafkaEx.Server0P8P0 do
   def kafka_server_init([args, name]) do
     # warn if ssl is configured
     if Keyword.get(args, :use_ssl) do
-      Logger.warn(fn ->
+      Logger.warning(fn ->
         "KafkaEx is being configured to use ssl with a broker version that " <>
           "does not support ssl"
       end)

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -81,7 +81,7 @@ defmodule KafkaEx.Server0P8P2 do
       rescue
         e ->
           sleep_for_reconnect()
-          Kernel.reraise(e, System.stacktrace())
+          Kernel.reraise(e, __STACKTRACE__)
       end
 
     state = %State{

--- a/lib/kafka_ex/server_0_p_9_p_0.ex
+++ b/lib/kafka_ex/server_0_p_9_p_0.ex
@@ -107,7 +107,7 @@ defmodule KafkaEx.Server0P9P0 do
       rescue
         e ->
           sleep_for_reconnect()
-          Kernel.reraise(e, System.stacktrace())
+          Kernel.reraise(e, __STACKTRACE__)
       end
 
     state = %State{

--- a/lib/kafka_ex/utils/murmur.ex
+++ b/lib/kafka_ex/utils/murmur.ex
@@ -3,7 +3,7 @@ defmodule KafkaEx.Utils.Murmur do
   Utility module that provides Murmur hashing algorithm.
   """
 
-  use Bitwise
+  import Bitwise
 
   # Arbitrary constant for murmur2 hashing
   # https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp#L39-L43

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule KafkaEx.Mixfile do
   def application do
     [
       mod: {KafkaEx, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :ssl]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "ordinal": {:hex, :ordinal, "0.2.0", "d3eda0cb04ee1f0ca0aae37bf2cf56c28adce345fe56a75659031b6068275191", [:mix], [], "hexpm", "defca8f10dee9f03a090ed929a595303252700a9a73096b6f2f8d88341690d65"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "e8907ee8e37cfa07d933a070669a88798082c3d7", []},
-  "snappyer": {:hex, :snappyer, "1.2.9", "9cc58470798648ce34c662ca0aa6daae31367667714c9a543384430a3586e5d3", [:rebar3], [], "hexpm", "18d00ca218ae613416e6eecafe1078db86342a66f86277bd45c95f05bf1c8b29"},
+  "snappyer": {:hex, :snappyer, "1.2.8", "201ce9067a33c71a6a5087c0c3a49a010b17112d461e6df696c722dcb6d0934a", [:rebar3], [], "hexpm", "35518e79a28548b56d8fd6aee2f565f12f51c2d3d053f9cfa817c83be88c4f3d"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "ordinal": {:hex, :ordinal, "0.2.0", "d3eda0cb04ee1f0ca0aae37bf2cf56c28adce345fe56a75659031b6068275191", [:mix], [], "hexpm", "defca8f10dee9f03a090ed929a595303252700a9a73096b6f2f8d88341690d65"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif", "e8907ee8e37cfa07d933a070669a88798082c3d7", []},
-  "snappyer": {:hex, :snappyer, "1.2.8", "201ce9067a33c71a6a5087c0c3a49a010b17112d461e6df696c722dcb6d0934a", [:rebar3], [], "hexpm", "35518e79a28548b56d8fd6aee2f565f12f51c2d3d053f9cfa817c83be88c4f3d"},
+  "snappyer": {:hex, :snappyer, "1.2.9", "9cc58470798648ce34c662ca0aa6daae31367667714c9a543384430a3586e5d3", [:rebar3], [], "hexpm", "18d00ca218ae613416e6eecafe1078db86342a66f86277bd45c95f05bf1c8b29"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},


### PR DESCRIPTION
* `use Mix.Config` is deprecated in favor of `import Config`
* `Logger.warn` is deprecated in favor of `Logger.warning`
* `current_offset/6` defined a default param but `current_offset/5` was never called
* `System.stacktrace()` is deprecated in favor of `__STACKTRACE__`
* if `ssl` is to be used, it needs to be in the `extra_applications` to ensure being started. Some dep probably started it so it was never a problem