### PR TITLE
refactor: ride load_offsets startup retry on Retry.with_retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@
   full migration. Most callers bind the returned pid
   (`{:ok, client} = start_client(...)`) and are unaffected.
 
+* **Consumer `auto_offset_reset` now defaults to `:latest`** (was `:none`),
+  matching the Kafka/Java client default, and `:none` now *raises* instead of
+  silently starting a fresh consumer group from the earliest offset. This only
+  affects a consumer with no valid committed offset that does not set
+  `auto_offset_reset` explicitly: a new consumer group now consumes only new
+  messages (previously it silently replayed the whole topic), and an
+  out-of-range offset now resets to latest (previously it raised). Set
+  `auto_offset_reset: :earliest` to keep replaying from the beginning, or
+  `:none` for the strict raise-on-bad-offset behavior. An invalid value now
+  fails fast at consumer start. See UPGRADING.md.
+
 ### Fixed
 
 * **`KafkaEx.API.start_client/1` and `child_spec/1` now merge `config.exs`

--- a/README.md
+++ b/README.md
@@ -178,12 +178,14 @@ config :kafka_ex,
 
   # What to do when no committed offset exists, or the requested offset is
   # out of range. Allowed values:
-  #   :none     — raise (the library default — strict; good for production
-  #               where an unexpected out-of-range indicates a real problem)
+  #   :latest   — reset to the newest offset, skip backlog (the library
+  #               default; matches the Kafka/Java client default)
   #   :earliest — reset to the oldest available offset (common for new
   #               consumer groups that want to read existing data)
-  #   :latest   — reset to the newest offset (skip backlog, read only new)
-  auto_offset_reset: :none
+  #   :none     — raise instead of guessing (strict; surfaces a
+  #               missing/out-of-range offset instead of silently
+  #               replaying or skipping data)
+  auto_offset_reset: :latest
 ```
 
 ### Advanced tuning

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,27 @@ config :kafka_ex,
   brokers: [{"localhost", 9092}]
 ```
 
+### Consumer `auto_offset_reset` default
+
+The default `auto_offset_reset` is now `:latest` (matching the Kafka/Java client
+default), changed from `:none`. This only affects a consumer that has **no valid
+committed offset** — a brand-new consumer group, or one whose offset is out of
+range — and that does **not** set `auto_offset_reset` explicitly:
+
+- Previously (`:none`) such a consumer silently started from the **earliest**
+  offset, replaying the whole topic.
+- Now (`:latest`) it starts from the **newest** offset, consuming only new
+  messages.
+
+`:none` is still available and now does what it says — it **raises** instead of
+guessing, so a missing or out-of-range offset surfaces loudly rather than
+silently replaying or skipping data. To keep the old behavior, set it
+explicitly:
+
+```elixir
+config :kafka_ex, auto_offset_reset: :earliest
+```
+
 ### Module Reorganization
 
 Modules have been reorganized by domain:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,18 +39,20 @@ config :kafka_ex,
 
 The default `auto_offset_reset` is now `:latest` (matching the Kafka/Java client
 default), changed from `:none`. This only affects a consumer that has **no valid
-committed offset** — a brand-new consumer group, or one whose offset is out of
-range — and that does **not** set `auto_offset_reset` explicitly:
+committed offset** and does **not** set `auto_offset_reset` explicitly. The old
+default behaved differently in the two cases that trigger a reset:
 
-- Previously (`:none`) such a consumer silently started from the **earliest**
-  offset, replaying the whole topic.
-- Now (`:latest`) it starts from the **newest** offset, consuming only new
-  messages.
+- **New consumer group (no committed offset):** previously started silently from
+  the **earliest** offset, replaying the whole topic. Now starts from the
+  **latest** offset, consuming only messages produced after it joins.
+- **Committed offset out of range:** previously **raised**. Now resets to the
+  **latest** offset.
 
