### PR TITLE
test: add coverage for INACTIVE issues #449, #298, #445

### DIFF
--- a/test/integration/produce/multi_topic_test.exs
+++ b/test/integration/produce/multi_topic_test.exs
@@ -1,0 +1,85 @@
+defmodule KafkaEx.Integration.Produce.MultiTopicTest do
+  @moduledoc """
+  Pin cross-topic metadata correctness on a single Client (issue #445).
+
+  The reporter's symptom (response says Topic B when produced to Topic A)
+  is unreachable by construction in v1.0 — the single GenServer serializes
+  handle_call/3 and the broker echoes the request topic in the response.
+  These tests lock the invariant in place against future refactors that
+  might introduce parallelism.
+  """
+  use ExUnit.Case, async: true
+  @moduletag :produce
+
+  import KafkaEx.TestHelpers
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.API
+  alias KafkaEx.Messages.RecordMetadata
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, pid} = Client.start_link(args, :no_name)
+
+    {:ok, %{client: pid}}
+  end
+
+  describe "multi-topic produce on a single Client [issue #445]" do
+    test "produce to two different topics returns correct topic per response", %{client: client} do
+      topic_a = generate_random_string()
+      topic_b = generate_random_string()
+
+      _ = create_topic(client, topic_a)
+      _ = create_topic(client, topic_b)
+
+      a_results =
+        for i <- 1..5 do
+          {:ok, %RecordMetadata{} = meta} =
+            API.produce(client, topic_a, 0, [%{value: "a#{i}"}])
+
+          meta
+        end
+
+      b_results =
+        for i <- 1..5 do
+          {:ok, %RecordMetadata{} = meta} =
+            API.produce(client, topic_b, 0, [%{value: "b#{i}"}])
+
+          meta
+        end
+
+      assert Enum.all?(a_results, fn m -> m.topic == topic_a end),
+             "expected every A response to echo #{topic_a}, got: #{inspect(Enum.map(a_results, & &1.topic))}"
+
+      assert Enum.all?(b_results, fn m -> m.topic == topic_b end),
+             "expected every B response to echo #{topic_b}, got: #{inspect(Enum.map(b_results, & &1.topic))}"
+
+      refute Enum.any?(a_results, fn m -> m.topic == topic_b end)
+      refute Enum.any?(b_results, fn m -> m.topic == topic_a end)
+    end
+
+    test "interleaved produce to two topics preserves topic identity per response", %{client: client} do
+      topic_a = generate_random_string()
+      topic_b = generate_random_string()
+
+      _ = create_topic(client, topic_a)
+      _ = create_topic(client, topic_b)
+
+      interleaved =
+        for i <- 1..10 do
+          topic = if rem(i, 2) == 0, do: topic_b, else: topic_a
+
+          {:ok, %RecordMetadata{} = meta} =
+            API.produce(client, topic, 0, [%{value: "msg#{i}"}])
+
+          {topic, meta.topic}
+        end
+
+      for {requested, returned} <- interleaved do
+        assert requested == returned,
+               "topic mismatch: requested #{requested}, got #{returned}"
+      end
+    end
+  end
+end

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -7,6 +7,7 @@ defmodule KafkaEx.ClientTest do
   alias KafkaEx.Client.State
   alias KafkaEx.Cluster.Broker
   alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Network.Socket
 
   describe "handle_call/3 - offset_fetch" do
     test "returns error for invalid consumer group" do
@@ -185,5 +186,155 @@ defmodule KafkaEx.ClientTest do
         refute Broker.connected?(broker)
       end
     end
