### PR TITLE
fix: re-discover the group coordinator on NOT_COORDINATOR

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -893,15 +893,7 @@ defmodule KafkaEx.Client do
     Logger.warning("Request #{inspect(request_name)} failed with error #{inspect(error_atom)}")
 
     if ctx.retryable?.(error_atom) do
-      # Refresh metadata for leadership-related errors before retrying
-      updated_state =
-        if requires_metadata_refresh?(error_atom) do
-          Logger.info("Refreshing metadata due to #{inspect(error_atom)} error")
-          update_metadata(state)
-        else
-          state
-        end
-
+      updated_state = refresh_for_error(error_atom, ctx, state)
       handle_request_with_retry(ctx, updated_state, retry_count - 1, error)
     else
       # Non-retryable error - fail immediately
@@ -921,6 +913,34 @@ defmodule KafkaEx.Client do
   defp requires_metadata_refresh?(:not_leader_or_follower), do: true
   defp requires_metadata_refresh?(:fenced_leader_epoch), do: true
   defp requires_metadata_refresh?(_), do: false
+
+  defp requires_coordinator_refresh?(:not_coordinator), do: true
+  defp requires_coordinator_refresh?(:coordinator_not_available), do: true
+  defp requires_coordinator_refresh?(_), do: false
+
+  defp refresh_for_error(error_atom, ctx, state) do
+    cond do
+      requires_metadata_refresh?(error_atom) ->
+        Logger.info("Refreshing metadata due to #{inspect(error_atom)} error")
+        update_metadata(state)
+
+      coordinator_request?(ctx.node_selector) and requires_coordinator_refresh?(error_atom) ->
+        Logger.info("Re-discovering group coordinator due to #{inspect(error_atom)} error")
+        refresh_coordinator(state, ctx.node_selector.consumer_group_name)
+
+      true ->
+        state
+    end
+  end
+
+  defp coordinator_request?(%NodeSelector{strategy: :consumer_group}), do: true
+  defp coordinator_request?(_), do: false
+
+  defp refresh_coordinator(state, consumer_group) do
+    state
+    |> State.drop_consumer_group_coordinator(consumer_group)
+    |> update_consumer_group_coordinator(consumer_group)
+  end
 
   # ----------------------------------------------------------------------------------------------------
   defp maybe_connect_broker(broker, state) do

--- a/lib/kafka_ex/client/state.ex
+++ b/lib/kafka_ex/client/state.ex
@@ -80,6 +80,11 @@ defmodule KafkaEx.Client.State do
     %{state | cluster_metadata: new_metadata}
   end
 
+  def drop_consumer_group_coordinator(%__MODULE__{cluster_metadata: cluster_metadata} = state, group) do
+    new_metadata = ClusterMetadata.drop_consumer_group_coordinator(cluster_metadata, group)
+    %{state | cluster_metadata: new_metadata}
+  end
+
   def remove_topics(%__MODULE__{cluster_metadata: cluster_metadata} = state, topics) do
     %{state | cluster_metadata: ClusterMetadata.remove_topics(cluster_metadata, topics)}
   end

--- a/lib/kafka_ex/cluster/broker.ex
+++ b/lib/kafka_ex/cluster/broker.ex
@@ -14,7 +14,7 @@ defmodule KafkaEx.Cluster.Broker do
           host: binary,
           port: non_neg_integer,
           socket: Socket.t() | nil,
-          rack: binary
+          rack: binary | nil
         }
 
   @doc """

--- a/lib/kafka_ex/cluster/cluster_metadata.ex
+++ b/lib/kafka_ex/cluster/cluster_metadata.ex
@@ -126,7 +126,11 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
         end)
       end)
 
-    {%{new_cluster_metadata | brokers: new_brokers}, brokers_to_close}
+    {%{
+       new_cluster_metadata
+       | brokers: new_brokers,
+         consumer_group_coordinators: old_cluster_metadata.consumer_group_coordinators
+     }, brokers_to_close}
   end
 
   @doc """
@@ -165,6 +169,18 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
             coordinator_node_id
           )
     }
