### PR TITLE
test: stabilize three flaky consumer-group / config tests

### DIFF
--- a/test/integration/consumer_group/lifecycle_test.exs
+++ b/test/integration/consumer_group/lifecycle_test.exs
@@ -39,7 +39,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.LifecycleTest do
       ]
 
       opts = [session_timeout: 30_000, rebalance_timeout: 60_000, group_protocols: group_protocols]
-      {:ok, join_response} = API.join_group(client, consumer_group, "", opts)
+      {:ok, join_response} = join_group_with_retry(client, consumer_group, "", opts)
 
       assert %JoinGroup{} = join_response
       assert join_response.generation_id >= 1
@@ -112,7 +112,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.LifecycleTest do
 
       # Join with short session timeout (6 seconds)
       opts = [session_timeout: 6_000, rebalance_timeout: 10_000, group_protocols: group_protocols]
-      {:ok, join_response} = API.join_group(client, consumer_group, "", opts)
+      {:ok, join_response} = join_group_with_retry(client, consumer_group, "", opts)
 
       member_id = join_response.member_id
       generation_id = join_response.generation_id
@@ -161,7 +161,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.LifecycleTest do
       ]
 
       opts = [session_timeout: 30_000, rebalance_timeout: 60_000, group_protocols: group_protocols]
-      {:ok, join_response} = API.join_group(client, consumer_group, "", opts)
+      {:ok, join_response} = join_group_with_retry(client, consumer_group, "", opts)
 
       member_id = join_response.member_id
       generation_id = join_response.generation_id

--- a/test/kafka_ex/auth/config_test.exs
+++ b/test/kafka_ex/auth/config_test.exs
@@ -1,5 +1,9 @@
 defmodule KafkaEx.Auth.ConfigTest do
-  use ExUnit.Case, async: true
+  # NOT async: these tests mutate global Application env (:sasl_username, :sasl,
+  # ...). App env is VM-global, so running concurrently with other tests lets
+  # them observe the half-set config (e.g. KafkaExTest.build_worker_options
+  # hitting check_legacy_keys! and raising on a transiently-set legacy key).
+  use ExUnit.Case, async: false
   alias KafkaEx.Auth.Config
 
   test "new/1 builds struct and redacts password in inspect" do

--- a/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
@@ -51,7 +51,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerSyncRecoveryTest do
     # here (no consumer child) -> :ok. No real consumers start because sync never
     # succeeds.
     {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
-    on_exit(fn -> if Process.alive?(sup), do: Supervisor.stop(sup) end)
+
+    on_exit(fn ->
+      try do
+        if Process.alive?(sup), do: Supervisor.stop(sup)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
 
     {:ok, mock} =
       MockClient.start_link(%{

--- a/test/support/integration_helpers.ex
+++ b/test/support/integration_helpers.ex
@@ -123,7 +123,37 @@ defmodule KafkaEx.IntegrationHelpers do
       timeout: 10_000
     ]
 
-    {:ok, response} = API.join_group(client, consumer_group, "", opts)
+    {:ok, response} = join_group_with_retry(client, consumer_group, "", opts)
     {response.member_id, response.generation_id}
   end
+
+  @doc """
+  Joins a consumer group, retrying the transient coordinator-not-ready errors
+  that occur right after topic creation: the group coordinator's
+  `__consumer_offsets` partition may still be loading, so the first JoinGroup
+  can come back as `:no_broker` / `:coordinator_not_available` before the
+  coordinator is electable. Bounded so a real failure still surfaces.
+  """
+  def join_group_with_retry(client, consumer_group, member_id, opts, retries \\ 20) do
+    case API.join_group(client, consumer_group, member_id, opts) do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, reason} when retries > 0 ->
+        if coordinator_not_ready?(reason) do
+          Process.sleep(250)
+          join_group_with_retry(client, consumer_group, member_id, opts, retries - 1)
+        else
+          {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp coordinator_not_ready?(:no_broker), do: true
+  defp coordinator_not_ready?(:coordinator_not_available), do: true
+  defp coordinator_not_ready?(:coordinator_load_in_progress), do: true
+  defp coordinator_not_ready?(_), do: false
 end


### PR DESCRIPTION
Fixes three pre-existing intermittent test failures (a flake cluster surfaced repeatedly in CI). All three are test-only — **no production code changes**. Root causes were confirmed, not patched over.

### 1. `ManagerSyncRecoveryTest` — teardown TOCTOU
The test asserts the manager *gives up* (raises `SyncGroupRetriesExhaustedError`); when it does, the supervisor it owns goes down with it. The `on_exit` callback did `if Process.alive?(sup), do: Supervisor.stop(sup)` — `alive?` returned true, the supervisor died, then `Supervisor.stop` exited with `:noproc` and failed the test in teardown. Wrapped the stop in `try/catch :exit`, matching the existing pattern in `SyncConsumerGroupTest`.

### 2. `Auth.ConfigTest` poisoning `KafkaExTest.build_worker_options`
`Auth.ConfigTest` was `async: true` while mutating **VM-global** application env (`:sasl_username` / `:sasl_password` / `:sasl_mechanism`). In the window between `put_env` and the cleanup `delete_env`, a concurrent async test (`KafkaExTest.build_worker_options`) read the half-set config, hit `check_legacy_keys!`, and raised the "legacy SASL keys" `ArgumentError`. Made the module `async: false` — tests that mutate global app env must run serially.

### 3. `lifecycle_test` — JoinGroup coordinator-not-ready race
Right after `create_topic`, the group coordinator's `__consumer_offsets` partition can still be loading, so the first `JoinGroup` returns `:no_broker` / `:coordinator_not_available` before the client's internal retry budget elects a coordinator. Added a bounded `join_group_with_retry` helper (retries `:no_broker` / `:coordinator_not_available` / `:coordinator_load_in_progress`, 20 × 250 ms) and used it at the three lifecycle join sites and in `join_to_group`.

### Verification
- `ManagerSyncRecoveryTest`: 20 consecutive runs green.
- Full `lifecycle_test.exs`: 4/4 green on the 3-broker docker cluster.
- Full unit suite: 2937 tests, 0 failures.
- `mix format` clean.