+  end
+
+  describe "handle_info({:tcp_closed, port}, state) [issue #449]" do
+    test "clears the matching broker's socket and returns :noreply" do
+      port = open_tcp_port()
+      broker = broker_with_port(1, port)
+      state = build_state(%{1 => broker})
+
+      assert {:noreply, new_state} = Client.handle_info({:tcp_closed, port}, state)
+
+      [updated_broker] = State.brokers(new_state)
+      assert updated_broker.node_id == 1
+      assert updated_broker.socket == nil
+    end
+
+    test "leaves other brokers' sockets untouched" do
+      port_1 = open_tcp_port()
+      port_2 = open_tcp_port()
+
+      state =
+        build_state(%{
+          1 => broker_with_port(1, port_1),
+          2 => broker_with_port(2, port_2)
+        })
+
+      {:noreply, new_state} = Client.handle_info({:tcp_closed, port_1}, state)
+
+      brokers_by_id =
+        new_state
+        |> State.brokers()
+        |> Map.new(fn b -> {b.node_id, b} end)
+
+      assert brokers_by_id[1].socket == nil
+      assert brokers_by_id[2].socket == %Socket{socket: port_2, ssl: false}
+    end
+
+    test "is a no-op when no broker matches the port" do
+      port_in_state = open_tcp_port()
+      port_unknown = open_tcp_port()
+
+      state = build_state(%{1 => broker_with_port(1, port_in_state)})
+
+      {:noreply, new_state} = Client.handle_info({:tcp_closed, port_unknown}, state)
+
+      [unchanged] = State.brokers(new_state)
+      assert unchanged.socket == %Socket{socket: port_in_state, ssl: false}
+    end
+
+    test "is idempotent when :tcp_closed is received twice" do
+      port = open_tcp_port()
+      state = build_state(%{1 => broker_with_port(1, port)})
+
+      {:noreply, state_1} = Client.handle_info({:tcp_closed, port}, state)
+      {:noreply, state_2} = Client.handle_info({:tcp_closed, port}, state_1)
+
+      [broker] = State.brokers(state_2)
+      assert broker.socket == nil
+    end
+
+    test "leaves a broker whose socket is already nil unchanged" do
+      port = open_tcp_port()
+      broker_with_nil = %{broker_with_port(1, port) | socket: nil}
+      state = build_state(%{1 => broker_with_nil})
+
+      {:noreply, new_state} = Client.handle_info({:tcp_closed, port}, state)
+
+      [unchanged] = State.brokers(new_state)
+      assert unchanged.socket == nil
+    end
+  end
+
+  describe "handle_info({:ssl_closed, ref}, state) [issue #449]" do
+    test "clears the matching broker's socket and returns :noreply" do
+      ref = make_ref()
+      broker = broker_with_ssl_ref(1, ref)
+      state = build_state(%{1 => broker})
+
+      assert {:noreply, new_state} = Client.handle_info({:ssl_closed, ref}, state)
+
+      [updated_broker] = State.brokers(new_state)
+      assert updated_broker.socket == nil
+    end
+
+    test "leaves other brokers' SSL sockets untouched" do
+      ref_1 = make_ref()
+      ref_2 = make_ref()
+
+      state =
+        build_state(%{
+          1 => broker_with_ssl_ref(1, ref_1),
+          2 => broker_with_ssl_ref(2, ref_2)
+        })
+
+      {:noreply, new_state} = Client.handle_info({:ssl_closed, ref_1}, state)
+
+      brokers_by_id =
+        new_state
+        |> State.brokers()
+        |> Map.new(fn b -> {b.node_id, b} end)
+
+      assert brokers_by_id[1].socket == nil
+      assert brokers_by_id[2].socket == %Socket{socket: ref_2, ssl: true}
+    end
+
+    test "is a no-op when no broker matches the ref" do
+      ref_in_state = make_ref()
+      ref_unknown = make_ref()
+
+      state = build_state(%{1 => broker_with_ssl_ref(1, ref_in_state)})
+
+      {:noreply, new_state} = Client.handle_info({:ssl_closed, ref_unknown}, state)
+
+      [unchanged] = State.brokers(new_state)
+      assert unchanged.socket == %Socket{socket: ref_in_state, ssl: true}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test helpers for remote-close tests (#449)
+  # ---------------------------------------------------------------------------
+
+  defp open_tcp_port do
+    {:ok, listen_socket} = :gen_tcp.listen(0, [:binary, active: false])
+    on_exit(fn -> :gen_tcp.close(listen_socket) end)
+    listen_socket
+  end
+
+  defp build_state(brokers_by_id) do
+    %State{
+      cluster_metadata: %ClusterMetadata{brokers: brokers_by_id},
+      worker_name: :test_worker
+    }
+  end
+
+  defp broker_with_port(node_id, port) do
+    %Broker{
+      node_id: node_id,
+      host: "broker#{node_id}.test",
+      port: 9092,
+      socket: %Socket{socket: port, ssl: false}
+    }
+  end
+
+  defp broker_with_ssl_ref(node_id, ref) do
+    %Broker{
+      node_id: node_id,
+      host: "broker#{node_id}.test",
+      port: 9093,
+      socket: %Socket{socket: ref, ssl: true}
+    }
   end
 end

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -303,6 +303,25 @@ defmodule KafkaEx.ClientTest do
     end
   end
 
+  describe "Client.start_link/2 with all brokers unreachable [issue #298]" do
+    setup do
+      original = Application.get_env(:kafka_ex, :sleep_for_reconnect)
+      Application.put_env(:kafka_ex, :sleep_for_reconnect, 1)
+      on_exit(fn -> Application.put_env(:kafka_ex, :sleep_for_reconnect, original) end)
+
+      Process.flag(:trap_exit, true)
+      :ok
+    end
+
+    test "raises 'Brokers sockets are not opened' for a single unreachable broker" do
+      assert_init_raises_brokers_not_opened([{"127.0.0.1", 1}])
+    end
+
+    test "raises 'Brokers sockets are not opened' when every broker in a multi-broker list is unreachable" do
+      assert_init_raises_brokers_not_opened([{"127.0.0.1", 1}, {"127.0.0.1", 2}])
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Test helpers for remote-close tests (#449)
   # ---------------------------------------------------------------------------
@@ -336,5 +355,43 @@ defmodule KafkaEx.ClientTest do
       port: 9093,
       socket: %Socket{socket: ref, ssl: true}
     }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test helpers for init validation tests (#298)
+  # ---------------------------------------------------------------------------
+
+  defp assert_init_raises_brokers_not_opened(uris) do
+    args = [uris: uris, consumer_group: :no_consumer_group]
+
+    result =
+      try do
+        Client.start_link(args, :no_name)
+      catch
+        :exit, reason -> {:exit, reason}
+      end
+
+    drain_exits()
+
+    case result do
+      {:error, {%RuntimeError{message: message}, _stacktrace}} ->
+        assert message =~ "Brokers sockets are not opened",
+               "expected 'Brokers sockets are not opened', got: #{inspect(message)}"
+
+      {:exit, {%RuntimeError{message: message}, _stacktrace}} ->
+        assert message =~ "Brokers sockets are not opened",
+               "expected 'Brokers sockets are not opened', got: #{inspect(message)}"
+
+      other ->
+        flunk("expected Client.start_link to raise 'Brokers sockets are not opened', got: #{inspect(other)}")
+    end
+  end
+
+  defp drain_exits do
+    receive do
+      {:EXIT, _pid, _reason} -> drain_exits()
+    after
+      0 -> :ok
+    end
   end
 end

--- a/test/kafka_ex/client/request_builder_test.exs
+++ b/test/kafka_ex/client/request_builder_test.exs
@@ -1,5 +1,9 @@
 defmodule KafkaEx.Client.RequestBuilderTest do
-  use ExUnit.Case, async: true
+  # async: false because the file mixes `capture_log` with many tests that
+  # legitimately emit Logger.error from RequestBuilder.get_api_version/3.
+  # capture_log/2 attaches a global handler and would race with parallel
+  # async tests, causing intermittent CI failures on `assert log == ""`.
+  use ExUnit.Case, async: false
 
   alias KafkaEx.Client.RequestBuilder
   alias KafkaEx.Messages.Header


### PR DESCRIPTION
## Summary

Adds unit + integration coverage to close out three INACTIVE issues from the recent triage. Each commit is per-issue; all tests verify behavior the v1.0 architecture already implements (regression pinning, no production code changes).

- **#449** — `handle_info({:tcp_closed | :ssl_closed, _}, _)` callbacks in `KafkaEx.Client`. 8 unit tests across two `describe` blocks in `test/kafka_ex/client/client_test.exs`. Chaos tests at `test/chaos/network_test.exs` cover the end-to-end recovery path but only 2 of 10 assert `Process.alive?(client)` — these unit tests pin the state transition directly.
- **#298** — Init fail-fast when all brokers are unreachable. 2 unit tests in `test/kafka_ex/client/client_test.exs` driving the behavior through the public `KafkaEx.Client.start_link/2` API with `127.0.0.1:1` as a known-unreachable address (no broker required, no encapsulation broken).
- **#445** — Cross-topic correctness on a single Client. 2 integration tests in `test/integration/produce/multi_topic_test.exs` produce to two topics (batched + interleaved) and assert each `RecordMetadata` echoes the correct topic. Locks in the single-GenServer invariant against future refactors that might introduce parallelism.

## Commits

- ``f3a39a8`` — ``test: add unit tests for remote-close handle_info in Client (#449)``
- ``ef110e9`` — ``test: add unit tests for init fail-fast when brokers unreachable (#298)``
- ``db24f1a`` — ``test: pin cross-topic correctness on a single Client (#445)``

## Test plan

- [x] ``mix test test/kafka_ex/client/client_test.exs`` — 24 tests, 0 failures (14 pre-existing + 10 new)
- [x] ``mix test test/integration/produce/multi_topic_test.exs --include produce`` — 2 tests, 0 failures (against ``./scripts/docker_up.sh`` cluster)
- [x] ``mix test.unit`` — full unit suite green, no regressions

Refs #449 #298 #445