+  end
+
+  @doc """
+  Forget the cached coordinator for a consumer group, forcing the next request to
+  re-run FindCoordinator (e.g. after a NOT_COORDINATOR response).
+  """
+  @spec drop_consumer_group_coordinator(t, KafkaExAPI.consumer_group_name()) :: t
+  def drop_consumer_group_coordinator(
+        %__MODULE__{consumer_group_coordinators: consumer_group_coordinators} = cluster_metadata,
+        consumer_group
+      ) do
+    %{cluster_metadata | consumer_group_coordinators: Map.delete(consumer_group_coordinators, consumer_group)}
   end
 
   @doc """

--- a/test/integration/consumer_group/coordinator_rediscovery_test.exs
+++ b/test/integration/consumer_group/coordinator_rediscovery_test.exs
@@ -1,0 +1,66 @@
+defmodule KafkaEx.Integration.ConsumerGroup.CoordinatorRediscoveryTest do
+  @moduledoc """
+  Integration regression for PR-3 / defect C-3.
+
+  When a consumer-group request reaches a broker that is NOT the group coordinator,
+  the broker returns NOT_COORDINATOR. The client must invalidate its cached
+  coordinator and re-run FindCoordinator before retrying — not blind-retry the wrong
+  broker (the rolling-deploy hang).
+
+  We trigger a *real* NOT_COORDINATOR deterministically (no broker killing) by seeding
+  the client's coordinator cache with the wrong broker via `:sys.replace_state`, then
+  issuing a real consumer-group request against the live cluster.
+
+  Pre-fix this returned `{:error, :not_coordinator}` (blind-retried the wrong broker);
+  post-fix it re-discovers the real coordinator and succeeds.
+  """
+  use ExUnit.Case, async: false
+  @moduletag :consumer_group
+
+  import KafkaEx.TestHelpers
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.API
+  alias KafkaEx.Client
+  alias KafkaEx.Client.State
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+
+    {:ok, %{client: client}}
+  end
+
+  @tag timeout: 60_000
+  test "a consumer-group request to a stale coordinator re-discovers and succeeds", %{client: client} do
+    topic = generate_random_string()
+    group = generate_random_string()
+    _ = create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    partitions = [%{partition_num: 0}]
+
+    # First request populates the real coordinator in the cache.
+    assert {:ok, _} = API.fetch_committed_offset(client, group, topic, partitions)
+
+    state = :sys.get_state(client)
+    real_coord = state.cluster_metadata.consumer_group_coordinators[group]
+    wrong_node = state.cluster_metadata.brokers |> Map.keys() |> Enum.find(&(&1 != real_coord))
+
+    assert wrong_node,
+           "need a multi-broker cluster to pick a non-coordinator broker (got brokers: " <>
+             "#{inspect(Map.keys(state.cluster_metadata.brokers))}, coord: #{inspect(real_coord)})"
+
+    # Seed the cache with the WRONG coordinator -> the next request hits a broker that
+    # really is not the coordinator for this group and returns NOT_COORDINATOR.
+    :sys.replace_state(client, fn st -> State.put_consumer_group_coordinator(st, group, wrong_node) end)
+
+    # PR-3: invalidate + re-discover + succeed.
+    assert {:ok, _} = API.fetch_committed_offset(client, group, topic, partitions)
+
+    # the cache self-corrected back to the real coordinator
+    healed = :sys.get_state(client).cluster_metadata.consumer_group_coordinators[group]
+    assert healed == real_coord
+  end
+end

--- a/test/kafka_ex/client/coordinator_refresh_test.exs
+++ b/test/kafka_ex/client/coordinator_refresh_test.exs
@@ -59,7 +59,7 @@ defmodule KafkaEx.Client.CoordinatorRefreshTest do
     # FindCoordinator is only built when the client decides to re-discover.
     stub(RequestBuilder, :find_coordinator_request, fn _opts, _state ->
       send(test_pid, :rediscovered)
-      {:error, :stub_short_circuit}
+      {:error, :api_version_no_supported}
     end)
 
     Client.handle_call(

--- a/test/kafka_ex/client/coordinator_refresh_test.exs
+++ b/test/kafka_ex/client/coordinator_refresh_test.exs
@@ -1,0 +1,74 @@
+defmodule KafkaEx.Client.CoordinatorRefreshTest do
+  @moduledoc """
+  Regression for PR-3 / defect C-3: a NOT_COORDINATOR (or COORDINATOR_NOT_AVAILABLE)
+  response on a consumer-group request must invalidate the cached coordinator and
+  re-run FindCoordinator before retrying — not blind-retry the stale broker.
+
+  Pre-fix, `requires_metadata_refresh?/1` only knew leadership errors, so
+  `:not_coordinator` retried the same cached coordinator and FindCoordinator was
+  never re-issued (the rolling-deploy hang). Driven through the real `handle_call`
+  path; no private function is exposed.
+
+  The `:not_coordinator` is injected via the network seam (PR-2 now surfaces the
+  real atom into the retry loop); the observable is that a FindCoordinator request
+  gets *built* — which only happens when the client re-discovers the coordinator.
+  """
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias KafkaEx.Client
+  alias KafkaEx.Client.RequestBuilder
+  alias KafkaEx.Client.State
+  alias KafkaEx.Cluster.Broker
+  alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Network.NetworkClient
+  alias KafkaEx.Network.Socket
+
+  setup :set_mimic_private
+
+  setup do
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, lport} = :inet.port(listen)
+    {:ok, sock} = :gen_tcp.connect(~c"localhost", lport, [:binary, active: false])
+
+    on_exit(fn ->
+      :gen_tcp.close(sock)
+      :gen_tcp.close(listen)
+    end)
+
+    broker = %Broker{node_id: 1, host: "localhost", port: lport, socket: %Socket{socket: sock, ssl: false}}
+
+    state = %State{
+      consumer_group_for_auto_commit: "test-group",
+      api_versions: %{9 => {0, 3}},
+      correlation_id: 1,
+      cluster_metadata: %ClusterMetadata{
+        brokers: %{1 => broker},
+        consumer_group_coordinators: %{"test-group" => 1}
+      }
+    }
+
+    {:ok, state: state}
+  end
+
+  test ":not_coordinator on a consumer-group request triggers coordinator re-discovery", %{state: state} do
+    test_pid = self()
+
+    stub(NetworkClient, :send_sync_request, fn _broker, _wire, _timeout -> {:error, :not_coordinator} end)
+
+    # FindCoordinator is only built when the client decides to re-discover.
+    stub(RequestBuilder, :find_coordinator_request, fn _opts, _state ->
+      send(test_pid, :rediscovered)
+      {:error, :stub_short_circuit}
+    end)
+
+    Client.handle_call(
+      {:offset_fetch, "test-group", [{"t", [%{partition_num: 0}]}], []},
+      self(),
+      state
+    )
+
+    # pre-fix this never fires: :not_coordinator retried the stale cached coordinator
+    assert_received :rediscovered
+  end
+end

--- a/test/kafka_ex/cluster/cluster_metadata_test.exs
+++ b/test/kafka_ex/cluster/cluster_metadata_test.exs
@@ -269,6 +269,42 @@ defmodule KafkaEx.Cluster.ClusterMetadataTest do
       assert merged_cluster.controller_id == 2
       assert Map.has_key?(merged_cluster.topics, "test-topic")
     end
+
+    test "preserves cached consumer group coordinators across a metadata refresh" do
+      old_cluster = %ClusterMetadata{
+        brokers: %{1 => %Broker{node_id: 1, host: "b1.example.com", port: 9092, socket: nil}},
+        consumer_group_coordinators: %{"group-a" => 1}
+      }
+
+      # a fresh Metadata response parse always carries empty coordinators;
+      # the merge must not discard the old ones (the 30s-refresh wipe, M-2)
+      new_cluster = %ClusterMetadata{
+        brokers: %{1 => %Broker{node_id: 1, host: "b1.example.com", port: 9092, socket: nil}},
+        consumer_group_coordinators: %{}
+      }
+
+      {merged_cluster, _} = ClusterMetadata.merge_brokers(old_cluster, new_cluster)
+
+      assert merged_cluster.consumer_group_coordinators == %{"group-a" => 1}
+    end
+  end
+
+  describe "drop_consumer_group_coordinator/2" do
+    test "removes the cached coordinator for the given group, leaving others" do
+      cluster = %ClusterMetadata{consumer_group_coordinators: %{"group-a" => 1, "group-b" => 2}}
+
+      dropped = ClusterMetadata.drop_consumer_group_coordinator(cluster, "group-a")
+
+      assert dropped.consumer_group_coordinators == %{"group-b" => 2}
+    end
+
+    test "is a no-op when the group has no cached coordinator" do
+      cluster = %ClusterMetadata{consumer_group_coordinators: %{"group-b" => 2}}
+
+      dropped = ClusterMetadata.drop_consumer_group_coordinator(cluster, "group-a")
+
+      assert dropped.consumer_group_coordinators == %{"group-b" => 2}
+    end
   end
 
   describe "broker_by_node_id/1" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,9 +11,9 @@ ExUnit.configure(
   ]
 )
 
-# Prepare the network I/O seam for unit tests that stub it via Mimic
-# (no-op for tests that don't stub).
+# Prepare the seams that unit tests stub via Mimic (no-op for tests that don't stub).
 Mimic.copy(KafkaEx.Network.NetworkClient)
+Mimic.copy(KafkaEx.Client.RequestBuilder)
 
 ExUnit.start()
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,7 +12,9 @@ ExUnit.configure(
 )
 
 # Prepare the seams that unit tests stub via Mimic (no-op for tests that don't stub).
-Mimic.copy(KafkaEx.Network.NetworkClient)
+# type_check: true validates stub args + return values against the module's typespecs,
+# so a stub can't return a value the real function never could (network I/O seam).
+Mimic.copy(KafkaEx.Network.NetworkClient, type_check: true)
 Mimic.copy(KafkaEx.Client.RequestBuilder)
 
 ExUnit.start()


### PR DESCRIPTION
## Problem

A consumer-group request (heartbeat / offset-commit / join / sync / offset-fetch) that received `NOT_COORDINATOR` or `COORDINATOR_NOT_AVAILABLE` was **retried against the same cached coordinator broker**. `requires_metadata_refresh?/1` only recognised partition-leadership errors, so the stale/dead coordinator was never invalidated — it was only re-discovered on a *cold* cache miss.

On every rolling Kafka deploy the group coordinator moves, so consumers blind-retried a dead broker, the manager rejoined, JoinGroup hit the same stale coordinator, and the group could hang until the join-retry budget was exhausted (`JoinGroupRetriesExhaustedError`). Separately, `merge_brokers/2` **wiped the entire coordinator cache every 30s** on the periodic metadata refresh (needless FindCoordinator churn that only accidentally masked the staleness bug).

## Change

- **`client.ex`** — on `:not_coordinator` / `:coordinator_not_available` for a consumer-group request, **drop the cached coordinator and re-run FindCoordinator before retrying** (`requires_coordinator_refresh?/1` + `refresh_for_error/3` + `refresh_coordinator/2`, drop-then-rediscover). `:coordinator_load_in_progress` is intentionally **excluded** — the broker is the coordinator, just loading, so retry the same node.
- **`cluster_metadata.ex`** — `merge_brokers/2` now **preserves** `consumer_group_coordinators` across the metadata refresh; adds `drop_consumer_group_coordinator/2`.
- **`state.ex`** — delegation.

## Why this is correct

The mapping (15 + 16 → invalidate + rediscover; 14 → retry same) is faithful to all three reference clients: Kafka Java `AbstractCoordinator.markCoordinatorUnknown()` (on 15 and 16), librdkafka (`ACTION_REFRESH` for 15/16 vs `ACTION_RETRY` for 14), and brod (rediscovers on every stabilize). Preserving the coordinator across metadata refreshes also matches the reference clients, which hold the coordinator until explicitly marked-unknown — and it's safe because 15/16 still force invalidation.

## Tests

- `coordinator_refresh_test.exs` — regression: `:not_coordinator` on a consumer-group request now triggers FindCoordinator re-discovery (verified failing on the pre-fix code, where it was blind-retried 3×). Driven through the real `handle_call` path.
- `cluster_metadata_test.exs` — coordinators survive a metadata merge (the 30s-wipe fix) + `drop_consumer_group_coordinator/2`.
- Full unit suite green.

## Scope / deferred follow-ups

- **Transport-layer coordinator invalidation** — all three reference clients also mark the coordinator unknown on a *transport* disconnect/timeout. This PR does **not** route `:timeout`/`:closed`/`:not_connected` to coordinator rediscovery, because doing so naively drops the coordinator and surfaces `:no_broker` instead of the real atom (regressing the transport-atom preservation from #544). Today these remain recoverable→rejoin and re-resolve via the cold-miss path. Deferred to a dedicated follow-up that re-discovers without clobbering the surfaced atom.
- **Coordinator-move chaos test** (Toxiproxy down-the-coordinator → rediscover + rejoin bounded) to land alongside that follow-up.

Builds on #544 (transport-atom preservation) and complements #546 (sync recovery).