### PR TITLE
Fix #538: start_client/1 crashes on missing config defaults; accept :brokers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@
 
 ### Fixed
 
+* **`KafkaEx.API.start_client/1` and `child_spec/1` now merge `config.exs`
+  defaults and accept the documented `:brokers` option (#538).** Previously
+  `start_client(brokers: [...])` crashed with `InvalidConsumerGroupError: nil`
+  because config defaults were never merged and the `:brokers` key was ignored
+  (the client read `:uris`). `:brokers` is now the canonical key; `:uris` is a
+  deprecated-but-working alias. `start_client/1` returns
+  `{:error, :invalid_consumer_group}` on a bad group; `child_spec/1` raises
+  `KafkaEx.InvalidConsumerGroupError` at spec-build time.
+
 * **`KafkaEx.API.fetch/5` (and `KafkaEx.Consumer.Stream`) hang at logend.**
   Previously the GenServer.call default timeout (5s) and the per-broker
   `Socket.recv` timeout (1-3s from `sync_timeout` config) were not

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ See [KafkaEx.API documentation](https://hexdocs.pm/kafka_ex/KafkaEx.API.html) fo
 
 ## Configuration
 
-KafkaEx can be configured via `config.exs` or by passing options directly to `KafkaEx.API.start_client/1`.
+KafkaEx can be configured via `config.exs`, by passing options directly to
+`KafkaEx.API.start_client/1`, or both — options passed to `start_client/1`
+override the matching `config.exs` defaults. The broker option key is
+`:brokers` (the legacy `:uris` is still accepted but deprecated).
 
 ### Basic Configuration
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,6 +61,12 @@ KafkaEx.fetch("topic", 0, 0)  # offset is positional
 {:ok, result} = KafkaEx.API.fetch(client, "topic", 0, 0)
 ```
 
+> **Option key:** the broker list option is `:brokers` (matching the
+> `config :kafka_ex, brokers:` key). The pre-1.0 `:uris` option is still
+> accepted as a deprecated alias. `start_client/1` now merges `config.exs`
+> defaults automatically, so you no longer need `KafkaEx.build_worker_options/1`
+> just to inherit your configured brokers and consumer group.
+
 ### Headers API — `[%Header{}]` instead of `[{key, value}]`
 
 The `headers:` option on every produce function now takes a list of

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -41,11 +41,14 @@ defmodule KafkaEx do
           | {:password, binary}
         ]
   @type worker_setting ::
-          {:uris, uri}
+          {:brokers, uri}
+          | {:uris, uri}
           | {:consumer_group, binary | :no_consumer_group}
           | {:metadata_update_interval, non_neg_integer}
+          | {:use_ssl, boolean}
           | {:ssl_options, ssl_options}
           | {:auth, KafkaEx.Auth.Config.t() | nil}
+          | {:allow_auto_topic_creation, boolean}
           | {:initial_topics, [binary]}
 
   @doc """
@@ -53,17 +56,22 @@ defmodule KafkaEx do
 
   ## Options
 
+  - `brokers`: List of brokers as `{"host", port}` tuples
   - `consumer_group`: Name of the consumer group, `:no_consumer_group` for none
-  - `uris`: List of brokers as `{"host", port}` tuples
+    (use `:no_consumer_group` for a produce-only worker)
   - `metadata_update_interval`: Metadata refresh interval in ms (default: 30000)
   - `use_ssl`: Enable SSL connections (default: false)
   - `ssl_options`: SSL options (see Erlang ssl docs)
   - `auth`: SASL authentication config (see `KafkaEx.Auth.Config`)
+  - `allow_auto_topic_creation`: Allow brokers to auto-create topics (default: true;
+    a typo'd topic name can silently create a topic on permissive clusters)
+  - `initial_topics`: Topics to fetch metadata for at startup (default: [])
+  - `uris`: **Deprecated** alias for `brokers`; still accepted
 
   ## Example
 
       {:ok, pid} = KafkaEx.create_worker(:my_worker)
-      {:ok, pid} = KafkaEx.create_worker(:my_worker, uris: [{"localhost", 9092}])
+      {:ok, pid} = KafkaEx.create_worker(:my_worker, brokers: [{"localhost", 9092}])
   """
   @spec create_worker(atom, KafkaEx.worker_init()) :: Supervisor.on_start_child()
   def create_worker(name, worker_init \\ []) do
@@ -112,10 +120,15 @@ defmodule KafkaEx do
   @doc """
   Builds worker options by merging with application config defaults.
 
+  Normalizes the canonical `:brokers` option to the internal `:uris` key
+  (an explicit `:uris` wins if both are given).
+
   Returns `{:error, :invalid_consumer_group}` if consumer group is invalid.
   """
   @spec build_worker_options(worker_init) :: {:ok, worker_init} | {:error, :invalid_consumer_group}
   def build_worker_options(worker_init) do
+    worker_init = normalize_broker_key(worker_init)
+
     defaults = [
       uris: Config.brokers(),
       consumer_group: Config.default_consumer_group(),
@@ -131,6 +144,20 @@ defmodule KafkaEx do
       {:ok, worker_init}
     else
       {:error, :invalid_consumer_group}
+    end
+  end
+
+  # `:brokers` is the canonical user-facing key (it matches the `:brokers`
+  # config key). Internally everything reads `:uris`, so translate here.
+  # We normalize BEFORE merging defaults so a user-supplied broker list
+  # overrides the config-derived `:uris`. An explicit `:uris` wins if both
+  # are given. Done here (not in static_init) so every entry point that
+  # calls build_worker_options/1 — start_client, child_spec, create_worker,
+  # start_link_worker — accepts `:brokers` uniformly.
+  defp normalize_broker_key(worker_init) do
+    case Keyword.pop(worker_init, :brokers) do
+      {nil, rest} -> rest
+      {brokers, rest} -> if Keyword.has_key?(rest, :uris), do: rest, else: Keyword.put(rest, :uris, brokers)
     end
   end
 

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -58,6 +58,7 @@ defmodule KafkaEx.API do
   alias KafkaEx.Client
   alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Cluster.Topic
+  alias KafkaEx.Config
   alias KafkaEx.Messages.ApiVersions
   alias KafkaEx.Messages.ConsumerGroupDescription
   alias KafkaEx.Messages.CreateTopics
@@ -236,10 +237,27 @@ defmodule KafkaEx.API do
   @doc """
   Start a KafkaEx Client GenServer.
 
+  Application config defaults (`config :kafka_ex, …`) are merged
+  automatically — any option you pass overrides the corresponding default.
+
   ## Options
 
-    * `:brokers` — list of `{host, port}` tuples. To inherit defaults from
-      application config, use `KafkaEx.build_worker_options/1` first (see examples)
+    * `:brokers` — list of `{host, port}` tuples. Defaults to the `:brokers`
+      application config.
+    * `:consumer_group` — consumer group for auto-commit, or
+      `:no_consumer_group`. Defaults to the `:default_consumer_group` config.
+      For a produce-only client, pass `consumer_group: :no_consumer_group` —
+      no group is needed to produce.
+    * `:use_ssl` — enable SSL (default from config, else `false`).
+    * `:ssl_options` — Erlang `:ssl` options (default from config).
+    * `:auth` — SASL auth config, see `KafkaEx.Auth.Config` (default from config).
+    * `:metadata_update_interval` — metadata refresh interval in ms (default `30_000`).
+    * `:allow_auto_topic_creation` — allow brokers to auto-create topics on
+      metadata requests (default `true`). Note: with broker-side
+      `auto.create.topics.enable`, a typo'd topic name can silently create a
+      topic; set to `false` to disable.
+    * `:initial_topics` — topics to fetch metadata for at startup (default `[]`).
+    * `:uris` — **deprecated** alias for `:brokers`; still accepted.
     * `:name` — process registration. Accepts any value valid for
       `GenServer.start_link/3`'s `name:` option:
         * an atom — local registration
@@ -247,24 +265,29 @@ defmodule KafkaEx.API do
         * `{:via, Module, term}` — custom registry (e.g. `Registry`)
       If absent (or `nil`), the client is started unnamed and the pid
       is the identity.
-    * Other options forwarded to `KafkaEx.Client.start_link/2`.
+
+  Returns `{:error, :invalid_consumer_group}` if the resolved consumer
+  group is invalid.
 
   ## Examples
 
-      iex> {:ok, opts} = KafkaEx.build_worker_options([])
-      iex> {:ok, client} = KafkaEx.API.start_client(opts)
-      iex> is_pid(client)
-      true
+      # Inherits brokers + consumer group from application config:
+      {:ok, client} = KafkaEx.API.start_client()
 
-      iex> {:ok, opts} = KafkaEx.build_worker_options([])
-      iex> {:ok, client} = KafkaEx.API.start_client([{:name, MyApp.KafkaClient} | opts])
-      iex> client == Process.whereis(MyApp.KafkaClient)
-      true
+      # Or pass brokers explicitly:
+      {:ok, client} = KafkaEx.API.start_client(brokers: [{"localhost", 9092}])
+
+      # With a registered name:
+      {:ok, client} = KafkaEx.API.start_client(name: MyApp.KafkaClient, brokers: [{"localhost", 9092}])
   """
   @spec start_client(opts) :: {:ok, pid} | {:error, term}
   def start_client(opts \\ []) do
     {name, client_opts} = Keyword.pop(opts, :name)
-    Client.start_link(client_opts, name || :no_name)
+
+    case KafkaEx.build_worker_options(client_opts) do
+      {:ok, worker_opts} -> Client.start_link(worker_opts, name || :no_name)
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """
@@ -281,14 +304,34 @@ defmodule KafkaEx.API do
       ]
 
       Supervisor.start_link(children, strategy: :one_for_one)
+
+  Application config defaults are merged automatically (same as
+  `start_client/1`). Because a child spec cannot carry an error tuple,
+  an invalid consumer group raises `KafkaEx.InvalidConsumerGroupError`
+  when the spec is built.
   """
   @spec child_spec(opts) :: Supervisor.child_spec()
   def child_spec(opts) do
     {name, client_opts} = Keyword.pop(opts, :name)
 
+    worker_opts =
+      case KafkaEx.build_worker_options(client_opts) do
+        {:ok, worker_opts} ->
+          worker_opts
+
+        {:error, :invalid_consumer_group} ->
+          # child_spec/1 must return a spec map, so we cannot return an
+          # error tuple. Raise eagerly at spec-build time (supervisor boot)
+          # for a clear failure instead of a cryptic GenServer init crash.
+          # Surface the *resolved* group (config default when none supplied)
+          # so the message names the real culprit.
+          raise KafkaEx.InvalidConsumerGroupError,
+                Keyword.get(client_opts, :consumer_group, Config.default_consumer_group())
+      end
+
     %{
       id: name || __MODULE__,
-      start: {KafkaEx.Client, :start_link, [client_opts, name || :no_name]},
+      start: {KafkaEx.Client, :start_link, [worker_opts, name || :no_name]},
       type: :worker,
       restart: :permanent
     }

--- a/lib/kafka_ex/client/state.ex
+++ b/lib/kafka_ex/client/state.ex
@@ -47,6 +47,12 @@ defmodule KafkaEx.Client.State do
       use_ssl: Keyword.get(args, :use_ssl, false),
       ssl_options: Keyword.get(args, :ssl_options, []),
       auth: Keyword.get(args, :auth, nil),
+      # Inert unless used: group-coordination calls (offset_commit/fetch,
+      # join/sync/leave/heartbeat, describe_groups) and the stream auto-commit
+      # path all take the group as an explicit argument — none fall back to
+      # this stored value. So defaulting a produce-only client to a real group
+      # name never triggers FindCoordinator/JoinGroup/OffsetCommit. Preserve
+      # that invariant if you ever add an implicit default off this field.
       consumer_group_for_auto_commit: Keyword.get(args, :consumer_group)
     }
   end

--- a/test/integration/lifecycle/start_client_test.exs
+++ b/test/integration/lifecycle/start_client_test.exs
@@ -129,6 +129,24 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
     end
   end
 
+  describe "start_client/1 config-default merging (issue #538)" do
+    test "with :brokers and no build_worker_options inherits config defaults" do
+      # Exact reproduction from issue #538: pass :brokers directly, rely on
+      # config.exs default_consumer_group. Must NOT raise InvalidConsumerGroupError.
+      assert {:ok, client} = API.start_client(brokers: [{"localhost", 9092}])
+      on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+
+      assert is_pid(client)
+    end
+
+    test "still accepts the legacy :uris alias" do
+      assert {:ok, client} = API.start_client(uris: [{"localhost", 9092}])
+      on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+
+      assert is_pid(client)
+    end
+  end
+
   defp wait_until(getter, predicate, timeout_ms) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_until(getter, predicate, deadline)

--- a/test/kafka_ex/api_test.exs
+++ b/test/kafka_ex/api_test.exs
@@ -18,7 +18,7 @@ defmodule KafkaEx.APITest do
   alias KafkaEx.Test.MockClient
 
   describe "child_spec/1" do
-    test "returns valid child spec" do
+    test "returns valid child spec with merged, normalized options" do
       spec = KafkaEx.API.child_spec(name: TestClient, brokers: [{"localhost", 9092}])
 
       assert spec.id == TestClient
@@ -27,7 +27,10 @@ defmodule KafkaEx.APITest do
       assert {KafkaEx.Client, :start_link, [client_opts, name]} = spec.start
       assert name == TestClient
       refute Keyword.has_key?(client_opts, :name)
-      assert client_opts[:brokers] == [{"localhost", 9092}]
+      # :brokers is normalized to :uris, and config defaults are merged in
+      assert client_opts[:uris] == [{"localhost", 9092}]
+      refute Keyword.has_key?(client_opts, :brokers)
+      assert client_opts[:consumer_group] == "kafka_ex"
     end
 
     test "uses module name as default id" do
@@ -35,6 +38,19 @@ defmodule KafkaEx.APITest do
 
       assert spec.id == KafkaEx.API
       assert {KafkaEx.Client, :start_link, [_client_opts, :no_name]} = spec.start
+    end
+
+    test "raises InvalidConsumerGroupError at spec-build time for an empty group" do
+      assert_raise KafkaEx.InvalidConsumerGroupError, fn ->
+        KafkaEx.API.child_spec(brokers: [{"localhost", 9092}], consumer_group: "")
+      end
+    end
+  end
+
+  describe "start_client/1" do
+    test "returns {:error, :invalid_consumer_group} for an empty group (no crash)" do
+      assert {:error, :invalid_consumer_group} =
+               KafkaEx.API.start_client(brokers: [{"localhost", 9092}], consumer_group: "")
     end
   end
 

--- a/test/kafka_ex_test.exs
+++ b/test/kafka_ex_test.exs
@@ -1,0 +1,51 @@
+defmodule KafkaExTest do
+  use ExUnit.Case, async: true
+
+  describe "build_worker_options/1" do
+    test "translates :brokers to :uris" do
+      {:ok, opts} = KafkaEx.build_worker_options(brokers: [{"example", 9092}])
+
+      assert opts[:uris] == [{"example", 9092}]
+      refute Keyword.has_key?(opts, :brokers)
+    end
+
+    test "an explicit :uris wins when both :brokers and :uris are given" do
+      {:ok, opts} = KafkaEx.build_worker_options(uris: [{"u", 1}], brokers: [{"b", 2}])
+
+      assert opts[:uris] == [{"u", 1}]
+      refute Keyword.has_key?(opts, :brokers)
+    end
+
+    test "user :brokers overrides the config-derived default uris" do
+      {:ok, opts} = KafkaEx.build_worker_options(brokers: [{"custom", 1234}])
+
+      assert opts[:uris] == [{"custom", 1234}]
+    end
+
+    test "merges config defaults when nothing is supplied" do
+      {:ok, opts} = KafkaEx.build_worker_options([])
+
+      # config/config.exs sets default_consumer_group: "kafka_ex"
+      assert opts[:consumer_group] == "kafka_ex"
+      assert is_list(opts[:uris])
+    end
+
+    test "returns error for an invalid (empty) consumer group" do
+      assert {:error, :invalid_consumer_group} =
+               KafkaEx.build_worker_options(consumer_group: "")
+    end
+
+    test "accepts :no_consumer_group as a valid group" do
+      {:ok, opts} = KafkaEx.build_worker_options(consumer_group: :no_consumer_group)
+
+      assert opts[:consumer_group] == :no_consumer_group
+    end
+
+    test "is idempotent — feeding its own output back in is a no-op" do
+      {:ok, once} = KafkaEx.build_worker_options(brokers: [{"x", 1}])
+      {:ok, twice} = KafkaEx.build_worker_options(once)
+
+      assert Enum.sort(once) == Enum.sort(twice)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #538. `KafkaEx.API.start_client(brokers: [{"localhost", 9092}])` crashed with `InvalidConsumerGroupError: nil`.

Two root causes, both because `start_client/1` and `child_spec/1` passed options straight to `KafkaEx.Client.start_link` without going through `KafkaEx.build_worker_options/1`:

- **Config defaults were never merged** → a missing `:consumer_group` reached the client as `nil` and failed validation in `KafkaEx.Client.init/1`.
- **The documented `:brokers` option was never read** — the client reads `:uris`, and `build_worker_options/1` only mapped the *config* `:brokers`, not a user-passed keyword.

## Changes

- `build_worker_options/1` now normalizes the canonical `:brokers` option to the internal `:uris` key (explicit `:uris` wins if both are given). Centralizing it here means `start_client/1`, `child_spec/1`, and the legacy `create_worker/2` / `start_link_worker/2` all accept `:brokers` uniformly.
- `start_client/1` and `child_spec/1` funnel through `build_worker_options/1`, so `config.exs` defaults are merged automatically.
- `start_client/1` returns `{:error, :invalid_consumer_group}` instead of crashing; `child_spec/1` raises `KafkaEx.InvalidConsumerGroupError` (naming the resolved group) at spec-build time, since a child spec can't carry an error tuple.
- `:brokers` is now the canonical option key; `:uris` is documented as a deprecated-but-working alias (docs-only, no runtime warning).
- Documented previously-hidden options (`:initial_topics`, `:allow_auto_topic_creation`) and updated README / UPGRADING / CHANGELOG.

## Test Plan

- [x] Unit suite green (`mix test`): `build_worker_options/1` (brokers→uris, precedence, idempotency, `:no_consumer_group`, invalid group), `start_client/1` error path, `child_spec/1` merged-opts shape + eager raise.
- [x] Broker-gated integration coverage added in `test/integration/lifecycle/start_client_test.exs` (exact #538 reproduction + `:uris` alias). Run with a broker: `mix test test/integration/lifecycle/start_client_test.exs --only lifecycle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)