### PR TITLE
Fix JoinGroup member_id_required (KIP-394) handling

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -757,7 +757,12 @@ defmodule KafkaEx.Client do
   end
 
   defp handle_join_group_request(request, node_selector, state) do
-    %RequestContext{request: request, parser_fn: &ResponseParser.join_group_response/1, node_selector: node_selector}
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.join_group_response/1,
+      node_selector: node_selector,
+      retryable?: &Retry.join_group_retryable?/1
+    }
     |> handle_request_with_retry(state)
   end
 

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -208,6 +208,21 @@ defmodule KafkaEx.Support.Retry do
   def consumer_group_retryable?(error), do: transient_error?(error)
 
   @doc """
+  Check if the error is safe to retry for join group operations.
+
+  KIP-394: JoinGroup V4+ requires two-step join.
+  First attempt with empty member_id returns :member_id_required
+  with an assigned member_id. Then another request needs to be
+  performed with that member_id.
+
+  We do not want to retry the same request if the error is
+  `:member_id_required`, but rather swap in the assigned member_id.
+  """
+  @spec join_group_retryable?(error()) :: boolean()
+  def join_group_retryable?(:member_id_required), do: false
+  def join_group_retryable?(_), do: true
+
+  @doc """
   Check if error is safe to retry for commit operations.
 
   Commits are idempotent so we can safely retry on transient errors.

--- a/test/chaos/join_group_test.exs
+++ b/test/chaos/join_group_test.exs
@@ -1,0 +1,96 @@
+defmodule KafkaEx.Chaos.JoinGroupTest do
+  @moduledoc """
+  Chaos coverage for the consumer-group JOIN path under network latency.
+
+  Regression for the KIP-394 `:member_id_required` retry fix: a v4+ `JoinGroup`
+  with an empty `member_id` gets `member_id_required` + a broker-assigned id to
+  retry with. The fix makes `member_id_required` non-retryable in the generic
+  loop so it bounces straight to the retry-with-assigned-id step (one extra
+  round-trip) instead of being blind-retried with the empty id (several wasted
+  round-trips). Under latency those wasted round-trips let the assigned id lapse
+  and the join never converges.
+
+  This test injects downstream latency tuned so the *fixed* client converges
+  (~2 round-trips) while the *unfixed* client would not (~4+ round-trips exceed
+  the session window). It is therefore timing-sensitive by nature.
+  """
+  use ExUnit.Case, async: false
+  @moduletag :chaos
+  @moduletag timeout: 300_000
+
+  require Logger
+  import KafkaEx.TestHelpers
+
+  alias KafkaEx.API
+  alias KafkaEx.ChaosTestHelpers
+  alias KafkaEx.Messages.JoinGroup
+  alias KafkaEx.Test.KayrockFixtures, as: Fixtures
+
+  setup_all do
+    {:ok, ctx} = ChaosTestHelpers.start_infrastructure()
+    on_exit(fn -> ChaosTestHelpers.stop_infrastructure(ctx) end)
+    {:ok, ctx}
+  end
+
+  setup ctx do
+    ChaosTestHelpers.reset_all(ctx.toxiproxy_container)
+    ChaosTestHelpers.stop_client()
+    Process.sleep(200)
+
+    on_exit(fn ->
+      ChaosTestHelpers.reset_all(ctx.toxiproxy_container)
+      ChaosTestHelpers.stop_client()
+    end)
+
+    {:ok, ctx}
+  end
+
+  defp join(client, group, version, session_timeout) do
+    protocols = [%{name: "assign", metadata: Fixtures.group_protocol_metadata(topics: ["t-#{group}"])}]
+
+    API.join_group(client, group, "",
+      session_timeout: session_timeout,
+      rebalance_timeout: 60_000,
+      group_protocols: protocols,
+      api_version: version
+    )
+  end
+
+  # Retried join — gets past a cold __consumer_offsets coordinator (which also
+  # surfaces as :unknown) so the warm-up is a clean signal.
+  defp join_retry(client, group, version, session_timeout, retries \\ 6) do
+    case join(client, group, version, session_timeout) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(1_000)
+        join_retry(client, group, version, session_timeout, retries - 1)
+
+      err ->
+        err
+    end
+  end
+
+  # v6 is the flexible version; the KIP-394 two-step join behaves identically for all v4+.
+  for version <- [6] do
+    test "JoinGroup v#{version} converges under network latency (KIP-394 member_id_required handled in one extra round-trip)",
+         ctx do
+      {:ok, client} = ChaosTestHelpers.start_client(ctx)
+
+      # Warm up the coordinator so the latency join below isn't flaky on a cold start.
+      _ = join_retry(client, "joingroup-warmup-#{generate_random_string()}", unquote(version), 30_000)
+
+      # session_timeout 6000 = broker's group.min.session.timeout.ms floor.
+      # At 2000ms latency the fixed client (~2 round-trips ≈ 4s) converges within
+      # the 6s session; the unfixed client (~4+ round-trips ≈ 8s+) would not.
+      result =
+        ChaosTestHelpers.with_latency(ctx.toxiproxy_container, ctx.proxy_name, 2_000, fn ->
+          join(client, "joingroup-latency-#{generate_random_string()}", unquote(version), 6_000)
+        end)
+
+      Logger.warning("[+2000ms latency, 6s session] JoinGroup v#{unquote(version)} => #{inspect(result)}")
+      assert {:ok, %JoinGroup{}} = result
+    end
+  end
+end

--- a/test/integration/join_group/version_test.exs
+++ b/test/integration/join_group/version_test.exs
@@ -1,0 +1,76 @@
+defmodule KafkaEx.Integration.JoinGroup.VersionTest do
+  @moduledoc """
+  Exercises `JoinGroup` across API versions against the shared integration
+  cluster (start it with `./scripts/docker_up.sh`).
+
+  Covers the meaningful protocol boundaries:
+    * v3 — last pre-KIP-394 version (one-step join, empty member_id accepted)
+    * v4 — first KIP-394 version (two-step join via `member_id_required`)
+    * v5 — adds `group_instance_id` (static membership, KIP-345)
+    * v6 — first flexible version (KIP-482, compact encoding + tagged fields)
+
+  Each version should return a valid assigned member id and generation. v4+ in
+  particular relies on the `:member_id_required` retry being handled correctly
+  (see `KafkaEx.Support.Retry.join_group_retryable?/1`).
+  """
+  use ExUnit.Case, async: false
+  @moduletag :consumer_group
+
+  import KafkaEx.TestHelpers
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.API
+  alias KafkaEx.Client
+  alias KafkaEx.Messages.JoinGroup
+  alias KafkaEx.Test.KayrockFixtures, as: Fixtures
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    {:ok, %{client: client}}
+  end
+
+  # First join after topic creation can hit a cold __consumer_offsets coordinator
+  # (surfaces as :unknown); retry that.
+  defp join_with_retry(client, group, topic, version, retries \\ 5) do
+    group_protocols = [%{name: "assign", metadata: Fixtures.group_protocol_metadata(topics: [topic])}]
+
+    opts = [
+      session_timeout: 30_000,
+      rebalance_timeout: 60_000,
+      group_protocols: group_protocols,
+      api_version: version
+    ]
+
+    case API.join_group(client, group, "", opts) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} when retries > 0 ->
+        Process.sleep(1_000)
+        join_with_retry(client, group, topic, version, retries - 1)
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  for version <- [3, 4, 5, 6] do
+    @tag timeout: 120_000
+    test "JoinGroup v#{version} returns an assigned member id and generation", %{client: client} do
+      topic = generate_random_string()
+      group = "cg-join-v#{unquote(version)}-#{generate_random_string()}"
+      _ = create_topic(client, topic)
+
+      assert {:ok, %JoinGroup{} = result} = join_with_retry(client, group, topic, unquote(version))
+
+      assert is_binary(result.member_id) and byte_size(result.member_id) > 0
+      assert result.generation_id >= 1
+      assert JoinGroup.leader?(result)
+
+      # Clean up: a single fresh member is the leader; leaving empties the group.
+      {:ok, _} = API.leave_group(client, group, result.member_id)
+    end
+  end
+end

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -372,4 +372,17 @@ defmodule KafkaEx.Support.RetryTest do
       refute Retry.commit_retryable?(:invalid_commit_offset_size)
     end
   end
+
+  describe "join_group_retryable?/1" do
+    test "member_id_required is NOT retryable (KIP-394: retry with the assigned id, not the same request)" do
+      refute Retry.join_group_retryable?(:member_id_required)
+    end
+
+    test "other join errors remain retryable" do
+      assert Retry.join_group_retryable?(:coordinator_load_in_progress)
+      assert Retry.join_group_retryable?(:not_coordinator)
+      assert Retry.join_group_retryable?(:request_timed_out)
+      assert Retry.join_group_retryable?(:unknown)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #540 

On a v4+ JoinGroup, a new member (empty member_id) gets the KIP-394 `MEMBER_ID_REQUIRED` response, which must be retried with the broker-assigned id. Before this change, the request would be retried with the missing member id for the configured number of times before the assigned member id would run. The added latency meant that the `join_group` request would not succeed.
 
This PR makes `:member_id_required` non-retryable for the join path, so  it bubbles straight to the assigned-id retry on the first response.

### Tests

  - Unit (test/kafka_ex/support/retry_test.exs): join_group_retryable?/1 — member_id_required non-retryable, other errors retryable.
  - Integration (test/integration/join_group/version_test.exs, new): JoinGroup v3/v4/v5/v6 against the test cluster, each returning a valid member id + generation.
  - Chaos (test/chaos/join_group_test.exs): a v6 join converges under injected latency (Toxiproxy). Timing-sensitive by design — tuned so the fixed client (~2 round-trips) converges within the session window while the unfixed client (~4+) would not; it's the end-to-end demonstration, with the unit test as the deterministic guard.