### PR TITLE
Fix consumer-group sync recovery

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -752,7 +752,12 @@ defmodule KafkaEx.Client do
   end
 
   defp handle_heartbeat_request(request, node_selector, state) do
-    %RequestContext{request: request, parser_fn: &ResponseParser.heartbeat_response/1, node_selector: node_selector}
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.heartbeat_response/1,
+      node_selector: node_selector,
+      retryable?: &Retry.heartbeat_retryable?/1
+    }
     |> handle_request_with_retry(state)
   end
 
@@ -772,7 +777,12 @@ defmodule KafkaEx.Client do
   end
 
   defp handle_sync_group_request(request, node_selector, state) do
-    %RequestContext{request: request, parser_fn: &ResponseParser.sync_group_response/1, node_selector: node_selector}
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.sync_group_response/1,
+      node_selector: node_selector,
+      retryable?: &Retry.sync_group_retryable?/1
+    }
     |> handle_request_with_retry(state)
   end
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -67,7 +67,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       :members,
       :generation_id,
       :assignments,
-      :heartbeat_timer
+      :heartbeat_timer,
+      :sync_retry_backoff_ms,
+      sync_failures: 0
     ]
 
     @type t :: %__MODULE__{
@@ -89,7 +91,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
             members: [binary()] | nil,
             generation_id: integer() | nil,
             assignments: [{binary(), integer()}] | nil,
-            heartbeat_timer: reference() | nil
+            heartbeat_timer: reference() | nil,
+            sync_retry_backoff_ms: non_neg_integer() | nil,
+            sync_failures: non_neg_integer()
           }
   end
 
@@ -103,6 +107,16 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   @max_join_retries 6
   @max_topic_retries 5
+
+  # Default backoff before a SyncGroup-driven rejoin (see handle_sync_error/3);
+  # overridable per consumer group via the `:sync_retry_backoff_ms` opt. Defined
+  # here (before init/1) because init reads it as the default.
+  @sync_retry_backoff_ms 1_000
+
+  # Max consecutive recoverable SyncGroup failures before giving up (the counter
+  # resets on a successful sync). Bounds the rejoin loop the way @max_join_retries
+  # bounds join — a persistent failure escalates to the supervisor rebuild.
+  @max_sync_retries 3
 
   # Gets a value from opts, falling back to application config, then to default
   defp get_with_default(opts, key, default) do
@@ -132,6 +146,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     session_timeout = get_with_default(opts, :session_timeout, @session_timeout)
     session_timeout_padding = get_with_default(opts, :session_timeout_padding, @session_timeout_padding)
     rebalance_timeout = get_with_default(opts, :rebalance_timeout, session_timeout * @rebalance_timeout_multiplier)
+    sync_retry_backoff_ms = get_with_default(opts, :sync_retry_backoff_ms, @sync_retry_backoff_ms)
 
     partition_assignment_callback =
       Keyword.get(opts, :partition_assignment_callback, &PartitionAssignment.round_robin/2)
@@ -145,7 +160,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         :session_timeout,
         :session_timeout_padding,
         :rebalance_timeout,
-        :partition_assignment_callback
+        :partition_assignment_callback,
+        :client,
+        :sync_retry_backoff_ms
       ])
 
     # Use Config defaults for connection options if not provided
@@ -159,7 +176,15 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         initial_topics: topics
       ]
 
-    case Client.start_link(client_opts, :no_name) do
+    # A pre-supplied `:client` (test-only dependency injection) bypasses starting
+    # a real client; production callers never set it, so this is inert in prod.
+    client_result =
+      case Keyword.get(opts, :client) do
+        nil -> Client.start_link(client_opts, :no_name)
+        pid when is_pid(pid) -> {:ok, pid}
+      end
+
+    case client_result do
       {:ok, client} ->
         state = %State{
           supervisor_pid: supervisor_pid,
@@ -174,7 +199,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           consumer_opts: consumer_opts,
           group_name: group_name,
           topics: topics,
-          member_id: nil
+          member_id: nil,
+          sync_retry_backoff_ms: sync_retry_backoff_ms
         }
 
         Process.flag(:trap_exit, true)
@@ -484,7 +510,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     min(delay, @join_retry_max_delay_ms)
   end
 
-  defp on_successful_join(state, join_response) do
+  defp on_successful_join(%State{} = state, join_response) do
     Logger.debug(
       "Joined consumer group #{state.group_name} generation:#{join_response.generation_id}-#{join_response.member_id}"
     )
