### PR TITLE
chore: clean up IO.inspect in delete_topics docstring example

### DIFF
--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -968,7 +968,7 @@ defmodule KafkaEx.API do
         IO.puts("All topics deleted successfully")
       else
         failed = DeleteTopics.failed_topics(result)
-        IO.inspect(failed, label: "Failed to delete")
+        IO.puts("Failed to delete: " <> inspect(failed))
       end
   """
   @spec delete_topics(client, [topic_name], timeout) :: {:ok, DeleteTopics.t()} | {:error, error_atom}


### PR DESCRIPTION
Replace IO.inspect with IO.puts/inspect in the @doc example for KafkaEx.API.delete_topics/3,4 so the rendered hexdocs do not model an anti-pattern.