### PR TITLE
refactor: rename Retry max_retries option to max_attempts

### DIFF
--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -470,7 +470,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   # Commit retry settings (issue #425)
   # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff
-  @commit_max_retries 3
+  @commit_max_attempts 3
   @commit_base_delay_ms 100
 
   # Client API
@@ -1030,13 +1030,13 @@ defmodule KafkaEx.Consumer.GenConsumer do
     end
 
     retry_opts = [
-      max_retries: @commit_max_retries,
+      max_attempts: @commit_max_attempts,
       base_delay_ms: @commit_base_delay_ms,
       retryable?: &Retry.commit_retryable?/1,
       on_retry: fn error, attempt, delay ->
         Logger.warning(
           "Commit failed for #{topic}/#{partition}@#{offset} with #{inspect(error)}, " <>
-            "retrying in #{delay}ms (attempt #{attempt}/#{@commit_max_retries})"
+            "retrying in #{delay}ms (attempt #{attempt}/#{@commit_max_attempts})"
         )
       end
     ]
@@ -1137,7 +1137,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
           {:noreply, State.t()} | {:stop, term(), State.t()}
   def commit_for_test(error, state), do: handle_commit_error(error, state)
 
-  @load_offsets_max_retries 6
+  @load_offsets_max_attempts 6
   @default_load_offsets_retry_backoff_ms 500
   @load_offsets_max_delay_ms 5_000
 
@@ -1159,7 +1159,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
     result =
       Retry.with_retry(fetch,
-        max_retries: @load_offsets_max_retries,
+        max_attempts: @load_offsets_max_attempts,
         base_delay_ms:
           Application.get_env(:kafka_ex, :load_offsets_retry_backoff_ms, @default_load_offsets_retry_backoff_ms),
         max_delay_ms: @load_offsets_max_delay_ms,
@@ -1167,7 +1167,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
         on_retry: fn reason, attempt, _delay ->
           Logger.warning(
             "Unable to load committed offsets for #{topic}/#{partition}: #{inspect(reason)}. " <>
-              "Retrying (#{attempt}/#{@load_offsets_max_retries})."
+              "Retrying (#{attempt}/#{@load_offsets_max_attempts})."
           )
         end
       )

--- a/lib/kafka_ex/consumer/stream.ex
+++ b/lib/kafka_ex/consumer/stream.ex
@@ -167,7 +167,7 @@ defmodule KafkaEx.Consumer.Stream do
 
     # Commit retry settings (issue #425)
     # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff
-    @commit_max_retries 3
+    @commit_max_attempts 3
     @commit_base_delay_ms 100
 
     defp commit_offset(%ConsumerStream{} = stream_data, offset) do
@@ -185,7 +185,7 @@ defmodule KafkaEx.Consumer.Stream do
       end
 
       retry_opts = [
-        max_retries: @commit_max_retries,
+        max_attempts: @commit_max_attempts,
         base_delay_ms: @commit_base_delay_ms,
         retryable?: &Retry.commit_retryable?/1
       ]

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -9,13 +9,13 @@ defmodule KafkaEx.Support.Retry do
 
   ## Usage
 