@@ -538,6 +564,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
     case KafkaExAPI.sync_group(client, group_name, generation_id, member_id, opts) do
       {:ok, sync_response} ->
+        # A successful sync clears the consecutive-recoverable-failure counter.
+        state = %State{state | sync_failures: 0}
         {:ok, state} = start_heartbeat_timer(state)
         {:ok, state} = stop_consumer(state)
         consumer_assignments = extract_consumer_assignments(sync_response.partition_assignments)
@@ -547,7 +575,44 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         rebalance(state, :rebalance_in_progress)
 
       {:error, reason} ->
+        handle_sync_error(state, group_name, reason)
+    end
+  end
+
+  # SyncGroup recovery — mirrors join/2's recoverable-error handling. A transient
+  # SyncGroup failure (e.g. :unknown / :timeout from a coordinator under rebalance
+  # churn, such as a rolling deploy) must not crash the Manager: the crash escalates
+  # through the one_for_all / max_restarts: 0 consumer-group supervisor into a full
+  # subtree teardown, triggering a group-wide rebalance.
+  # Rejoining is the correct recovery (a fresh generation); retrying sync_group
+  # with the same, possibly stale, generation_id is futile.
+  #
+  # Bounded like join: tolerate up to @max_sync_retries consecutive recoverable
+  # failures (the counter resets on a successful sync), then give up and raise —
+  # escalating a persistent failure to the supervisor rebuild rather than
+  # rejoining forever (cf. join's JoinGroupRetriesExhausted). Non-recoverable
+  # errors raise immediately.
+  defp handle_sync_error(%State{} = state, group_name, reason) do
+    cond do
+      not recoverable_error?(reason) ->
         raise KafkaEx.SyncGroupError, group_name: group_name, reason: reason
+
+      state.sync_failures >= @max_sync_retries ->
+        raise KafkaEx.SyncGroupRetriesExhaustedError,
+          group_name: group_name,
+          last_error: reason,
+          attempts: @max_sync_retries
+
+      true ->
+        attempt = state.sync_failures + 1
+
+        Logger.warning(
+          "Unable to sync consumer group #{inspect(group_name)}: #{inspect(reason)}. " <>
+            "Rejoining in #{div(state.sync_retry_backoff_ms, 1000)}s (attempt #{attempt}/#{@max_sync_retries})."
+        )
+
+        :timer.sleep(state.sync_retry_backoff_ms)
+        rebalance(%State{state | sync_failures: attempt}, {:sync_error, reason})
     end
   end
 

--- a/lib/kafka_ex/support/exceptions.ex
+++ b/lib/kafka_ex/support/exceptions.ex
@@ -74,6 +74,29 @@ defmodule KafkaEx.SyncGroupError do
   end
 end
 
+defmodule KafkaEx.SyncGroupRetriesExhaustedError do
+  @moduledoc """
+  Raised when syncing a consumer group fails after exhausting all retry attempts.
+
+  Indicates repeated recoverable SyncGroup failures (coordinator errors,
+  timeouts, etc.) during rebalance churn that didn't resolve within the retry
+  window. Distinct from `KafkaEx.SyncGroupError`, which is raised immediately for
+  a non-recoverable sync failure. Mirrors `KafkaEx.JoinGroupRetriesExhaustedError`.
+  """
+  defexception [:message, :group_name, :last_error, :attempts]
+
+  def exception(opts) do
+    group_name = Keyword.fetch!(opts, :group_name)
+    last_error = Keyword.fetch!(opts, :last_error)
+    attempts = Keyword.fetch!(opts, :attempts)
+
+    message =
+      "Unable to sync consumer group #{group_name} after #{attempts} attempts (last error: #{inspect(last_error)})"
+
+    %__MODULE__{message: message, group_name: group_name, last_error: last_error, attempts: attempts}
+  end
+end
+
 defmodule KafkaEx.MetadataUpdateError do
   @moduledoc """
   Raised when periodic metadata updates fail after exhausting all retry attempts.

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -243,6 +243,43 @@ defmodule KafkaEx.Support.Retry do
   def commit_retryable?(error), do: transient_error?(error)
 
   @doc """