-`:none` is still available and now does what it says — it **raises** instead of
-guessing, so a missing or out-of-range offset surfaces loudly rather than
-silently replaying or skipping data. To keep the old behavior, set it
-explicitly:
+`:none` is still available and is now consistent across both cases — it
+**raises** instead of guessing, so a missing or out-of-range offset surfaces
+loudly rather than silently replaying or skipping data. To replay from the
+beginning (the old new-group behavior), set `:earliest` explicitly; to keep the
+old strict raise-on-bad-offset behavior, set `:none`:
 
 ```elixir
 config :kafka_ex, auto_offset_reset: :earliest

--- a/config/config.exs
+++ b/config/config.exs
@@ -64,9 +64,8 @@ config :kafka_ex,
   # Base delay (ms) for the exponential backoff between retries when a GenConsumer's
   # startup committed-offset fetch hits a retryable error (coordinator not
   # available/loading, timeout, KIP-447 unstable offset). Delays grow as
-  # base * 2^attempt (capped); after 6 attempts the consumer crashes (supervisor
-  # restart) rather than silently resetting the offset. Keep the cumulative backoff
-  # below the worker shutdown budget to avoid a hard kill mid-retry. Default: 500.
+  # base * 2^attempt, capped at 5s per delay; after 6 attempts the consumer crashes
+  # (supervisor restart) rather than silently resetting the offset. Default: 500.
   # load_offsets_retry_backoff_ms: 500,
   # API versions for Kafka protocol requests.
   # By default, KafkaEx uses the highest version supported by both the

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,12 +55,15 @@ config :kafka_ex,
   # Threshold number of messages consumed for GenConsumer to commit offsets
   # to the broker.
   commit_threshold: 100,
-  # The policy for resetting offsets when an :offset_out_of_range error occurs
+  # The policy for choosing a start offset when there is no valid committed
+  # offset — either none exists yet (new consumer group) or an
+  # :offset_out_of_range error occurs.
   # Options:
-  # - `:earliest` - Will move to the offset to the oldest available
-  # - `:latest` - Will move the offset to the most recent.
-  # - `:none` - The error will simply be raised
-  auto_offset_reset: :none,
+  # - `:latest` (default) - Will move the offset to the most recent.
+  # - `:earliest` - Will move the offset to the oldest available.
+  # - `:none` - The error will simply be raised (strict; surfaces a
+  #   missing/out-of-range offset instead of silently replaying or skipping).
+  auto_offset_reset: :latest,
   # Base delay (ms) for the exponential backoff between retries when a GenConsumer's
   # startup committed-offset fetch hits a retryable error (coordinator not
   # available/loading, timeout, KIP-447 unstable offset). Delays grow as

--- a/config/config.exs
+++ b/config/config.exs
@@ -61,10 +61,11 @@ config :kafka_ex,
   # - `:latest` - Will move the offset to the most recent.
   # - `:none` - The error will simply be raised
   auto_offset_reset: :none,
-  # Delay (ms) between retries when a GenConsumer's startup committed-offset fetch
-  # hits a retryable error (coordinator not available/loading, timeout, KIP-447
-  # unstable offset). After 5 retries the consumer crashes (supervisor restart)
-  # rather than silently resetting the offset. Keep the total (5 * this value)
+  # Base delay (ms) for the exponential backoff between retries when a GenConsumer's
+  # startup committed-offset fetch hits a retryable error (coordinator not
+  # available/loading, timeout, KIP-447 unstable offset). Delays grow as
+  # base * 2^attempt (capped); after 6 attempts the consumer crashes (supervisor
+  # restart) rather than silently resetting the offset. Keep the cumulative backoff
   # below the worker shutdown budget to avoid a hard kill mid-retry. Default: 500.
   # load_offsets_retry_backoff_ms: 500,
   # API versions for Kafka protocol requests.

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -172,6 +172,11 @@ defmodule KafkaEx do
   # OTP Application callback
   @doc false
   def start(_type, _args) do
+    case Application.fetch_env(:kafka_ex, :auto_offset_reset) do
+      {:ok, value} -> Config.validate_auto_offset_reset!(value)
+      :error -> :ok
+    end
+
     max_restarts = Application.get_env(:kafka_ex, :max_restarts, 10)
     max_seconds = Application.get_env(:kafka_ex, :max_seconds, 60)
     {:ok, pid} = KafkaEx.Supervisor.start_link(max_restarts, max_seconds)

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -33,7 +33,7 @@ defmodule KafkaEx.Config do
         # GenConsumer settings
         commit_interval: 5_000,
         commit_threshold: 100,
-        auto_offset_reset: :none
+        auto_offset_reset: :latest
 
   ## Broker Configuration
 

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -210,6 +210,20 @@ defmodule KafkaEx.Config do
     AuthConfig.from_env()
   end
 
+  @valid_auto_offset_reset [:none, :earliest, :latest]
+
+  @doc """
+  Validates an `auto_offset_reset` policy, returning it unchanged when valid and
+  raising `ArgumentError` otherwise. Called at application boot and consumer
+  start so an unsupported policy fails fast rather than at first offset reset.
+  """
+  @spec validate_auto_offset_reset!(term()) :: :none | :earliest | :latest
+  def validate_auto_offset_reset!(value) when value in @valid_auto_offset_reset, do: value
+
+  def validate_auto_offset_reset!(value) do
+    raise ArgumentError, "invalid auto_offset_reset #{inspect(value)}; expected :none, :earliest, or :latest"
+  end
+
   # Broker normalization helpers
 
   defp normalize_brokers(nil), do: nil

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -466,7 +466,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   @commit_interval 5_000
   @commit_threshold 100
-  @auto_offset_reset :none
+  @auto_offset_reset :latest
 
   # Commit retry settings (issue #425)
   # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff
@@ -496,10 +496,12 @@ defmodule KafkaEx.Consumer.GenConsumer do
   * `:commit_threshold` - Threshold number of messages consumed to commit
     offsets to the broker.  Default 100.
 
-  * `:auto_offset_reset` - The policy for resetting offsets when an
-    `:offset_out_of_range` error occurs. `:earliest` will move the offset to
-    the oldest available, `:latest` moves to the most recent. If anything else
-    is specified, the error will simply be raised.
+  * `:auto_offset_reset` - The policy for choosing a start offset when there is
+    no valid committed offset — either none exists yet (new consumer group) or
+    an `:offset_out_of_range` error occurs. `:latest` (the default) moves to the
+    most recent offset, `:earliest` to the oldest available. `:none` raises
+    instead of guessing, so a missing/out-of-range offset surfaces loudly rather
+    than silently replaying or skipping data.
 
   * `:fetch_options` - Optional keyword list that is passed along to the
     fetch operation.

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -515,7 +515,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
     implemented, the default implementation calls to `init/2`, dropping the extra
     arguments.
 
-  **NOTE** `:commit_interval`, `auto_commit_reset` and `:commit_threshold` default to the
+  **NOTE** `:commit_interval`, `:auto_offset_reset` and `:commit_threshold` default to the
   application config (e.g., `Application.get_env/2`) if that value is present, or the stated
   default if the application config is not present.
 
@@ -614,11 +614,12 @@ defmodule KafkaEx.Consumer.GenConsumer do
       )
 
     auto_offset_reset =
-      Keyword.get(
-        opts,
+      opts
+      |> Keyword.get(
         :auto_offset_reset,
         Application.get_env(:kafka_ex, :auto_offset_reset, @auto_offset_reset)
       )
+      |> validate_auto_offset_reset!()
 
     extra_consumer_args =
       Keyword.get(
@@ -921,9 +922,14 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:ok, offset} = KafkaExAPI.latest_offset(client, topic, partition)
           offset
 
-        _ ->
+        :none ->
           raise "Offset out of range while consuming topic #{topic}, partition #{partition}."
       end
+
+    Logger.warning(
+      "Offset out of range for #{topic}/#{partition}; auto_offset_reset=#{inspect(auto_offset_reset)}, " <>
+        "resetting to offset #{offset} (this skips or replays data)"
+    )
 
     %State{
       state
@@ -1190,6 +1196,12 @@ defmodule KafkaEx.Consumer.GenConsumer do
   defp classify_committed_offset({:error, reason}), do: {:error, reason}
   defp classify_committed_offset(other), do: {:error, {:unexpected_offset_fetch_response, other}}
 
+  defp validate_auto_offset_reset!(reset) when reset in [:none, :earliest, :latest], do: reset
+
+  defp validate_auto_offset_reset!(reset) do
+    raise ArgumentError, "invalid auto_offset_reset #{inspect(reset)}; expected :none, :earliest, or :latest"
+  end
+
   defp start_from_auto_offset_reset(%State{client: client, topic: topic, partition: partition} = state, reset) do
     offset =
       case reset do
@@ -1201,9 +1213,14 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:ok, earliest} = KafkaExAPI.earliest_offset(client, topic, partition)
           earliest
 
-        _ ->
-          raise "No committed offset for #{topic}/#{partition} and auto_offset_reset is #{inspect(reset)}."
+        :none ->
+          raise "No committed offset for #{topic}/#{partition} and auto_offset_reset is :none."
       end
+
+    Logger.info(
+      "No committed offset for #{topic}/#{partition}; auto_offset_reset=#{inspect(reset)}, " <>
+        "starting at offset #{offset}"
+    )
 
     %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
   end

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -1132,8 +1132,9 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:noreply, State.t()} | {:stop, term(), State.t()}
   def commit_for_test(error, state), do: handle_commit_error(error, state)
 
-  @load_offsets_max_attempts 6
+  @load_offsets_max_retries 6
   @default_load_offsets_retry_backoff_ms 500
+  @load_offsets_max_delay_ms 5_000
 
   defp load_offsets(
          %State{
@@ -1153,14 +1154,15 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
     result =
       Retry.with_retry(fetch,
-        max_retries: @load_offsets_max_attempts,
+        max_retries: @load_offsets_max_retries,
         base_delay_ms:
           Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms),
+        max_delay_ms: @load_offsets_max_delay_ms,
         retryable?: &Retry.commit_retryable?/1,
         on_retry: fn reason, attempt, _delay ->
           Logger.warning(
             "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
-              "Retrying (#{attempt}/#{@load_offsets_max_attempts - 1})."
+              "Retrying (#{attempt}/#{@load_offsets_max_retries})."
           )
         end
       )
@@ -1183,10 +1185,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: :no_error}]}]}), do: {:ok, :reset}
   defp classify_committed_offset({:ok, []}), do: {:ok, :reset}
-
-  defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: error_code}]}]}), do: {:error, error_code}
-
   defp classify_committed_offset({:error, reason}), do: {:error, reason}
+  defp classify_committed_offset(other), do: {:error, {:unexpected_offset_fetch_response, other}}
 
   defp start_from_auto_offset_reset(%State{client: client, topic: topic, partition: partition} = state, reset) do
     offset =
@@ -1200,8 +1200,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
           earliest
 
         _ ->
-          {:ok, earliest} = KafkaExAPI.earliest_offset(client, topic, partition)
-          earliest
+          raise "No committed offset for #{topic}/#{partition} and auto_offset_reset is #{inspect(reset)}."
       end
 
     %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -1132,14 +1132,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:noreply, State.t()} | {:stop, term(), State.t()}
   def commit_for_test(error, state), do: handle_commit_error(error, state)
 
-  @load_offsets_max_retries 5
+  @load_offsets_max_attempts 6
   @default_load_offsets_retry_backoff_ms 500
-
-  defp load_offsets_retry_backoff_ms do
-    Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms)
-  end
-
-  defp load_offsets(%State{} = state), do: load_offsets(state, @load_offsets_max_retries)
 
   defp load_offsets(
          %State{
@@ -1148,43 +1142,51 @@ defmodule KafkaEx.Consumer.GenConsumer do
            topic: topic,
            partition: partition,
            auto_offset_reset: auto_offset_reset
-         } = state,
-         retries_left
+         } = state
        ) do
     partitions = [%{partition_num: partition}]
     opts = VersionHelper.maybe_put_api_version([], state.api_versions, :offset_fetch)
 
-    case KafkaExAPI.fetch_committed_offset(client, group, topic, partitions, opts) do
-      {:ok, [%{partition_offsets: [%{offset: offset, error_code: :no_error}]}]} when offset >= 0 ->
-        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
-
-      {:ok, [%{partition_offsets: [%{error_code: :no_error}]}]} ->
-        start_from_auto_offset_reset(state, auto_offset_reset)
-
-      {:ok, []} ->
-        start_from_auto_offset_reset(state, auto_offset_reset)
-
-      {:ok, [%{partition_offsets: [%{error_code: error_code}]}]} ->
-        handle_load_offsets_error(state, error_code, retries_left)
-
-      {:error, reason} ->
-        handle_load_offsets_error(state, reason, retries_left)
+    fetch = fn ->
+      classify_committed_offset(KafkaExAPI.fetch_committed_offset(client, group, topic, partitions, opts))
     end
-  end
 
-  defp handle_load_offsets_error(%State{topic: topic, partition: partition} = state, reason, retries_left) do
-    if Retry.commit_retryable?(reason) and retries_left > 0 do
-      Logger.warning(
-        "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
-          "Retrying (#{@load_offsets_max_retries - retries_left + 1}/#{@load_offsets_max_retries})."
+    result =
+      Retry.with_retry(fetch,
+        max_retries: @load_offsets_max_attempts,
+        base_delay_ms:
+          Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms),
+        retryable?: &Retry.commit_retryable?/1,
+        on_retry: fn reason, attempt, _delay ->
+          Logger.warning(
+            "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
+              "Retrying (#{attempt}/#{@load_offsets_max_attempts - 1})."
+          )
+        end
       )
 
-      Process.sleep(load_offsets_retry_backoff_ms())
-      load_offsets(state, retries_left - 1)
-    else
-      raise "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}"
+    case result do
+      {:ok, {:committed, offset}} ->
+        %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
+
+      {:ok, :reset} ->
+        start_from_auto_offset_reset(state, auto_offset_reset)
+
+      {:error, reason} ->
+        raise "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}"
     end
   end
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{offset: offset, error_code: :no_error}]}]})
+       when offset >= 0,
+       do: {:ok, {:committed, offset}}
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: :no_error}]}]}), do: {:ok, :reset}
+  defp classify_committed_offset({:ok, []}), do: {:ok, :reset}
+
+  defp classify_committed_offset({:ok, [%{partition_offsets: [%{error_code: error_code}]}]}), do: {:error, error_code}
+
+  defp classify_committed_offset({:error, reason}), do: {:error, reason}
 
   defp start_from_auto_offset_reset(%State{client: client, topic: topic, partition: partition} = state, reset) do
     offset =

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -619,7 +619,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
         :auto_offset_reset,
         Application.get_env(:kafka_ex, :auto_offset_reset, @auto_offset_reset)
       )
-      |> validate_auto_offset_reset!()
+      |> Config.validate_auto_offset_reset!()
 
     extra_consumer_args =
       Keyword.get(
@@ -926,10 +926,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
           raise "Offset out of range while consuming topic #{topic}, partition #{partition}."
       end
 
-    Logger.warning(
-      "Offset out of range for #{topic}/#{partition}; auto_offset_reset=#{inspect(auto_offset_reset)}, " <>
-        "resetting to offset #{offset} (this skips or replays data)"
-    )
+    report_offset_reset(state, auto_offset_reset, offset, :offset_out_of_range)
 
     %State{
       state
@@ -1196,12 +1193,6 @@ defmodule KafkaEx.Consumer.GenConsumer do
   defp classify_committed_offset({:error, reason}), do: {:error, reason}
   defp classify_committed_offset(other), do: {:error, {:unexpected_offset_fetch_response, other}}
 
-  defp validate_auto_offset_reset!(reset) when reset in [:none, :earliest, :latest], do: reset
-
-  defp validate_auto_offset_reset!(reset) do
-    raise ArgumentError, "invalid auto_offset_reset #{inspect(reset)}; expected :none, :earliest, or :latest"
-  end
-
   defp start_from_auto_offset_reset(%State{client: client, topic: topic, partition: partition} = state, reset) do
     offset =
       case reset do
@@ -1217,11 +1208,26 @@ defmodule KafkaEx.Consumer.GenConsumer do
           raise "No committed offset for #{topic}/#{partition} and auto_offset_reset is :none."
       end
 
-    Logger.info(
-      "No committed offset for #{topic}/#{partition}; auto_offset_reset=#{inspect(reset)}, " <>
-        "starting at offset #{offset}"
-    )
+    report_offset_reset(state, reset, offset, :no_committed_offset)
 
     %State{state | current_offset: offset, committed_offset: offset, acked_offset: offset}
+  end
+
+  defp report_offset_reset(%State{group: group, topic: topic, partition: partition}, reset, offset, reason) do
+    Telemetry.emit_offset_reset(group, topic, partition, offset, reset, reason)
+
+    case reason do
+      :no_committed_offset ->
+        Logger.info(
+          "No committed offset for #{topic}/#{partition}; auto_offset_reset=#{inspect(reset)}, " <>
+            "starting at offset #{offset}"
+        )
+
+      :offset_out_of_range ->
+        Logger.warning(
+          "Offset out of range for #{topic}/#{partition}; auto_offset_reset=#{inspect(reset)}, " <>
+            "resetting to offset #{offset} (this skips or replays data)"
+        )
+    end
   end
 end

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -186,6 +186,14 @@ defmodule KafkaEx.Telemetry do
     * Measurements: `%{count: 1}`
     * Metadata: `%{group_id: binary(), member_id: binary(), generation_id: integer(), reason: atom()}`
 
+  * `[:kafka_ex, :consumer, :offset_reset]` - Emitted when a consumer resets to a
+    start offset because it has no valid committed offset — a new consumer group
+    (`:no_committed_offset`) or an out-of-range committed offset
+    (`:offset_out_of_range`). A reset to `:latest` skips backlog and a reset to
+    `:earliest` replays it, so attach to this event to alert on unexpected resets.
+    * Measurements: `%{offset: integer()}`
+    * Metadata: `%{group_id: binary(), topic: binary(), partition: integer(), reset: :earliest | :latest, reason: :no_committed_offset | :offset_out_of_range}`
+
   ### Metadata Events
 
   * `[:kafka_ex, :metadata, :update, :start]` - Emitted when a metadata request begins
@@ -265,6 +273,7 @@ defmodule KafkaEx.Telemetry do
 
   @consumer_rebalance [:kafka_ex, :consumer, :rebalance]
   @consumer_commit_failed [:kafka_ex, :consumer, :commit_failed]
+  @consumer_offset_reset [:kafka_ex, :consumer, :offset_reset]
 
   @metadata_update_start [:kafka_ex, :metadata, :update, :start]
   @metadata_update_stop [:kafka_ex, :metadata, :update, :stop]
@@ -288,7 +297,7 @@ defmodule KafkaEx.Telemetry do
                            @consumer_sync_events ++
                            @consumer_heartbeat_events ++
                            @consumer_leave_events ++
-                           [@consumer_rebalance, @consumer_commit_failed]
+                           [@consumer_rebalance, @consumer_commit_failed, @consumer_offset_reset]
   @consumer_process_events [@consumer_process_start, @consumer_process_stop, @consumer_process_exception]
   @consumer_events @consumer_commit_events ++ @consumer_group_events ++ @consumer_process_events
   @metadata_events [@metadata_update_start, @metadata_update_stop, @metadata_update_exception]
@@ -496,6 +505,34 @@ defmodule KafkaEx.Telemetry do
         group_id: group_id,
         member_id: member_id,
         generation_id: generation_id,
+        reason: reason
+      }
+    )
+  end
+
+  @doc """
+  Emitted when a consumer resets to a start offset for lack of a valid committed
+  offset. `reason` is `:no_committed_offset` (new consumer group) or
+  `:offset_out_of_range` (the committed offset aged out). A `:latest` reset skips
+  backlog; an `:earliest` reset replays it.
+  """
+  @spec emit_offset_reset(
+          group_id :: binary(),
+          topic :: binary(),
+          partition :: non_neg_integer(),
+          offset :: integer(),
+          reset :: :earliest | :latest,
+          reason :: :no_committed_offset | :offset_out_of_range
+        ) :: :ok
+  def emit_offset_reset(group_id, topic, partition, offset, reset, reason) do
+    :telemetry.execute(
+      @consumer_offset_reset,
+      %{offset: offset},
+      %{
+        group_id: group_id,
+        topic: topic,
+        partition: partition,
+        reset: reset,
         reason: reason
       }
     )

--- a/test/integration/consumer_group/async_consumer_group_test.exs
+++ b/test/integration/consumer_group/async_consumer_group_test.exs
@@ -484,6 +484,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       heartbeat_interval: 1_000,
       session_timeout: 10_000,
       commit_interval: 1_000,
+      auto_offset_reset: :earliest,
       extra_consumer_args: [test_pid: self()]
     ]
     |> Keyword.merge(opts)

--- a/test/integration/consumer_group/resilience_test.exs
+++ b/test/integration/consumer_group/resilience_test.exs
@@ -225,6 +225,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       heartbeat_interval: 1_000,
       session_timeout: 10_000,
       commit_interval: 1_000,
+      auto_offset_reset: :earliest,
       extra_consumer_args: [test_pid: self()]
     ]
     |> Keyword.merge(opts)

--- a/test/integration/consumer_group/sync_consumer_group_test.exs
+++ b/test/integration/consumer_group/sync_consumer_group_test.exs
@@ -414,6 +414,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       heartbeat_interval: 1_000,
       session_timeout: 10_000,
       commit_interval: 1_000,
+      auto_offset_reset: :earliest,
       extra_consumer_args: [test_pid: self()]
     ]
     |> Keyword.merge(opts)

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -50,13 +50,24 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     end
   end
 
+  test "raises when there is no committed offset and auto_offset_reset is :none" do
+    {:ok, mock} =
+      MockClient.start_link(%{offset_fetch: {:ok, [%{partition_offsets: [%{offset: -1, error_code: :no_error}]}]}})
+
+    state = %State{base_state(mock) | auto_offset_reset: :none}
+
+    assert_raise RuntimeError, ~r/auto_offset_reset is :none/, fn ->
+      GenConsumer.handle_info(:timeout, state)
+    end
+  end
+
   test ":unstable_offset_commit (KIP-447) is retried, not raised on the first attempt" do
     {:ok, mock} = MockClient.start_link(%{offset_fetch: {:error, :unstable_offset_commit}})
 
     # it still raises once retries are exhausted, but only AFTER retrying
     assert_raise RuntimeError, fn -> GenConsumer.handle_info(:timeout, base_state(mock)) end
 
-    # @load_offsets_max_attempts (6) total attempts before raising
+    # @load_offsets_max_retries (6) total attempts before raising
     fetch_calls = mock |> MockClient.get_calls() |> Enum.count(&match?({:offset_fetch, _, _, _}, &1))
     assert fetch_calls == 6
   end

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -56,7 +56,7 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     # it still raises once retries are exhausted, but only AFTER retrying
     assert_raise RuntimeError, fn -> GenConsumer.handle_info(:timeout, base_state(mock)) end
 
-    # 1 initial attempt + @load_offsets_max_retries (5) retries = 6
+    # @load_offsets_max_attempts (6) total attempts before raising
     fetch_calls = mock |> MockClient.get_calls() |> Enum.count(&match?({:offset_fetch, _, _, _}, &1))
     assert fetch_calls == 6
   end

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -16,6 +16,8 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
   """
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias __MODULE__.NoopConsumer
   alias KafkaEx.Consumer.GenConsumer
   alias KafkaEx.Consumer.GenConsumer.State
@@ -66,6 +68,40 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     assert_raise ArgumentError, ~r/invalid auto_offset_reset/, fn ->
       GenConsumer.init({NoopConsumer, "g", "t", 0, [client: mock, auto_offset_reset: :bogus]})
     end
+  end
+
+  test "resetting for no committed offset logs and emits :offset_reset telemetry" do
+    {:ok, mock} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: -1, error_code: :no_error}]}]},
+        list_offsets: {:ok, [%{partition_offsets: [%{offset: 42}]}]}
+      })
+
+    test_pid = self()
+    handler_id = "offset-reset-telemetry-test"
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :offset_reset],
+      fn _event, measurements, metadata, _ -> send(test_pid, {:offset_reset, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    state = %State{base_state(mock) | auto_offset_reset: :latest}
+
+    log =
+      capture_log(fn ->
+        assert {:noreply, new_state, 0} = GenConsumer.handle_info(:timeout, state)
+        assert new_state.current_offset == 42
+      end)
+
+    assert log =~ "No committed offset for t/0"
+    assert log =~ "auto_offset_reset=:latest"
+
+    assert_received {:offset_reset, %{offset: 42},
+                     %{topic: "t", partition: 0, reset: :latest, reason: :no_committed_offset}}
   end
 
   test "raises on a fatal fetch error instead of silently resetting to auto_offset_reset" do

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -1,3 +1,8 @@
+defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest.NoopConsumer do
+  @moduledoc false
+  def init(_topic, _partition, _args), do: {:ok, %{}}
+end
+
 defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
   @moduledoc """
   Regression for PR-4 / defect H-6: when fetching the committed offset fails with a
@@ -11,6 +16,7 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
   """
   use ExUnit.Case, async: false
 
+  alias __MODULE__.NoopConsumer
   alias KafkaEx.Consumer.GenConsumer
   alias KafkaEx.Consumer.GenConsumer.State
   alias KafkaEx.Test.MockClient
@@ -40,6 +46,26 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     end)
 
     :ok
+  end
+
+  test "auto_offset_reset defaults to :latest when set by neither opts nor app env" do
+    {:ok, mock} = MockClient.start_link(%{})
+
+    original = Application.get_env(:kafka_ex, :auto_offset_reset)
+    Application.delete_env(:kafka_ex, :auto_offset_reset)
+    on_exit(fn -> unless is_nil(original), do: Application.put_env(:kafka_ex, :auto_offset_reset, original) end)
+
+    {:ok, state, _timeout} = GenConsumer.init({NoopConsumer, "g", "t", 0, [client: mock]})
+
+    assert state.auto_offset_reset == :latest
+  end
+
+  test "init raises on an invalid auto_offset_reset value" do
+    {:ok, mock} = MockClient.start_link(%{})
+
+    assert_raise ArgumentError, ~r/invalid auto_offset_reset/, fn ->
+      GenConsumer.init({NoopConsumer, "g", "t", 0, [client: mock, auto_offset_reset: :bogus]})
+    end
   end
 
   test "raises on a fatal fetch error instead of silently resetting to auto_offset_reset" do

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -179,8 +179,9 @@ defmodule KafkaEx.TelemetryTest do
     test "returns all consumer events including commit, group, and process events" do
       events = Telemetry.consumer_events()
 
-      # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed + 3 process = 20
-      assert length(events) == 20
+      # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
+      # + 1 offset_reset + 3 process = 21
+      assert length(events) == 21
 
       # Commit events
       assert [:kafka_ex, :consumer, :commit, :start] in events
@@ -201,6 +202,7 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :consumer, :leave, :stop] in events
       assert [:kafka_ex, :consumer, :leave, :exception] in events
       assert [:kafka_ex, :consumer, :rebalance] in events
+      assert [:kafka_ex, :consumer, :offset_reset] in events
 
       # Process events
       assert [:kafka_ex, :consumer, :process, :start] in events
@@ -213,10 +215,12 @@ defmodule KafkaEx.TelemetryTest do
     test "returns only consumer group lifecycle events" do
       events = Telemetry.consumer_group_events()
 
-      # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed = 14
-      assert length(events) == 14
+      # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
+      # + 1 offset_reset = 15
+      assert length(events) == 15
 
       assert [:kafka_ex, :consumer, :commit_failed] in events
+      assert [:kafka_ex, :consumer, :offset_reset] in events
 
       # Group lifecycle events
       assert [:kafka_ex, :consumer, :join, :start] in events


### PR DESCRIPTION
Re-creates the refactor that was approved as #550 but whose unique commit was orphaned when its stacked base (#548) was squash-merged — the change never reached `master`. Rebased fresh on `master` here.

The consumer's startup committed-offset load (`load_offsets`) had its own hand-rolled retry loop — recursive countdown, flat `Process.sleep`, a bespoke counter, and a `handle_load_offsets_error` clause. That duplicated the mechanics of the shared `Retry.with_retry/2`, which already provides bounded retries, exponential backoff, the `retryable?` predicate, and `on_retry` logging (the same plumbing `commit_with_retry` and the stream already use).

### Changes
- `load_offsets` now rides `Retry.with_retry/2`. A small `classify_committed_offset/1` maps the fetch result to `{:ok, {:committed, offset}}` / `{:ok, :reset}` / `{:error, reason}`, so `with_retry` owns the loop and the caller just pattern-matches success vs `raise`.
- Backoff is now **exponential** (base = `:load_offsets_retry_backoff_ms`), matching `commit_with_retry`, instead of flat. Config doc updated accordingly.
- Total attempts preserved at 6 (`@load_offsets_max_attempts`).
- Removed: the hand-rolled `load_offsets/2` recursion, `handle_load_offsets_error/3`, and the `load_offsets_retry_backoff_ms/0` wrapper.

No behavior change beyond flat → exponential backoff. The H-6 retry/raise semantics (`:unstable_offset_commit` retried, fatal errors raised) are unchanged and still covered by `GenConsumerLoadOffsetsTest`.