### PR TITLE
[T] Add fetch/produce/commit events

### DIFF
--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -47,6 +47,56 @@ defmodule KafkaEx.Telemetry do
   * `[:kafka_ex, :connection, :exception]` - Emitted when connection fails with exception
     * Measurements: `%{duration: integer()}`
     * Metadata: Start metadata plus `%{kind: atom(), reason: term(), stacktrace: list()}`
+
+  ### Produce Events
+
+  * `[:kafka_ex, :produce, :start]` - Emitted when a produce operation begins
+    * Measurements: `%{system_time: integer(), message_count: integer()}`
+    * Metadata: `%{topic: binary(), partition: integer(), client_id: binary(), required_acks: integer()}`
+
+  * `[:kafka_ex, :produce, :stop]` - Emitted when a produce operation completes
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Same as start event plus `%{result: :ok | :error, offset: integer(), error: term()}`
+      * `result` - `:ok` on success, `:error` on failure
+      * `offset` - Base offset (only on success when acks > 0)
+      * `error` - Error reason (only on failure)
+
+  * `[:kafka_ex, :produce, :exception]` - Emitted when a produce operation fails
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Start metadata plus `%{kind: atom(), reason: term(), stacktrace: list()}`
+
+  ### Fetch Events
+
+  * `[:kafka_ex, :fetch, :start]` - Emitted when a fetch operation begins
+    * Measurements: `%{system_time: integer()}`
+    * Metadata: `%{topic: binary(), partition: integer(), offset: integer(), client_id: binary()}`
+
+  * `[:kafka_ex, :fetch, :stop]` - Emitted when a fetch operation completes
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Same as start event plus `%{result: :ok | :error, message_count: integer(), error: term()}`
+      * `result` - `:ok` on success, `:error` on failure
+      * `message_count` - Number of messages fetched (only on success)
+      * `error` - Error reason (only on failure)
+
+  * `[:kafka_ex, :fetch, :exception]` - Emitted when a fetch operation fails
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Start metadata plus `%{kind: atom(), reason: term(), stacktrace: list()}`
+
+  ### Consumer Events
+
+  * `[:kafka_ex, :consumer, :commit, :start]` - Emitted when an offset commit begins
+    * Measurements: `%{system_time: integer()}`
+    * Metadata: `%{group_id: binary(), client_id: binary(), topic: binary(), partition_count: integer()}`
+
+  * `[:kafka_ex, :consumer, :commit, :stop]` - Emitted when an offset commit completes
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Same as start event plus `%{result: :ok | :error, error: term()}`
+      * `result` - `:ok` on success, `:error` on failure
+      * `error` - Error reason (only on failure)
+
+  * `[:kafka_ex, :consumer, :commit, :exception]` - Emitted when an offset commit fails
+    * Measurements: `%{duration: integer()}`
+    * Metadata: Start metadata plus `%{kind: atom(), reason: term(), stacktrace: list()}`
   """
 
   @protocol Application.compile_env(:kafka_ex, :protocol, KafkaEx.Protocol.KayrockProtocol)
@@ -59,15 +109,30 @@ defmodule KafkaEx.Telemetry do
   @connection_stop [:kafka_ex, :connection, :stop]
   @connection_exception [:kafka_ex, :connection, :exception]
 
+  @produce_start [:kafka_ex, :produce, :start]
+  @produce_stop [:kafka_ex, :produce, :stop]
+  @produce_exception [:kafka_ex, :produce, :exception]
+
+  @fetch_start [:kafka_ex, :fetch, :start]
+  @fetch_stop [:kafka_ex, :fetch, :stop]
+  @fetch_exception [:kafka_ex, :fetch, :exception]
+
+  @consumer_commit_start [:kafka_ex, :consumer, :commit, :start]
+  @consumer_commit_stop [:kafka_ex, :consumer, :commit, :stop]
+  @consumer_commit_exception [:kafka_ex, :consumer, :commit, :exception]
+
   @request_events [@request_start, @request_stop, @request_exception]
   @connection_events [@connection_start, @connection_stop, @connection_exception]
+  @produce_events [@produce_start, @produce_stop, @produce_exception]
+  @fetch_events [@fetch_start, @fetch_stop, @fetch_exception]
+  @consumer_events [@consumer_commit_start, @consumer_commit_stop, @consumer_commit_exception]
 
   @doc """
   Returns the list of all telemetry events emitted by KafkaEx.
   """
   @spec events() :: [list(atom())]
   def events do
-    @request_events ++ @connection_events
+    @request_events ++ @connection_events ++ @produce_events ++ @fetch_events ++ @consumer_events
   end
 
   @doc "Returns request-related telemetry events."
@@ -78,6 +143,18 @@ defmodule KafkaEx.Telemetry do
   @spec connection_events() :: [list(atom())]
   def connection_events, do: @connection_events
 
+  @doc "Returns produce-related telemetry events."
+  @spec produce_events() :: [list(atom())]
+  def produce_events, do: @produce_events
+
+  @doc "Returns fetch-related telemetry events."
+  @spec fetch_events() :: [list(atom())]
+  def fetch_events, do: @fetch_events
+
+  @doc "Returns consumer-related telemetry events."
+  @spec consumer_events() :: [list(atom())]
+  def consumer_events, do: @consumer_events
+
   # ---------------------------------------------------------------------------
   # Helper functions for emitting events
   # ---------------------------------------------------------------------------
@@ -85,8 +162,18 @@ defmodule KafkaEx.Telemetry do
   @doc false
   @spec span(list(atom()), map(), (-> {result, map()})) :: result when result: any()
   def span(event_prefix, metadata, fun) do
-    :telemetry.span(event_prefix, metadata, fun)
+    :telemetry.span(event_prefix, metadata, fn ->
+      {result, stop_metadata} = fun.()
+      stop_metadata_with_result = add_result_to_metadata(result, stop_metadata)
+      {result, stop_metadata_with_result}
+    end)
   end
+
+  defp add_result_to_metadata({{:ok, _}, _state}, metadata), do: Map.put(metadata, :result, :ok)
+  defp add_result_to_metadata({:ok, _}, metadata), do: Map.put(metadata, :result, :ok)
+  defp add_result_to_metadata({{:error, error}, _state}, metadata), do: Map.merge(metadata, %{result: :error, error: error})
+  defp add_result_to_metadata({:error, error}, metadata), do: Map.merge(metadata, %{result: :error, error: error})
+  defp add_result_to_metadata(_other, metadata), do: metadata
 
   @doc false
   @spec request_metadata(struct(), map()) :: map()
@@ -106,5 +193,38 @@ defmodule KafkaEx.Telemetry do
   @spec connection_metadata(binary() | charlist(), integer(), boolean()) :: map()
   def connection_metadata(host, port, ssl) do
     %{host: to_string(host), port: port, ssl: ssl}
+  end
+
+  @doc false
+  @spec produce_metadata(binary(), integer(), binary(), integer()) :: map()
+  def produce_metadata(topic, partition, client_id, required_acks) do
+    %{
+      topic: topic,
+      partition: partition,
+      client_id: client_id,
+      required_acks: required_acks
+    }
+  end
+
+  @doc false
+  @spec fetch_metadata(binary(), integer(), integer(), binary()) :: map()
+  def fetch_metadata(topic, partition, offset, client_id) do
+    %{
+      topic: topic,
+      partition: partition,
+      offset: offset,
+      client_id: client_id
+    }
+  end
+
+  @doc false
+  @spec commit_metadata(binary(), binary(), binary(), integer()) :: map()
+  def commit_metadata(group_id, client_id, topic, partition_count) do
+    %{
+      group_id: group_id,
+      client_id: client_id,
+      topic: topic,
+      partition_count: partition_count
+    }
   end
 end

--- a/test/integration/lifecycle/telemetry_test.exs
+++ b/test/integration/lifecycle/telemetry_test.exs
@@ -1,24 +1,36 @@
 defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   @moduletag :lifecycle
 
   alias KafkaEx.Client
   alias KafkaEx.API
   alias KafkaEx.Telemetry
 
-  describe "telemetry spans" do
-    test "request span emits start and stop events" do
-      ref = make_ref()
-      test_pid = self()
+  setup do
+    ref = make_ref()
+    test_pid = self()
 
-      handler = fn event, measurements, metadata, _config ->
-        send(test_pid, {:telemetry, ref, event, measurements, metadata})
+    handler = fn event, measurements, metadata, _config ->
+      send(test_pid, {:telemetry, ref, event, measurements, metadata})
+    end
+
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, client} = Client.start_link(args, :no_name)
+
+    on_exit(fn ->
+      :telemetry.detach(ref)
+
+      if Process.alive?(client) do
+        GenServer.stop(client)
       end
+    end)
 
+    {:ok, ref: ref, handler: handler, client: client}
+  end
+
+  describe "telemetry spans" do
+    test "request span emits start and stop events", %{ref: ref, handler: handler, client: client} do
       :telemetry.attach_many(ref, Telemetry.request_events(), handler, nil)
-
-      {:ok, args} = KafkaEx.build_worker_options([])
-      {:ok, client} = Client.start_link(args, :no_name)
 
       # Flush startup events
       flush_messages(ref)
@@ -37,23 +49,17 @@ defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
       assert_receive {:telemetry, ^ref, [:kafka_ex, :request, :stop], stop_measurements, _}, 5000
       assert Map.has_key?(stop_measurements, :duration)
       assert stop_measurements.duration > 0
-
-      :telemetry.detach(ref)
-      GenServer.stop(client)
     end
 
-    test "connection span emits start and stop events" do
-      ref = make_ref()
-      test_pid = self()
-
-      handler = fn event, measurements, metadata, _config ->
-        send(test_pid, {:telemetry, ref, event, measurements, metadata})
-      end
-
+    test "connection span emits start and stop events", %{ref: ref, handler: handler} do
       :telemetry.attach_many(ref, Telemetry.connection_events(), handler, nil)
 
       {:ok, args} = KafkaEx.build_worker_options([])
-      {:ok, client} = Client.start_link(args, :no_name)
+      {:ok, new_client} = Client.start_link(args, :no_name)
+
+      on_exit(fn ->
+        if Process.alive?(new_client), do: GenServer.stop(new_client)
+      end)
 
       # Verify start event
       assert_receive {:telemetry, ^ref, [:kafka_ex, :connection, :start], start_measurements, start_metadata}, 5000
@@ -67,9 +73,123 @@ defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
       assert Map.has_key?(stop_measurements, :duration)
       assert stop_measurements.duration > 0
       assert stop_metadata.success == true
+    end
 
-      :telemetry.detach(ref)
-      GenServer.stop(client)
+    test "produce span emits start and stop events", %{ref: ref, handler: handler, client: client} do
+      :telemetry.attach_many(ref, Telemetry.produce_events(), handler, nil)
+
+      topic_name = "telemetry-produce-test-#{:rand.uniform(100_000)}"
+      {:ok, _} = API.create_topics(client, [[topic: topic_name, num_partitions: 1, replication_factor: 1]], 10_000)
+      Process.sleep(500)
+
+      {:ok, _} = API.produce(client, topic_name, 0, [%{value: "test-message"}])
+
+      # Verify start event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :produce, :start], start_measurements, start_metadata}, 5000
+      assert Map.has_key?(start_measurements, :system_time)
+      assert start_metadata.message_count == 1
+      assert start_metadata.topic == topic_name
+      assert start_metadata.partition == 0
+      assert is_binary(start_metadata.client_id)
+      assert is_integer(start_metadata.required_acks)
+
+      # Verify stop event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :produce, :stop], stop_measurements, stop_metadata}, 5000
+      assert Map.has_key?(stop_measurements, :duration)
+      assert stop_measurements.duration > 0
+      assert stop_metadata.result == :ok
+      assert is_integer(stop_metadata.offset)
+    end
+
+    test "produce span includes error in stop metadata on failure", %{ref: ref, handler: handler, client: client} do
+      :telemetry.attach_many(ref, Telemetry.produce_events(), handler, nil)
+
+      # Produce to non-existent topic (auto-creation disabled scenario or invalid partition)
+      {:error, _} = API.produce(client, "telemetry-produce-test", 999, [%{value: "test"}])
+
+      # Verify start event was emitted
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :produce, :start], _, _}, 5000
+
+      # Verify stop event includes error info
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :produce, :stop], stop_measurements, stop_metadata}, 5000
+      assert Map.has_key?(stop_measurements, :duration)
+      assert stop_metadata.result == :error
+      assert Map.has_key?(stop_metadata, :error)
+    end
+
+    test "fetch span emits start and stop events", %{ref: ref, handler: handler, client: client} do
+      :telemetry.attach_many(ref, Telemetry.fetch_events(), handler, nil)
+
+      topic_name = "telemetry-fetch-test-#{:rand.uniform(100_000)}"
+      {:ok, _} = API.create_topics(client, [[topic: topic_name, num_partitions: 1, replication_factor: 1]], 10_000)
+      Process.sleep(500)
+
+      {:ok, produce_result} = API.produce(client, topic_name, 0, [%{value: "test-message"}])
+      offset = produce_result.base_offset
+
+      {:ok, _} = API.fetch(client, topic_name, 0, offset, max_bytes: 100_000)
+
+      # Verify start event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :fetch, :start], start_measurements, start_metadata}, 5000
+      assert Map.has_key?(start_measurements, :system_time)
+      assert start_metadata.topic == topic_name
+      assert start_metadata.partition == 0
+      assert start_metadata.offset == offset
+      assert is_binary(start_metadata.client_id)
+
+      # Verify stop event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :fetch, :stop], stop_measurements, stop_metadata}, 5000
+      assert Map.has_key?(stop_measurements, :duration)
+      assert stop_measurements.duration > 0
+      assert stop_metadata.result == :ok
+      assert stop_metadata.message_count == 1
+    end
+
+    test "fetch span includes error in stop metadata on failure", %{ref: ref, handler: handler, client: client} do
+      :telemetry.attach_many(ref, Telemetry.fetch_events(), handler, nil)
+
+      # Fetch from non-existent topic/partition
+      {:error, _} = API.fetch(client, "non-existent-topic-xyz", 999, 0, max_bytes: 100_000)
+
+      # Verify start event was emitted
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :fetch, :start], _, _}, 5000
+
+      # Verify stop event includes error info
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :fetch, :stop], stop_measurements, stop_metadata}, 5000
+      assert Map.has_key?(stop_measurements, :duration)
+      assert stop_metadata.result == :error
+      assert Map.has_key?(stop_metadata, :error)
+    end
+  end
+
+  describe "consumer telemetry events" do
+    test "offset commit span emits start and stop events", %{ref: ref, handler: handler, client: client} do
+      :telemetry.attach_many(ref, Telemetry.consumer_events(), handler, nil)
+
+      topic_name = "telemetry-commit-test-#{:rand.uniform(100_000)}"
+      group_name = "telemetry-commit-group-#{:rand.uniform(100_000)}"
+      {:ok, _} = API.create_topics(client, [[topic: topic_name, num_partitions: 1, replication_factor: 1]], 10_000)
+      Process.sleep(500)
+
+      # Commit an offset
+      partitions = [%{partition_num: 0, offset: 100}]
+      {:ok, _} = API.commit_offset(client, group_name, topic_name, partitions)
+
+      # Verify start event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :consumer, :commit, :start], start_measurements, start_metadata},
+                     5000
+
+      assert Map.has_key?(start_measurements, :system_time)
+      assert start_metadata.group_id == group_name
+      assert start_metadata.topic == topic_name
+      assert is_binary(start_metadata.client_id)
+      assert start_metadata.partition_count == 1
+
+      # Verify stop event
+      assert_receive {:telemetry, ^ref, [:kafka_ex, :consumer, :commit, :stop], stop_measurements, stop_metadata}, 5000
+      assert Map.has_key?(stop_measurements, :duration)
+      assert stop_measurements.duration > 0
+      assert stop_metadata.result == :ok
     end
   end
 

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -32,6 +32,30 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :connection, :stop] in events
       assert [:kafka_ex, :connection, :exception] in events
     end
+
+    test "includes produce events" do
+      events = Telemetry.events()
+
+      assert [:kafka_ex, :produce, :start] in events
+      assert [:kafka_ex, :produce, :stop] in events
+      assert [:kafka_ex, :produce, :exception] in events
+    end
+
+    test "includes fetch events" do
+      events = Telemetry.events()
+
+      assert [:kafka_ex, :fetch, :start] in events
+      assert [:kafka_ex, :fetch, :stop] in events
+      assert [:kafka_ex, :fetch, :exception] in events
+    end
+
+    test "includes consumer events" do
+      events = Telemetry.events()
+
+      assert [:kafka_ex, :consumer, :commit, :start] in events
+      assert [:kafka_ex, :consumer, :commit, :stop] in events
+      assert [:kafka_ex, :consumer, :commit, :exception] in events
+    end
   end
 
   describe "request_events/0" do
@@ -55,6 +79,41 @@ defmodule KafkaEx.TelemetryTest do
       Enum.each(events, fn event ->
         assert Enum.at(event, 1) == :connection
       end)
+    end
+  end
+
+  describe "produce_events/0" do
+    test "returns only produce events" do
+      events = Telemetry.produce_events()
+
+      assert length(events) == 3
+
+      Enum.each(events, fn event ->
+        assert Enum.at(event, 1) == :produce
+      end)
+    end
+  end
+
+  describe "fetch_events/0" do
+    test "returns only fetch events" do
+      events = Telemetry.fetch_events()
+
+      assert length(events) == 3
+
+      Enum.each(events, fn event ->
+        assert Enum.at(event, 1) == :fetch
+      end)
+    end
+  end
+
+  describe "consumer_events/0" do
+    test "returns only consumer events" do
+      events = Telemetry.consumer_events()
+
+      assert length(events) == 3
+      assert [:kafka_ex, :consumer, :commit, :start] in events
+      assert [:kafka_ex, :consumer, :commit, :stop] in events
+      assert [:kafka_ex, :consumer, :commit, :exception] in events
     end
   end
 
@@ -140,6 +199,28 @@ defmodule KafkaEx.TelemetryTest do
     end
   end
 
+  describe "produce_metadata/4" do
+    test "creates produce metadata" do
+      metadata = Telemetry.produce_metadata("test-topic", 0, "test-client", 1)
+
+      assert metadata.topic == "test-topic"
+      assert metadata.partition == 0
+      assert metadata.client_id == "test-client"
+      assert metadata.required_acks == 1
+    end
+  end
+
+  describe "fetch_metadata/4" do
+    test "creates fetch metadata" do
+      metadata = Telemetry.fetch_metadata("test-topic", 0, 100, "test-client")
+
+      assert metadata.topic == "test-topic"
+      assert metadata.partition == 0
+      assert metadata.offset == 100
+      assert metadata.client_id == "test-client"
+    end
+  end
+
   describe "span/3" do
     test "emits start and stop events" do
       ref = make_ref()
@@ -213,4 +294,16 @@ defmodule KafkaEx.TelemetryTest do
       :telemetry.detach(ref)
     end
   end
+
+  describe "commit_metadata/4" do
+    test "creates commit metadata" do
+      metadata = Telemetry.commit_metadata("test-group", "test-client", "test-topic", 3)
+
+      assert metadata.group_id == "test-group"
+      assert metadata.client_id == "test-client"
+      assert metadata.topic == "test-topic"
+      assert metadata.partition_count == 3
+    end
+  end
+
 end


### PR DESCRIPTION
## Overview

- Add fetch, produce & commit telemetry events 
- Extend current spans to contains result to be able to track `error` returns