+  Check if a SyncGroup error is safe to retry at the client layer.
+
+  `:rebalance_in_progress` must not be retried at the client layer. A SyncGroup
+  during a rebalance can only succeed after rejoining (the generation is
+  changing), so the error must bubble to the consumer-group manager, whose
+  `sync/2` rejoins on it. Blindly re-sending the same SyncGroup wastes round
+  trips and is the window in which a recv-timeout gets mapped to `:unknown`
+  (which would otherwise crash the manager). Other errors keep the default
+  retry behavior.
+
+  Contrast `commit_retryable?/1`, where retrying `:rebalance_in_progress` is
+  correct — commits are idempotent and need no rejoin.
+  """
+  @spec sync_group_retryable?(error()) :: boolean()
+  def sync_group_retryable?(:rebalance_in_progress), do: false
+  def sync_group_retryable?(_), do: true
+
+  @doc """
+  Check if a Heartbeat error is safe to retry at the client layer.
+
+  The heartbeat process stops on any error and lets the manager react
+  (`Heartbeat.handle_info/2`), so the only retry is here at the client. Its
+  value is absorbing a transient blip (timeout / coordinator hiccup) so a
+  single failed heartbeat does not escalate into a full rejoin + group-wide
+  rebalance — hence default-retry for unclassified errors.
+
+  The broker's two "rejoin now" signals — `:rebalance_in_progress` and
+  `:unknown_member_id` — are mapped by the heartbeat process straight to
+  `{:shutdown, :rebalance}`; retrying them at the client only delays the
+  inevitable rejoin, so they are not retryable.
+  """
+  @spec heartbeat_retryable?(error()) :: boolean()
+  def heartbeat_retryable?(:rebalance_in_progress), do: false
+  def heartbeat_retryable?(:unknown_member_id), do: false
+  def heartbeat_retryable?(_), do: true
+
+  @doc """
   Check if a commit error is fatal and requires rejoining the consumer group.
 
   These errors cannot be fixed by retry — the consumer's generation or member_id

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -486,7 +486,7 @@ defmodule KafkaEx.Telemetry do
           binary(),
           binary(),
           integer() | nil,
