### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## Unreleased
+## 1.0.1 (2026-06-17)
 
 ### Breaking Changes
 
@@ -54,6 +54,26 @@
   - `auto_commit: true` + error response no longer raises `KeyError`
     on `fetch_response.message_set`. `need_commit?/2` returns false
     for error responses, so no commit is attempted.
+
+* **KIP-394 two-step `JoinGroup` no longer retries on `:member_id_required`
+  (#541).** The generic retry loop treated `:member_id_required` as a
+  transient error and blindly re-sent the identical request, which the
+  broker rejected again. `JoinGroup` now uses a dedicated
+  `KafkaEx.Support.Retry.join_group_retryable?/1` classifier that returns
+  `false` for `:member_id_required`, so the two-step path swaps in the
+  broker-assigned `member_id` and rejoins as KIP-394 intends. Required for
+  correct interop with Kafka 2.3+ under
+  `group.initial.rebalance.delay.ms`.
+
+### Internal
+
+* Migrated the test suite's mocking from Hammox to Mimic (`mimic ~> 1.7`),
+  dropping the unused `KafkaEx.NetworkClientMock`. No runtime/production
+  changes. (#534)
+* Added regression test coverage pinning previously-untested behavior:
+  remote-close (`:tcp_closed`/`:ssl_closed`) handling and its telemetry in
+  `KafkaEx.Client` (#449), init fail-fast when all brokers are unreachable
+  (#298), and cross-topic response identity on a single client (#445). (#535)
 
 ## 1.0.0
 

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -309,6 +309,19 @@ defmodule KafkaEx.API do
   `start_client/1`). Because a child spec cannot carry an error tuple,
   an invalid consumer group raises `KafkaEx.InvalidConsumerGroupError`
   when the spec is built.
+
+  > #### Two unnamed clients under one supervisor {: .warning}
+  >
+  > The child `:id` defaults to `:name` (falling back to `KafkaEx.API`
+  > when no name is given). A single unnamed client is fine, but **two
+  > unnamed clients in the same supervisor both get `id: KafkaEx.API`**,
+  > which the supervisor rejects with a "duplicate child specs" error.
+  > Either give each client a `:name`, or override `:id` explicitly:
+  >
+  >     children = [
+  >       Supervisor.child_spec({KafkaEx.API, brokers: [...]}, id: :kafka_a),
+  >       Supervisor.child_spec({KafkaEx.API, brokers: [...]}, id: :kafka_b)
+  >     ]
   """
   @spec child_spec(opts) :: Supervisor.child_spec()
   def child_spec(opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KafkaEx.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kafkaex/kafka_ex"
-  @version "1.0.0"
+  @version "1.0.1"
 
   def project do
     [


### PR DESCRIPTION
## Release v1.0.1

Finalizes the changelog and bumps the version for the **v1.0.1** patch release. Covers the 6 PRs merged since `v1.0.0`.

### What changed
- **`CHANGELOG.md`** — promoted `## Unreleased` → `## 1.0.1 (2026-06-17)`; added the missing Fixed entry for #541; added an **Internal** section for the test/tooling PRs.
- **`mix.exs`** — `@version` `1.0.0` → `1.0.1`.

### PRs included in v1.0.1
| PR | Summary | Section |
|----|---------|---------|
| #542 | `start_client/1`/`child_spec/1` merge config defaults, accept `:brokers` (#538) | Fixed |
| #541 | KIP-394 `JoinGroup` no longer retries on `:member_id_required` | Fixed |
| #537 | `fetch/5`/`Consumer.Stream` hang at logend + stream halt on error | Fixed |
| #536 | honor `:name` in `start_client/1` (unnamed by default) | **Breaking** |
| #535 | regression coverage (#449/#298/#445) | Internal |
| #534 | Hammox → Mimic test-mocking migration | Internal |

### Notes
- #536 is a **breaking change** (`start_client()` no longer registers globally by default) — see `UPGRADING.md`.
- #537 left a consumer-group rebalance test deliberately skipped (known slow-rebalance behavior under the corrected fetch timeouts; fix tracked for the GenConsumer Fetcher/Consumer split). Not a shipped behavior change, so it's not in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
