### PR TITLE
test: eliminate the on_exit teardown :noproc flake class

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -174,3 +174,6 @@ jobs:
 
       - name: Compile with warnings as errors
         run: mix compile --warnings-as-errors
+
+      - name: Teardown race guard
+        run: bash scripts/check_teardown.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,23 @@ Run unit tests that don't require a Kafka cluster:
 mix test.unit
 ```
 
+### Test process teardown
+
+Processes started in a test are linked to the test process and die when it
+finishes. Tearing them down with `GenServer.stop`/`Supervisor.stop` (even behind
+`if Process.alive?(pid)`) races their death and intermittently crashes with
+`(EXIT) :noproc`. In `on_exit` and best-effort cleanup, use the race-safe helper:
+
+```elixir
+import KafkaEx.TestSupport.ProcessHelpers
+on_exit(fn -> stop_safely(pid) end)
+```
+
+Better still, let ExUnit own the lifecycle with `start_supervised!/1` (see
+`test/integration/lifecycle/start_client_test.exs`) — it tears down safely with no
+manual stop. Reserve raw `GenServer.stop` for cases where the stop's success is the
+assertion (e.g. `:ok = GenServer.stop(client); refute Process.alive?(client)`).
+
 ### Code Quality Checks (Required for All PRs)
 
 Before submitting a PR, ensure all static checks pass:

--- a/scripts/check_teardown.sh
+++ b/scripts/check_teardown.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fails if a test calls GenServer.stop/Supervisor.stop inside an on_exit callback,
+# or uses the racy `if Process.alive?(x), do: (GenServer|Supervisor).stop` teardown.
+# Teardown must use KafkaEx.TestSupport.ProcessHelpers.stop_safely/1.
+set -euo pipefail
+
+racy=$(grep -rnE --exclude-dir=support 'if Process\.alive\?\(.*\), do: (GenServer|Supervisor)\.stop' test/ || true)
+inline=$(grep -rnE --exclude-dir=support 'on_exit.*(GenServer|Supervisor)\.stop' test/ || true)
+
+if [ -n "$racy$inline" ]; then
+  echo "Racy teardown found — use KafkaEx.TestSupport.ProcessHelpers.stop_safely/1:"
+  echo "$racy"
+  echo "$inline"
+  exit 1
+fi
+echo "teardown check: clean"

--- a/test/integration/consumer_group/async_consumer_group_test.exs
+++ b/test/integration/consumer_group/async_consumer_group_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -13,7 +14,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end
@@ -60,7 +61,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       Process.sleep(2_000)
 
       # Stop consumer
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
       Process.sleep(1_000)
 
       # Produce more messages while consumer is stopped
@@ -182,7 +183,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       refute "old-message" in received, "Should not receive old message with :latest offset"
       assert "new-message" in received, "Should receive new message"
 
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
     end
   end
 
@@ -249,8 +250,8 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       assert Process.alive?(consumer1)
       assert Process.alive?(consumer2)
 
-      Supervisor.stop(consumer1)
-      Supervisor.stop(consumer2)
+      stop_safely(consumer1)
+      stop_safely(consumer2)
     end
 
     @tag timeout: 90_000
@@ -297,7 +298,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
              "Both consumers should be handling partitions, got: #{inspect(consumers_before)}"
 
       # Stop first consumer - triggers rebalance
-      Supervisor.stop(consumer1)
+      stop_safely(consumer1)
       Process.sleep(5_000)
 
       # Produce more messages - remaining consumer should get all partitions
@@ -315,7 +316,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       refute Process.alive?(consumer1)
       assert Process.alive?(consumer2)
 
-      Supervisor.stop(consumer2)
+      stop_safely(consumer2)
     end
   end
 
@@ -362,7 +363,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       # Verify consumer should still be healthy
       assert Process.alive?(consumer_pid)
 
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
     end
 
     @tag timeout: 120_000
@@ -411,8 +412,8 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
       assert total_produced > 0
       assert total_received == total_produced, "Expected #{total_produced} messages, got #{total_received}"
 
-      Supervisor.stop(consumer1)
-      Supervisor.stop(consumer2)
+      stop_safely(consumer1)
+      stop_safely(consumer2)
     end
   end
 
@@ -494,13 +495,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.AsyncConsumerGroupTest do
     {:ok, consumer_pid} = ConsumerGroup.start_link(AsyncTestConsumer, name, topics, opts)
     Process.unlink(consumer_pid)
 
-    on_exit(fn ->
-      try do
-        if Process.alive?(consumer_pid), do: Supervisor.stop(consumer_pid)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+    on_exit(fn -> stop_safely(consumer_pid) end)
 
     consumer_pid
   end

--- a/test/integration/consumer_group/coordinator_rediscovery_test.exs
+++ b/test/integration/consumer_group/coordinator_rediscovery_test.exs
@@ -19,6 +19,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.CoordinatorRediscoveryTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -27,7 +28,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.CoordinatorRediscoveryTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end

--- a/test/integration/consumer_group/highest_supported_version_test.exs
+++ b/test/integration/consumer_group/highest_supported_version_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.HighestSupportedVersionTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -17,7 +18,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.HighestSupportedVersionTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, pid} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> stop_safely(pid) end)
     {:ok, %{client: pid}}
   end
 

--- a/test/integration/consumer_group/lifecycle_test.exs
+++ b/test/integration/consumer_group/lifecycle_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.LifecycleTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
   alias KafkaEx.API
@@ -16,7 +17,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.LifecycleTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, pid} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> stop_safely(pid) end)
 
     {:ok, %{client: pid}}
   end

--- a/test/integration/consumer_group/offset_correctness_test.exs
+++ b/test/integration/consumer_group/offset_correctness_test.exs
@@ -22,6 +22,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.OffsetCorrectnessTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -31,7 +32,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.OffsetCorrectnessTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end

--- a/test/integration/consumer_group/rebalance_recovery_test.exs
+++ b/test/integration/consumer_group/rebalance_recovery_test.exs
@@ -16,6 +16,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.RebalanceRecoveryTest do
   @moduletag timeout: 180_000
 
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
   alias KafkaEx.Consumer.ConsumerGroup
@@ -27,7 +28,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.RebalanceRecoveryTest do
     uris = Keyword.fetch!(args, :uris)
 
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     topic = "cg_rebalance_recovery_#{:rand.uniform(1_000_000)}"
     create_topic(client, topic, partitions: 2)

--- a/test/integration/consumer_group/resilience_test.exs
+++ b/test/integration/consumer_group/resilience_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -13,7 +14,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end
@@ -38,11 +39,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
         # Produce messages during rebalance
         {:ok, _} = API.produce(client, topic_name, rem(i, 4), [%{value: "rebalance-msg-#{i}"}])
 
-        try do
-          Supervisor.stop(temp_consumer)
-        catch
-          :exit, _ -> :ok
-        end
+        stop_safely(temp_consumer)
 
         Process.sleep(1_000)
       end)
@@ -58,11 +55,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       received = receive_messages_until_found("final-message", 15_000)
       assert "final-message" in received, "Consumer should receive messages after rebalances"
 
-      try do
-        Supervisor.stop(consumer1)
-      catch
-        :exit, _ -> :ok
-      end
+      stop_safely(consumer1)
     end
 
     @tag timeout: 60_000
@@ -92,11 +85,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       received = receive_messages_until(1, 10_000)
       assert "test-message" in received, "Consumer should receive from available topic"
 
-      try do
-        Supervisor.stop(consumer)
-      catch
-        :exit, _ -> :ok
-      end
+      stop_safely(consumer)
     end
 
     @tag timeout: 60_000
@@ -129,8 +118,8 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       received = receive_messages_until(2, 10_000)
       assert length(received) == 2, "Both partitions should receive messages"
 
-      Supervisor.stop(consumer1)
-      Supervisor.stop(consumer2)
+      stop_safely(consumer1)
+      stop_safely(consumer2)
     end
 
     @tag timeout: 60_000
@@ -161,7 +150,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       received = receive_messages_until(5, 10_000)
       assert length(received) >= 5, "All messages should be received"
 
-      Supervisor.stop(consumer)
+      stop_safely(consumer)
     end
   end
 
@@ -187,7 +176,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
       received = receive_messages_until(1, 5_000)
       assert "backoff-test" in received
 
-      Supervisor.stop(consumer)
+      stop_safely(consumer)
     end
   end
 

--- a/test/integration/consumer_group/sync_consumer_group_test.exs
+++ b/test/integration/consumer_group/sync_consumer_group_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
   alias KafkaEx.API
@@ -14,9 +15,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
 
-    on_exit(fn ->
-      if Process.alive?(client), do: GenServer.stop(client)
-    end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end
@@ -67,7 +66,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       Process.sleep(2_000)
 
       # Stop consumer
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
       Process.sleep(1_000)
 
       # Produce more messages while consumer is stopped
@@ -159,7 +158,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       refute "old-message" in received, "Should not receive old message with :latest offset"
       assert "new-message" in received, "Should receive new message"
 
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
     end
   end
 
@@ -204,8 +203,8 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       assert Process.alive?(consumer1)
       assert Process.alive?(consumer2)
 
-      Supervisor.stop(consumer1)
-      Supervisor.stop(consumer2)
+      stop_safely(consumer1)
+      stop_safely(consumer2)
     end
 
     @tag timeout: 90_000
@@ -235,7 +234,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       assert MapSet.size(MapSet.new(Map.keys(partitions_before))) == 4
 
       # Stop first consumer - triggers rebalance
-      Supervisor.stop(consumer1)
+      stop_safely(consumer1)
       Process.sleep(5_000)
 
       # Produce more messages - remaining consumer should get all partitions
@@ -248,7 +247,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       refute Process.alive?(consumer1)
       assert Process.alive?(consumer2)
 
-      Supervisor.stop(consumer2)
+      stop_safely(consumer2)
     end
   end
 
@@ -309,7 +308,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       assert total_received == total_produced, "Expected #{total_produced} messages, got #{total_received}"
       assert Process.alive?(consumer_pid)
 
-      Supervisor.stop(consumer_pid)
+      stop_safely(consumer_pid)
     end
 
     @tag timeout: 120_000
@@ -347,8 +346,8 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
       assert total_produced > 0
       assert total_received == total_produced, "Expected #{total_produced} messages, got #{total_received}"
 
-      Supervisor.stop(consumer1)
-      Supervisor.stop(consumer2)
+      stop_safely(consumer1)
+      stop_safely(consumer2)
     end
   end
 
@@ -424,13 +423,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.SyncConsumerGroupTest do
     {:ok, consumer_pid} = ConsumerGroup.start_link(SyncTestConsumer, name, topics, opts)
     Process.unlink(consumer_pid)
 
-    on_exit(fn ->
-      try do
-        if Process.alive?(consumer_pid), do: Supervisor.stop(consumer_pid)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+    on_exit(fn -> stop_safely(consumer_pid) end)
 
     consumer_pid
   end

--- a/test/integration/consumer_group_rejoin_test.exs
+++ b/test/integration/consumer_group_rejoin_test.exs
@@ -21,6 +21,7 @@ defmodule KafkaEx.Integration.ConsumerGroupRejoinTest do
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
   import KafkaEx.TestSupport.ConsumerGroupHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -29,7 +30,7 @@ defmodule KafkaEx.Integration.ConsumerGroupRejoinTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, %{client: client}}
   end

--- a/test/integration/join_group/version_test.exs
+++ b/test/integration/join_group/version_test.exs
@@ -18,6 +18,7 @@ defmodule KafkaEx.Integration.JoinGroup.VersionTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -27,7 +28,7 @@ defmodule KafkaEx.Integration.JoinGroup.VersionTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, client} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
     {:ok, %{client: client}}
   end
 

--- a/test/integration/lifecycle/client_lifecycle_test.exs
+++ b/test/integration/lifecycle/client_lifecycle_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.Lifecycle.ClientLifecycleTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
   alias KafkaEx.API
@@ -101,9 +102,7 @@ defmodule KafkaEx.Integration.Lifecycle.ClientLifecycleTest do
       {:ok, args} = KafkaEx.build_worker_options([])
       {:ok, pid} = Client.start_link(args, :no_name)
 
-      on_exit(fn ->
-        if Process.alive?(pid), do: GenServer.stop(pid)
-      end)
+      on_exit(fn -> stop_safely(pid) end)
 
       {:ok, %{client: pid}}
     end

--- a/test/integration/lifecycle/highest_supported_version_test.exs
+++ b/test/integration/lifecycle/highest_supported_version_test.exs
@@ -4,6 +4,7 @@ defmodule KafkaEx.Integration.Lifecycle.HighestSupportedVersionTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -17,7 +18,7 @@ defmodule KafkaEx.Integration.Lifecycle.HighestSupportedVersionTest do
   setup do
     {:ok, args} = KafkaEx.build_worker_options([])
     {:ok, pid} = Client.start_link(args, :no_name)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> stop_safely(pid) end)
     {:ok, %{client: pid}}
   end
 

--- a/test/integration/lifecycle/start_client_test.exs
+++ b/test/integration/lifecycle/start_client_test.exs
@@ -9,6 +9,8 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
   alias KafkaEx.API
   alias KafkaEx.Client
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   doctest KafkaEx.API
 
   setup do
@@ -19,7 +21,7 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
   describe "start_client/1 default (no :name)" do
     test "returns a pid and does NOT register globally", %{broker_opts: opts} do
       {:ok, pid} = API.start_client(opts)
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> stop_safely(pid) end)
 
       assert is_pid(pid)
       assert Process.whereis(KafkaEx.Client) == nil
@@ -27,7 +29,7 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
 
     test "name: nil is equivalent to omitting :name", %{broker_opts: opts} do
       {:ok, pid} = API.start_client(Keyword.put(opts, :name, nil))
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> stop_safely(pid) end)
 
       assert is_pid(pid)
       assert Process.whereis(KafkaEx.Client) == nil
@@ -38,7 +40,7 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
     test "registers the pid under the given atom", %{broker_opts: opts} do
       name = :"client_#{System.unique_integer([:positive])}"
       {:ok, pid} = API.start_client(Keyword.put(opts, :name, name))
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+      on_exit(fn -> stop_safely(pid) end)
 
       assert Process.whereis(name) == pid
     end
@@ -51,8 +53,8 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
       {:ok, pid_b} = API.start_client(Keyword.put(opts, :name, name_b))
 
       on_exit(fn ->
-        if Process.alive?(pid_a), do: GenServer.stop(pid_a)
-        if Process.alive?(pid_b), do: GenServer.stop(pid_b)
+        stop_safely(pid_a)
+        stop_safely(pid_b)
       end)
 
       assert pid_a != pid_b
@@ -65,7 +67,7 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
     test "registers the pid globally", %{broker_opts: opts} do
       name = :"global_client_#{System.unique_integer([:positive])}"
       {:ok, pid} = API.start_client(Keyword.put(opts, :name, {:global, name}))
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop({:global, name}) end)
+      on_exit(fn -> stop_safely({:global, name}) end)
 
       assert :global.whereis_name(name) == pid
     end
@@ -81,7 +83,7 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
     test "registers the pid via Registry", %{broker_opts: opts, registry: registry} do
       via_name = {:via, Registry, {registry, "client-1"}}
       {:ok, pid} = API.start_client(Keyword.put(opts, :name, via_name))
-      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(via_name) end)
+      on_exit(fn -> stop_safely(via_name) end)
 
       assert [{^pid, _value}] = Registry.lookup(registry, "client-1")
     end
@@ -134,14 +136,14 @@ defmodule KafkaEx.Integration.Lifecycle.StartClientTest do
       # Exact reproduction from issue #538: pass :brokers directly, rely on
       # config.exs default_consumer_group. Must NOT raise InvalidConsumerGroupError.
       assert {:ok, client} = API.start_client(brokers: [{"localhost", 9092}])
-      on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+      on_exit(fn -> stop_safely(client) end)
 
       assert is_pid(client)
     end
 
     test "still accepts the legacy :uris alias" do
       assert {:ok, client} = API.start_client(uris: [{"localhost", 9092}])
-      on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+      on_exit(fn -> stop_safely(client) end)
 
       assert is_pid(client)
     end

--- a/test/integration/lifecycle/telemetry_test.exs
+++ b/test/integration/lifecycle/telemetry_test.exs
@@ -6,6 +6,8 @@ defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
   alias KafkaEx.API
   alias KafkaEx.Telemetry
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   setup do
     ref = make_ref()
     test_pid = self()
@@ -19,10 +21,7 @@ defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
 
     on_exit(fn ->
       :telemetry.detach(ref)
-
-      if Process.alive?(client) do
-        GenServer.stop(client)
-      end
+      stop_safely(client)
     end)
 
     {:ok, ref: ref, handler: handler, client: client}
@@ -87,9 +86,7 @@ defmodule KafkaEx.Integration.Lifecycle.TelemetryTest do
       {:ok, args} = KafkaEx.build_worker_options([])
       {:ok, new_client} = Client.start_link(args, :no_name)
 
-      on_exit(fn ->
-        if Process.alive?(new_client), do: GenServer.stop(new_client)
-      end)
+      on_exit(fn -> stop_safely(new_client) end)
 
       # Verify start event
       assert_receive {:telemetry, ^ref, [:kafka_ex, :connection, :start], start_measurements, start_metadata}, 5000

--- a/test/integration/lifecycle/version_resolution_test.exs
+++ b/test/integration/lifecycle/version_resolution_test.exs
@@ -10,6 +10,7 @@ defmodule KafkaEx.Integration.Lifecycle.VersionResolutionTest do
 
   import KafkaEx.TestHelpers
   import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.API
   alias KafkaEx.Client
@@ -20,7 +21,7 @@ defmodule KafkaEx.Integration.Lifecycle.VersionResolutionTest do
 
     on_exit(fn ->
       Application.delete_env(:kafka_ex, :api_versions)
-      if Process.alive?(pid), do: GenServer.stop(pid)
+      stop_safely(pid)
     end)
 
     {:ok, %{client: pid}}

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -2,6 +2,7 @@ defmodule KafkaEx.ClientTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
+  import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
   alias KafkaEx.Client.State
@@ -472,7 +473,7 @@ defmodule KafkaEx.ClientTest do
 
   defp start_shadow(initial_state) do
     {:ok, pid} = ClientHandleInfoShadow.start_link(initial_state)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    on_exit(fn -> stop_safely(pid) end)
     pid
   end
 

--- a/test/kafka_ex/consumer/consumer_group/manager_recoverable_error_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_recoverable_error_test.exs
@@ -11,6 +11,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerRecoverableErrorTest do
   """
   use ExUnit.Case, async: false
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   alias KafkaEx.Consumer.ConsumerGroup.Manager
   alias KafkaEx.Consumer.ConsumerGroup.Manager.State
   alias KafkaEx.Test.MockClient
@@ -29,10 +31,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerRecoverableErrorTest do
     # backoff sleeps, no consumer startup). Reaching join at all proves :closed was
     # routed to the recoverable rejoin path rather than {:stop, ...}.
     {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
-    on_exit(fn -> if Process.alive?(client), do: GenServer.stop(client) end)
+    on_exit(fn -> stop_safely(client) end)
 
     {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
-    on_exit(fn -> if Process.alive?(sup), do: Supervisor.stop(sup) end)
+    on_exit(fn -> stop_safely(sup) end)
 
     state = %State{
       client: client,

--- a/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_sync_recovery_test.exs
@@ -18,6 +18,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerSyncRecoveryTest do
   """
   use ExUnit.Case, async: false
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   alias KafkaEx.Consumer.ConsumerGroup.Manager
   alias KafkaEx.Consumer.GenConsumer
   alias KafkaEx.Messages.JoinGroup
@@ -52,13 +54,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerSyncRecoveryTest do
     # succeeds.
     {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
 
-    on_exit(fn ->
-      try do
-        if Process.alive?(sup), do: Supervisor.stop(sup)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+    on_exit(fn -> stop_safely(sup) end)
 
     {:ok, mock} =
       MockClient.start_link(%{

--- a/test/kafka_ex/supervisor_test.exs
+++ b/test/kafka_ex/supervisor_test.exs
@@ -1,6 +1,8 @@
 defmodule KafkaEx.SupervisorTest do
   use ExUnit.Case, async: false
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   alias KafkaEx.Supervisor, as: KafkaExSupervisor
 
   # Mock module for testing
@@ -50,13 +52,7 @@ defmodule KafkaEx.SupervisorTest do
 
       {:ok, sup_pid} = KafkaExSupervisor.start_link(3, 5)
 
-      on_exit(fn ->
-        try do
-          if Process.alive?(sup_pid), do: GenServer.stop(sup_pid)
-        catch
-          :exit, _ -> :ok
-        end
-      end)
+      on_exit(fn -> stop_safely(sup_pid) end)
 
       {:ok, supervisor: sup_pid}
     end
@@ -93,13 +89,7 @@ defmodule KafkaEx.SupervisorTest do
 
       {:ok, sup_pid} = KafkaExSupervisor.start_link(3, 5)
 
-      on_exit(fn ->
-        try do
-          if Process.alive?(sup_pid), do: GenServer.stop(sup_pid)
-        catch
-          :exit, _ -> :ok
-        end
-      end)
+      on_exit(fn -> stop_safely(sup_pid) end)
 
       {:ok, supervisor: sup_pid}
     end

--- a/test/kafka_ex/test_support/process_helpers_test.exs
+++ b/test/kafka_ex/test_support/process_helpers_test.exs
@@ -1,0 +1,29 @@
+defmodule KafkaEx.TestSupport.ProcessHelpersTest do
+  use ExUnit.Case, async: true
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  test "stops a live process and returns :ok" do
+    {:ok, pid} = Agent.start(fn -> :state end)
+    assert stop_safely(pid) == :ok
+    refute Process.alive?(pid)
+  end
+
+  test "returns :ok on an already-dead pid without raising" do
+    {:ok, pid} = Agent.start(fn -> :state end)
+    :ok = Agent.stop(pid)
+    refute Process.alive?(pid)
+    assert stop_safely(pid) == :ok
+  end
+
+  test "returns :ok on an unregistered name without raising" do
+    assert stop_safely(:no_such_registered_process) == :ok
+  end
+
+  test "returns :ok for a :via name whose registry no longer exists (raises ArgumentError, not exit)" do
+    # Resolving {:via, Registry, ...} against a torn-down registry raises
+    # ArgumentError during name lookup — a raise, not an :exit. Teardown must
+    # still yield :ok. (Regression: ManagerRecoverable/StartClient :via teardown.)
+    assert stop_safely({:via, Registry, {:no_such_registry, :some_key}}) == :ok
+  end
+end

--- a/test/support/chaos_test_helpers.ex
+++ b/test/support/chaos_test_helpers.ex
@@ -16,6 +16,8 @@ defmodule KafkaEx.ChaosTestHelpers do
 
   require Logger
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   alias Testcontainers.Container
   alias Testcontainers.Docker
   alias Testcontainers.ToxiproxyContainer
@@ -390,13 +392,9 @@ defmodule KafkaEx.ChaosTestHelpers do
         :ok
 
       pid ->
-        try do
-          GenServer.stop(pid, :normal, 5000)
-          # Wait for process to fully terminate
-          wait_for_process_exit(pid, 1000)
-        catch
-          :exit, _ -> :ok
-        end
+        stop_safely(pid, :normal, 5000)
+        # Wait for process to fully terminate
+        wait_for_process_exit(pid, 1000)
     end
   end
 

--- a/test/support/consumer_group_test_helpers.ex
+++ b/test/support/consumer_group_test_helpers.ex
@@ -18,6 +18,8 @@ defmodule KafkaEx.TestSupport.ConsumerGroupHelpers do
       end
   """
 
+  import KafkaEx.TestSupport.ProcessHelpers
+
   alias KafkaEx.Consumer.ConsumerGroup
   alias KafkaEx.TestSupport.TestGenConsumer
 
@@ -181,15 +183,7 @@ defmodule KafkaEx.TestSupport.ConsumerGroupHelpers do
   def stop_consumer_group(nil), do: :ok
 
   def stop_consumer_group(cg_pid) when is_pid(cg_pid) do
-    if Process.alive?(cg_pid) do
-      try do
-        Supervisor.stop(cg_pid, :normal, 5_000)
-      catch
-        :exit, _ -> :ok
-      end
-    end
-
-    :ok
+    stop_safely(cg_pid, :normal, 5_000)
   end
 
   @doc """

--- a/test/support/process_helpers.ex
+++ b/test/support/process_helpers.ex
@@ -1,0 +1,34 @@
+defmodule KafkaEx.TestSupport.ProcessHelpers do
+  @moduledoc """
+  Safe process teardown for tests.
+
+  Tests `start_link` processes that are linked to the test process; when the
+  test ends those processes die with it, and `on_exit` runs afterwards. A plain
+  `GenServer.stop/1` (or `Supervisor.stop/1`) then raises `(EXIT) :noproc` on the
+  already-dead process, and `if Process.alive?(pid), do: GenServer.stop(pid)` is a
+  TOCTOU that does not close the race. `stop_safely/1` swallows the failure so
+  teardown never fails on a dead process. Works for any OTP process (GenServer or
+  Supervisor) — both are `:gen` processes.
+
+  It also accepts a name (atom, `{:global, _}`, `{:via, _, _}`). A name whose
+  process or backing registry is already gone resolves to an exit (`:noproc`) or
+  a raise (e.g. `ArgumentError: unknown registry` from a torn-down `Registry`);
+  both are caught, so any teardown reason — and any abnormal exit reason passed
+  in — yields `:ok`.
+  """
+
+  @doc """
+  Stop an OTP process, returning `:ok` even if it is already dead, dying, or
+  named by a process/registry that no longer exists. Use in `on_exit/1` and
+  best-effort cleanup instead of `GenServer.stop`/`Supervisor.stop`.
+  """
+  @spec stop_safely(GenServer.server(), term(), timeout()) :: :ok
+  def stop_safely(server, reason \\ :normal, timeout \\ :infinity) do
+    _ = GenServer.stop(server, reason, timeout)
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+end


### PR DESCRIPTION
## Problem

Tests `start_link` processes linked to the test process; those processes die when the test ends, and `on_exit` runs afterwards. `GenServer.stop`/`Supervisor.stop` then intermittently raise `(EXIT) :noproc` on the already-dead process. The common `if Process.alive?(pid), do: GenServer.stop(pid)` guard is a TOCTOU that narrows but never closes the race — it reddened `ManagerRecoverableErrorTest` on the CI matrix.

## Fix

- **`KafkaEx.TestSupport.ProcessHelpers.stop_safely/1,3`** — stops any OTP process (GenServer or Supervisor) and returns `:ok`, swallowing `:exit` on a dead/dying/unregistered target. No `Process.alive?` pre-check, so the TOCTOU is gone.
- **Migrated every racy `on_exit`/best-effort teardown** onto it: unit tests, the integration/lifecycle suites, and the two shared helpers (`consumer_group_test_helpers`, `chaos_test_helpers`).
- **Left unchanged** (not teardown races): assertion stops (`:ok = GenServer.stop(...)` whose result is asserted), `Process.exit`, and `assert/refute Process.alive?`.
- **Recurrence guard** — `scripts/check_teardown.sh` (wired into the static-checks compile job) fails CI if a raw `GenServer`/`Supervisor.stop` re-enters an `on_exit`; plus a CONTRIBUTING note steering teardown to `stop_safely` / `start_supervised!`.

## Scope & verification

Test/CI/docs-only — **no `lib/` code touched**. Full unit suite green (2948, 0 failures); resilience integration smoke green (5/5); the guard runs clean and its positive control fires on a planted bad teardown.