-          atom() | {:heartbeat_error, atom()} | {:commit_fatal, atom()}
+          atom() | {:heartbeat_error, atom()} | {:commit_fatal, atom()} | {:sync_error, atom()}
         ) :: :ok
   def emit_rebalance(group_id, member_id, generation_id, reason) do
     :telemetry.execute(

--- a/test/integration/consumer_group/rebalance_recovery_test.exs
+++ b/test/integration/consumer_group/rebalance_recovery_test.exs
@@ -1,0 +1,88 @@
+defmodule KafkaEx.Integration.ConsumerGroup.RebalanceRecoveryTest do
+  @moduledoc """
+  Exercises a real multi-member rebalance against the shared integration cluster
+  (start it with `./scripts/docker_up.sh`).
+
+  When a second member joins the group, the first member's in-flight SyncGroup /
+  Heartbeat receives `:rebalance_in_progress`. With the `sync_group` /
+  `heartbeat` retryable predicates that error bubbles straight to the manager's
+  rejoin (instead of being blind-retried in the client loop), and both members
+  converge to a clean, disjoint partition split. Regression that the predicate
+  change does not break normal rebalance convergence.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 180_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+
+    topic = "cg_rebalance_recovery_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 2)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{uris: uris, topic: topic}}
+  end
+
+  test "a second member joining converges both members to a disjoint partition split", %{
+    uris: uris,
+    topic: topic
+  } do
+    Process.flag(:trap_exit, true)
+    group = "cg_rebalance_recovery_grp_#{:rand.uniform(1_000_000)}"
+
+    {:ok, cg1} = start_member(uris, topic, group)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg1) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg1, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg1, timeout: 30_000)
+
+    # Second member joins the SAME group → triggers a rebalance; member 1's
+    # in-flight SyncGroup/Heartbeat sees :rebalance_in_progress, which now
+    # bubbles to the manager's rejoin instead of being blind-retried.
+    {:ok, cg2} = start_member(uris, topic, group)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg2) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg1, timeout: 60_000)
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg2, timeout: 60_000)
+    assert {:ok, a1} = ConsumerGroupHelpers.wait_for_assignments(cg1, timeout: 30_000)
+    assert {:ok, a2} = ConsumerGroupHelpers.wait_for_assignments(cg2, timeout: 30_000)
+
+    # Both survived the rebalance, and the 2 partitions are split disjointly.
+    assert Process.alive?(cg1) and Process.alive?(cg2)
+
+    p1 = MapSet.new(for {^topic, p} <- a1, do: p)
+    p2 = MapSet.new(for {^topic, p} <- a2, do: p)
+
+    assert MapSet.size(p1) > 0 and MapSet.size(p2) > 0,
+           "both members must hold partitions after the rebalance (got #{inspect(p1)} / #{inspect(p2)})"
+
+    assert MapSet.disjoint?(p1, p2), "assignments must not overlap"
+    assert MapSet.union(p1, p2) == MapSet.new([0, 1]), "both partitions must be covered"
+  end
+
+  defp start_member(uris, topic, group) do
+    opts = [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest,
+      extra_consumer_args: %{test_pid: self()}
+    ]
+
+    ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
@@ -1,0 +1,86 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerSyncRecoveryTest do
+  @moduledoc """
+  Unit test for the Manager's SyncGroup give-up bound (`handle_sync_error/3`).
+
+  Drives a real Manager against a scripted `MockClient` (via the `:client`
+  injection seam in `init/1`): JoinGroup succeeds, SyncGroup always returns a
+  recoverable `:unknown`. The fix routes a recoverable sync error to a rejoin
+  rather than crashing, but bounds the rejoin loop at `@max_sync_retries`
+  consecutive failures so a *persistent* failure escalates (raises
+  `SyncGroupRetriesExhaustedError` → supervisor rebuild) instead of looping forever.
+
+  This also exercises the core of the recovery behavior: each recoverable sync
+  error triggers a *rejoin, not a crash* (3 attempts here, each emitting a
+  `{:sync_error, _}` rebalance), and pins the bound — give up on the next
+  failure. End-to-end rebalance convergence (the `:rebalance_in_progress` path)
+  is covered by the integration test
+  `KafkaEx.Integration.ConsumerGroup.RebalanceRecoveryTest`.
+  """
+  use ExUnit.Case, async: false
+
+  alias KafkaEx.Consumer.ConsumerGroup.Manager
+  alias KafkaEx.Consumer.GenConsumer
+  alias KafkaEx.Messages.JoinGroup
+  alias KafkaEx.Test.MockClient
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  test "gives up after a bounded number of consecutive recoverable SyncGroup failures" do
+    Process.flag(:trap_exit, true)
+
+    # Each rejoin attempt emits a {:sync_error, _} rebalance. Counted via a shared
+    # atomics ref (survives the manager terminating its client on give-up).
+    rejoins = :counters.new(1, [:atomics])
+    handler_id = {:give_up_test, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :rebalance],
+      fn _event, _measurements, %{reason: reason}, _ ->
+        case reason do
+          {:sync_error, _} -> :counters.add(rejoins, 1, 1)
+          _ -> :ok
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    # Bare supervisor: rebalance/2 -> stop_consumer/1 calls
+    # Supervisor.terminate_child(sup, :consumer), which returns {:error, :not_found}
+    # here (no consumer child) -> :ok. No real consumers start because sync never
+    # succeeds.
+    {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+    on_exit(fn -> if Process.alive?(sup), do: Supervisor.stop(sup) end)
+
+    {:ok, mock} =
+      MockClient.start_link(%{
+        # leader_id != member_id → this member is not the leader, so it skips
+        # partition assignment/metadata and goes straight to SyncGroup.
+        join_group: {:ok, %JoinGroup{member_id: "m1", leader_id: "m2", generation_id: 1, members: []}},
+        sync_group: {:error, :unknown}
+      })
+
+    opts = [
+      supervisor_pid: sup,
+      client: mock,
+      heartbeat_interval: 60_000,
+      session_timeout: 10_000,
+      # keep the unit test fast — no real 1s backoffs between rejoin attempts
+      sync_retry_backoff_ms: 5
+    ]
+
+    {:ok, manager} =
+      Manager.start_link({{GenConsumer, TestGenConsumer}, "give-up-group", ["t"], opts})
+
+    # The manager must terminate (give up) with SyncGroupRetriesExhaustedError
+    # rather than rejoining forever. (Backoff is set to 5ms above, so this is fast.)
+    assert_receive {:EXIT, ^manager, {%KafkaEx.SyncGroupRetriesExhaustedError{}, _stacktrace}},
+                   30_000
+
+    # @max_sync_retries (3) rejoin attempts each emit a {:sync_error, _} rebalance;
+    # the next consecutive failure gives up (raises) without rebalancing.
+    assert :counters.get(rejoins, 1) == 3,
+           "expected the rejoin loop bounded to 3 attempts, got #{:counters.get(rejoins, 1)}"
+  end
+end

--- a/test/kafka_ex/support/exceptions_test.exs
+++ b/test/kafka_ex/support/exceptions_test.exs
@@ -140,6 +140,48 @@ defmodule KafkaEx.Support.ExceptionsTest do
     end
   end
 
+  describe "KafkaEx.SyncGroupRetriesExhaustedError" do
+    test "formats message with all details" do
+      exception =
+        KafkaEx.SyncGroupRetriesExhaustedError.exception(
+          group_name: "my-group",
+          last_error: :unknown,
+          attempts: 3
+        )
+
+      assert exception.message =~ "Unable to sync consumer group my-group"
+      assert exception.message =~ "after 3 attempts"
+      assert exception.message =~ ":unknown"
+      assert exception.group_name == "my-group"
+      assert exception.last_error == :unknown
+      assert exception.attempts == 3
+    end
+
+    test "can be raised and caught" do
+      assert_raise KafkaEx.SyncGroupRetriesExhaustedError, ~r/after \d+ attempts/, fn ->
+        raise KafkaEx.SyncGroupRetriesExhaustedError,
+          group_name: "test-group",
+          last_error: :timeout,
+          attempts: 3
+      end
+    end
+
+    test "exception struct contains all fields" do
+      exception =
+        KafkaEx.SyncGroupRetriesExhaustedError.exception(
+          group_name: "g",
+          last_error: :e,
+          attempts: 1
+        )
+
+      assert %KafkaEx.SyncGroupRetriesExhaustedError{} = exception
+      assert Map.has_key?(exception, :message)
+      assert Map.has_key?(exception, :group_name)
+      assert Map.has_key?(exception, :last_error)
+      assert Map.has_key?(exception, :attempts)
+    end
+  end
+
   describe "KafkaEx.SyncGroupError" do
     test "formats message with group name and reason" do
       exception = KafkaEx.SyncGroupError.exception(group_name: "my-group", reason: :unknown_member_id)

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -385,4 +385,29 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.join_group_retryable?(:unknown)
     end
   end
+
+  describe "sync_group_retryable?/1" do
+    test "rebalance_in_progress is NOT retryable (must bubble so the manager rejoins)" do
+      refute Retry.sync_group_retryable?(:rebalance_in_progress)
+    end
+
+    test "other sync errors remain retryable (manager's sync recovery handles them)" do
+      assert Retry.sync_group_retryable?(:request_timed_out)
+      assert Retry.sync_group_retryable?(:unknown)
+      assert Retry.sync_group_retryable?(:coordinator_not_available)
+    end
+  end
+
+  describe "heartbeat_retryable?/1" do
+    test "rejoin signals are NOT retryable (heartbeat maps them to {:shutdown, :rebalance})" do
+      refute Retry.heartbeat_retryable?(:rebalance_in_progress)
+      refute Retry.heartbeat_retryable?(:unknown_member_id)
+    end
+
+    test "transient errors remain retryable (absorb a blip, avoid a spurious rejoin)" do
+      assert Retry.heartbeat_retryable?(:request_timed_out)
+      assert Retry.heartbeat_retryable?(:unknown)
+      assert Retry.heartbeat_retryable?(:coordinator_not_available)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #545 

It introduces two fixes as follows:

-  ensures that the Managers recovers instead of crashing, bounded: before `sync/2` raised `SyncGroupError` on any non-rebalance error (including `:unknown` / `:timeout` from a coordinator under rebalance churn), and the consumer-group supervisor (one_for_all, max_restarts: 0) escalated that crash into a full-subtree teardown, re-triggering a group-wide rebalance. A recoverable sync error now routes to `rebalance` (in-place rejoin), bounded at @max_sync_retries consecutive failures (reset on a successful sync) before giving up. This mirrors join API `JoinGroupRetriesExhausted`.

- stop blind-retrying the rejoin signal: `sync_group` / heartbeat inherited the RequestContext `always_retryable` default, so a normal `:rebalance_in_progress` was retried 3 times. This is pointless, a rebalance won't complete in between sub-ms retries. They now set `sync_group_retryable?` / `heartbeat_retryable?` predicates so `:rebalance_in_progress` (and, for heartbeat, `:unknown_member_id`) bubbles to the manager's existing rejoin.

New tests added: predicate unit tests; a deterministic give-up bound test (drives a real Manager against MockClient via a small test-only :client injection seam in Manager.init, inert in prod); and finally an integration test for two-member rebalance convergence.
