### PR TITLE
refactor: ride load_offsets startup retry on Retry.with_retry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,10 +61,11 @@ config :kafka_ex,
   # - `:latest` - Will move the offset to the most recent.
   # - `:none` - The error will simply be raised
   auto_offset_reset: :none,
-  # Delay (ms) between retries when a GenConsumer's startup committed-offset fetch
-  # hits a retryable error (coordinator not available/loading, timeout, KIP-447
-  # unstable offset). After 5 retries the consumer crashes (supervisor restart)
-  # rather than silently resetting the offset. Keep the total (5 * this value)
+  # Base delay (ms) for the exponential backoff between retries when a GenConsumer's
+  # startup committed-offset fetch hits a retryable error (coordinator not
+  # available/loading, timeout, KIP-447 unstable offset). Delays grow as
+  # base * 2^attempt (capped); after 6 attempts the consumer crashes (supervisor
+  # restart) rather than silently resetting the offset. Keep the cumulative backoff
   # below the worker shutdown budget to avoid a hard kill mid-retry. Default: 500.
   # load_offsets_retry_backoff_ms: 500,
   # API versions for Kafka protocol requests.

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -1132,14 +1132,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:noreply, State.t()} | {:stop, term(), State.t()}
   def commit_for_test(error, state), do: handle_commit_error(error, state)
 
-  @load_offsets_max_retries 5
+  @load_offsets_max_attempts 6
   @default_load_offsets_retry_backoff_ms 500
-
-  defp load_offsets_retry_backoff_ms do
-    Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms)
-  end
-
-  defp load_offsets(%State{} = state), do: load_offsets(state, @load_offsets_max_retries)
 
   defp load_offsets(
          %State{
@@ -1148,43 +1142,51 @@ defmodule KafkaEx.Consumer.GenConsumer do
            topic: topic,
            partition: partition,
            auto_offset_reset: auto_offset_reset
-         } = state,
-         retries_left
+         } = state
        ) do
     partitions = [%{partition_num: partition}]
     opts = VersionHelper.maybe_put_api_version([], state.api_versions, :offset_fetch)
 
-    case KafkaExAPI.fetch_committed_offset(client, group, topic, partitions, opts) do
-      {:ok, [%{partition_offsets: [%{offset: offset, error_code: :no_error}]}]} when offset >= 0 ->
-        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
-
-      {:ok, [%{partition_offsets: [%{error_code: :no_error}]}]} ->
-        start_from_auto_offset_reset(state, auto_offset_reset)
-
-      {:ok, []} ->
-        start_from_auto_offset_reset(state, auto_offset_reset)
-
-      {:ok, [%{partition_offsets: [%{error_code: error_code}]}]} ->
-        handle_load_offsets_error(state, error_code, retries_left)
-
-      {:error, reason} ->
-        handle_load_offsets_error(state, reason, retries_left)
+    fetch = fn ->
+      classify_committed_offset(KafkaExAPI.fetch_committed_offset(client, group, topic, partitions, opts))
     end
-  end
 
-  defp handle_load_offsets_error(%State{topic: topic, partition: partition} = state, reason, retries_left) do
-    if Retry.commit_retryable?(reason) and retries_left > 0 do
-      Logger.warning(
-        "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
-          "Retrying (#{@load_offsets_max_retries - retries_left + 1}/#{@load_offsets_max_retries})."
+    result =
+      Retry.with_retry(fetch,
+        max_retries: @load_offsets_max_attempts,
+        base_delay_ms:
+          Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms),
+        retryable?: &Retry.commit_retryable?/1,
+        on_retry: fn reason, attempt, _delay ->
+          Logger.warning(
+            "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
+              "Retrying (#{attempt}/#{@load_offsets_max_attempts - 1})."
+          )
+        end
       )
 
-      Process.sleep(load_offsets_retry_backoff_ms())
-      load_offsets(state, retries_left - 1)
-    else
-      raise "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}"
+    case result do
+      {:ok, {:committed, offset}} ->
+        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
+
+      {:ok, :reset} ->
+        start_from_auto_offset_reset(state, auto_offset_reset)
+
+      {:error, reason} ->
+        raise "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}"
     end
   end
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{offset: offset, error_code: :no_error}]}]})
+       when offset >= 0,
+       do: {:ok, {:committed, offset}}
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: :no_error}]}]}), do: {:ok, :reset}
+  defp classify_committed_offset({:ok, []}), do: {:ok, :reset}
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: error_code}]}]}), do: {:error, error_code}
+
+  defp classify_committed_offset({:error, reason}), do: {:error, reason}
 
   defp start_from_auto_offset_reset(%State{client: client, topic: topic, partition: partition} = state, reset) do
     offset =

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -56,7 +56,7 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     # it still raises once retries are exhausted, but only AFTER retrying
     assert_raise RuntimeError, fn -> GenConsumer.handle_info(:timeout, base_state(mock)) end
 
-    # 1 initial attempt + @load_offsets_max_retries (5) retries = 6
+    # @load_offsets_max_attempts (6) total attempts before raising
     fetch_calls = mock |> MockClient.get_calls() |> Enum.count(&match?({:offset_fetch, _, _, _}, &1))
     assert fetch_calls == 6
   end


### PR DESCRIPTION
**Stacked on #548** — review/merge that first; this PR's diff is only the refactor on top.

Follow-up from the PR-4 cleanup pass. The consumer's startup committed-offset load (`load_offsets`, added in #548) had its own hand-rolled retry loop — recursive countdown, flat `Process.sleep`, a bespoke counter, and a `handle_load_offsets_error` clause. That duplicated the mechanics of the shared `Retry.with_retry/2`, which already provides bounded retries, exponential backoff, the `retryable?` predicate, and `on_retry` logging (the same plumbing `commit_with_retry` and the stream already use).

### Changes
- `load_offsets` now rides `Retry.with_retry/2`. A small `classify_committed_offset/1` maps the fetch result to `{:ok, {:committed, offset}}` / `{:ok, :reset}` / `{:error, reason}`, so `with_retry` owns the loop and the caller just pattern-matches success vs `raise`.
- Backoff is now **exponential** (base = `:load_offsets_retry_backoff_ms`), matching `commit_with_retry`, instead of flat. Config doc updated accordingly.
- Total attempts preserved at 6 (`@load_offsets_max_attempts`).
- Removed: the hand-rolled `load_offsets/2` recursion, `handle_load_offsets_error/3`, and the `load_offsets_retry_backoff_ms/0` wrapper.

No behavior change beyond flat → exponential backoff. Unit suite green; the H-6 retry/raise semantics (`:unstable_offset_commit` retried, fatal errors raised) are unchanged and still covered by `GenConsumerLoadOffsetsTest`.