-      # Simple retry with defaults (3 retries, 100ms base delay)
+      # Simple retry with defaults (3 attempts, 100ms base delay)
       Retry.with_retry(fn -> some_operation() end)
 
       # Custom retry configuration
       Retry.with_retry(
         fn -> some_operation() end,
-        max_retries: 5,
+        max_attempts: 5,
         base_delay_ms: 200,
         max_delay_ms: 5000,
         retryable?: &Retry.transient_error?/1
@@ -31,7 +31,7 @@ defmodule KafkaEx.Support.Retry do
   @type retry_result :: {:ok, term()} | {:error, error()}
 
   @type retry_opts :: [
-          max_retries: non_neg_integer(),
+          max_attempts: non_neg_integer(),
           base_delay_ms: non_neg_integer(),
           max_delay_ms: non_neg_integer() | :infinity,
           retryable?: (error() -> boolean()),
@@ -39,7 +39,7 @@ defmodule KafkaEx.Support.Retry do
         ]
 
   # Default retry settings
-  @default_max_retries 3
+  @default_max_attempts 3
   @default_base_delay_ms 100
   @default_max_delay_ms :infinity
 
@@ -80,7 +80,7 @@ defmodule KafkaEx.Support.Retry do
   Execute a function with retry and exponential backoff.
 
   ## Options
-    - `:max_retries` - Maximum number of retry attempts (default: 3)
+    - `:max_attempts` - Maximum number of attempts, including the first (default: 3)
     - `:base_delay_ms` - Base delay for exponential backoff (default: 100)
     - `:max_delay_ms` - Maximum delay cap (default: `:infinity`)
     - `:retryable?` - Function to determine if error is retryable (default: always true)
@@ -103,13 +103,13 @@ defmodule KafkaEx.Support.Retry do
   """
   @spec with_retry((-> retry_result()), retry_opts()) :: retry_result()
   def with_retry(fun, opts \\ []) do
-    max_retries = Keyword.get(opts, :max_retries, @default_max_retries)
+    max_attempts = Keyword.get(opts, :max_attempts, @default_max_attempts)
     base_delay = Keyword.get(opts, :base_delay_ms, @default_base_delay_ms)
     max_delay = Keyword.get(opts, :max_delay_ms, @default_max_delay_ms)
     retryable? = Keyword.get(opts, :retryable?, fn _ -> true end)
     on_retry = Keyword.get(opts, :on_retry)
 
-    do_retry(fun, 0, max_retries, base_delay, max_delay, retryable?, on_retry, nil)
+    do_retry(fun, 0, max_attempts, base_delay, max_delay, retryable?, on_retry, nil)
   end
 
   defp do_retry(_fun, attempt, max, _base, _max_delay, _retryable?, _on_retry, last_error)

--- a/test/kafka_ex/consumer/commit_retry_test.exs
+++ b/test/kafka_ex/consumer/commit_retry_test.exs
@@ -90,27 +90,27 @@ defmodule KafkaEx.Consumer.CommitRetryTest do
 
   # Test the retry behavior patterns
   describe "retry behavior" do
-    @commit_max_retries 3
+    @commit_max_attempts 3
 
-    test "max retries constant is 3" do
-      assert @commit_max_retries == 3
+    test "max attempts constant is 3" do
+      assert @commit_max_attempts == 3
     end
 
     test "retries eventually exhaust" do
       # Simulate retry countdown
-      retries = Enum.take_while(@commit_max_retries..0//-1, fn n -> n >= 0 end)
+      retries = Enum.take_while(@commit_max_attempts..0//-1, fn n -> n >= 0 end)
       # 3, 2, 1, 0
       assert length(retries) == 4
     end
 
     test "first retry uses attempt 0 delay" do
       # When retries_left = 3 (max), attempt = 3 - 3 = 0
-      assert @commit_max_retries - @commit_max_retries == 0
+      assert @commit_max_attempts - @commit_max_attempts == 0
     end
 
     test "last retry uses attempt 2 delay" do
       # When retries_left = 1, attempt = 3 - 1 = 2
-      assert @commit_max_retries - 1 == 2
+      assert @commit_max_attempts - 1 == 2
     end
   end
 
@@ -146,16 +146,16 @@ defmodule KafkaEx.Consumer.CommitRetryTest do
 
   # Stream module retry logic (should mirror GenConsumer)
   describe "stream commit retry consistency" do
-    @stream_commit_max_retries 3
+    @stream_commit_max_attempts 3
     @stream_commit_retry_base_delay_ms 100
 
     defp stream_retry_delay(retries_left) do
       # This mirrors the stream.ex implementation
-      trunc(@stream_commit_retry_base_delay_ms * :math.pow(2, @stream_commit_max_retries - retries_left))
+      trunc(@stream_commit_retry_base_delay_ms * :math.pow(2, @stream_commit_max_attempts - retries_left))
     end
 
-    test "stream uses same max retries as GenConsumer" do
-      assert @stream_commit_max_retries == 3
+    test "stream uses same max attempts as GenConsumer" do
+      assert @stream_commit_max_attempts == 3
     end
 
     test "stream uses same base delay as GenConsumer" do

--- a/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_load_offsets_test.exs
@@ -129,7 +129,7 @@ defmodule KafkaEx.Consumer.GenConsumerLoadOffsetsTest do
     # it still raises once retries are exhausted, but only AFTER retrying
     assert_raise RuntimeError, fn -> GenConsumer.handle_info(:timeout, base_state(mock)) end
 
-    # @load_offsets_max_retries (6) total attempts before raising
+    # @load_offsets_max_attempts (6) total attempts before raising
     fetch_calls = mock |> MockClient.get_calls() |> Enum.count(&match?({:offset_fetch, _, _, _}, &1))
     assert fetch_calls == 6
   end

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -57,7 +57,7 @@ defmodule KafkaEx.Support.RetryTest do
             :counters.add(counter, 1, 1)
             {:error, :always_fails}
           end,
-          max_retries: 3,
+          max_attempts: 3,
           base_delay_ms: 1
         )
 
@@ -79,7 +79,7 @@ defmodule KafkaEx.Support.RetryTest do
               {:ok, :success}
             end
           end,
-          max_retries: 5,
+          max_attempts: 5,
           base_delay_ms: 1
         )
 
@@ -96,7 +96,7 @@ defmodule KafkaEx.Support.RetryTest do
             :counters.add(counter, 1, 1)
             {:error, :not_retryable}
           end,
-          max_retries: 5,
+          max_attempts: 5,
           base_delay_ms: 1,
           retryable?: fn error -> error == :retryable end
         )
@@ -111,7 +111,7 @@ defmodule KafkaEx.Support.RetryTest do
 
       Retry.with_retry(
         fn -> {:error, :test_error} end,
-        max_retries: 3,
+        max_attempts: 3,
         base_delay_ms: 1,
         on_retry: fn error, attempt, delay ->
           [{:attempts, attempts}] = :ets.lookup(errors, :attempts)
@@ -128,7 +128,7 @@ defmodule KafkaEx.Support.RetryTest do
     end
 
     test "uses default options when not specified" do
-      # Default: max_retries: 3, base_delay_ms: 100, retryable?: fn _ -> true end
+      # Default: max_attempts: 3, base_delay_ms: 100, retryable?: fn _ -> true end
       counter = :counters.new(1, [])
 
       # This would be slow with default 100ms delay, so we override base_delay_ms
@@ -140,7 +140,7 @@ defmodule KafkaEx.Support.RetryTest do
         base_delay_ms: 1
       )
 
-      # Default max_retries is 3
+      # Default max_attempts is 3
       assert :counters.get(counter, 1) == 3
     end
   end


### PR DESCRIPTION
## What

`KafkaEx.Support.Retry`'s `:max_retries` option actually bounds the **total number of attempts**, not retries-after-the-first — `max_attempts: 3` yields 3 calls (1 initial + 2 retries), not 4. The name has been misleading. This renames the option to `:max_attempts` so the name matches the behavior.

**No behavior change** — pure rename. The attempt-counting guard in `with_retry/2` is unchanged.

## Changes

- `Support.Retry` — `:max_retries` → `:max_attempts` option, `@default_max_retries` → `@default_max_attempts`, `@type retry_opts`, and docs.
- `GenConsumer` — `@commit_max_retries` → `@commit_max_attempts`, `@load_offsets_max_retries` → `@load_offsets_max_attempts`, the `max_attempts:` keys, and log strings.
- `Consumer.Stream` — `@commit_max_retries` → `@commit_max_attempts` + key.
- Tests (`retry_test`, `commit_retry_test`, `gen_consumer_load_offsets_test`) — option keys, test-local mirror constants, comments, and test names.

## Out of scope (intentionally untouched)

`client.ex` / `api.ex` retry constants (`@retry_count`, `@fetch_max_retries`, `@reconnect_max_retries`, `@api_versions_max_retries`) are separate manual retry loops, not this option.

## Verification

Format clean, compile warning-free, full unit suite green (2945, 0 failures).