### PR TITLE
fix: rejoin (not crash) on illegal_generation/unknown_member_id; terminal-stop on fenced_instance_id

### DIFF
--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -15,12 +15,18 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
      needed.
      * `:rebalance_in_progress` a rebalance has been initiated, so each member
      should re-join.
-     * `:unknown_member_id` means that this heartbeat was from a previous dead
-     generation.
+     * `:unknown_member_id` means the coordinator has forgotten this member; it
+     must re-join with a fresh (reset) member_id.
+     * `:illegal_generation` means this member's generation is stale; it must
+     re-join (keeping its member_id) to pick up the new generation.
+     * `:fenced_instance_id` means another member has claimed this member's
+     static `group.instance.id`; this is terminal and the member stops rather
+     than re-joining.
 
-   For either of the error conditions, the heartbeat process exits, which is
-   trapped by the KafkaEx.Consumer.ConsumerGroup.Manager and handled by re-joining the
-   consumer group. (see KafkaEx.Consumer.ConsumerGroup.Manager.join/1)
+   For the recoverable conditions the heartbeat process exits with a
+   `{:shutdown, _}` reason that the KafkaEx.Consumer.ConsumerGroup.Manager
+   traps and turns into a re-join (resetting identity per the reason) or a
+   clean terminal stop. (see KafkaEx.Consumer.ConsumerGroup.Manager)
   """
 
   use GenServer
@@ -79,8 +85,19 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:error, :rebalance_in_progress} ->
         {:stop, {:shutdown, :rebalance}, state}
 
+      {:error, :illegal_generation} ->
+        {:stop, {:shutdown, {:rejoin, :illegal_generation}}, state}
+
       {:error, :unknown_member_id} ->
-        {:stop, {:shutdown, :rebalance}, state}
+        {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
+
+      {:error, :fenced_instance_id} ->
+        Logger.error(
+          "Heartbeat fenced (:fenced_instance_id): another member holds this " <>
+            "group.instance.id; stopping without rejoin"
+        )
+
+        {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, state}
 
       {:error, reason} ->
         Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -91,7 +91,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
             members: [binary()] | nil,
             generation_id: integer() | nil,
             assignments: [{binary(), integer()}] | nil,
-            heartbeat_timer: reference() | nil,
+            heartbeat_timer: pid() | nil,
             sync_retry_backoff_ms: non_neg_integer() | nil,
             sync_failures: non_neg_integer()
           }
@@ -363,6 +363,26 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
+  # The heartbeat hit a "rejoin now, with identity reset" signal:
+  # :illegal_generation (stale generation — keep member_id) or
+  # :unknown_member_id (coordinator forgot us — clear member_id). reset_generation/2
+  # applies the right reset, then we rejoin in place. This is recovery, NOT a crash,
+  # so the one_for_all / max_restarts: 0 consumer-group supervisor is never torn down.
+  def handle_info({:EXIT, timer, {:shutdown, {:rejoin, reason}}}, %State{heartbeat_timer: timer} = state) do
+    Logger.warning("Heartbeat signalled rejoin (#{inspect(reason)}), resetting generation and rejoining group")
+    state = reset_generation(state, reason)
+    {:ok, state} = rebalance(state, {:heartbeat_rejoin, reason})
+    {:noreply, state}
+  end
+
+  # The heartbeat hit a terminal error (:fenced_instance_id — another member
+  # holds this static group.instance.id). Rejoining would split-brain or be
+  # fenced again, so stop cleanly and let the supervisor tear the member down.
+  def handle_info({:EXIT, timer, {:shutdown, {:terminal, reason}}}, %State{heartbeat_timer: timer} = state) do
+    Logger.error("Heartbeat hit terminal error #{inspect(reason)}, stopping consumer group member")
+    {:stop, {:shutdown, {:terminal, reason}}, state}
+  end
+
   # If the heartbeat gets an error, attempt to rejoin for recoverable errors.
   # Recoverable errors: coordinator changed or temporarily unavailable
   def handle_info({:EXIT, _heartbeat_timer, {:shutdown, {:error, reason}}}, %State{} = state) do
@@ -402,6 +422,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   def handle_info({:EXIT, pid, :normal}, %State{} = state) do
     Logger.debug("Manager trapping normal :EXIT from linked pid #{inspect(pid)}")
     {:noreply, state}
+  end
+
+  # Deferred terminal stop requested from inside the synchronous join/sync call
+  # chain, which can't return {:stop, _, _} directly. handle_sync_error/3 sends
+  # this on a terminal SyncGroup error (:fenced_instance_id) so the member stops
+  # cleanly without rejoining.
+  def handle_info({:terminal_shutdown, reason}, %State{} = state) do
+    {:stop, {:shutdown, {:terminal, reason}}, state}
   end
 
   # When terminating, inform the group coordinator that this member is leaving
@@ -579,22 +607,19 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     end
   end
 
-  # SyncGroup recovery — mirrors join/2's recoverable-error handling. A transient
-  # SyncGroup failure (e.g. :unknown / :timeout from a coordinator under rebalance
-  # churn, such as a rolling deploy) must not crash the Manager: the crash escalates
-  # through the one_for_all / max_restarts: 0 consumer-group supervisor into a full
-  # subtree teardown, triggering a group-wide rebalance.
-  # Rejoining is the correct recovery (a fresh generation); retrying sync_group
-  # with the same, possibly stale, generation_id is futile.
-  #
-  # Bounded like join: tolerate up to @max_sync_retries consecutive recoverable
-  # failures (the counter resets on a successful sync), then give up and raise —
-  # escalating a persistent failure to the supervisor rebuild rather than
-  # rejoining forever (cf. join's JoinGroupRetriesExhausted). Non-recoverable
-  # errors raise immediately.
+  defp handle_sync_error(%State{} = state, group_name, :fenced_instance_id = reason) do
+    Logger.error(
+      "SyncGroup for #{inspect(group_name)} returned :fenced_instance_id; " <>
+        "another member holds this group.instance.id. Stopping without rejoin"
+    )
+
+    send(self(), {:terminal_shutdown, reason})
+    {:ok, state}
+  end
+
   defp handle_sync_error(%State{} = state, group_name, reason) do
     cond do
-      not recoverable_error?(reason) ->
+      not sync_rejoinable?(reason) ->
         raise KafkaEx.SyncGroupError, group_name: group_name, reason: reason
 
       state.sync_failures >= @max_sync_retries ->
@@ -612,9 +637,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         )
 
         :timer.sleep(state.sync_retry_backoff_ms)
+        state = reset_generation(state, reason)
         rebalance(%State{state | sync_failures: attempt}, {:sync_error, reason})
     end
   end
+
+  defp sync_rejoinable?(:illegal_generation), do: true
+  defp sync_rejoinable?(:unknown_member_id), do: true
+  defp sync_rejoinable?(reason), do: recoverable_error?(reason)
 
   # Convert assignments from Manager format to protocol-agnostic format for sync_group request
   # Input: [{member_id, [{topic, [partition_ids]}]}]

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -255,9 +255,17 @@ defmodule KafkaEx.Support.Retry do
 
   Contrast `commit_retryable?/1`, where retrying `:rebalance_in_progress` is
   correct — commits are idempotent and need no rejoin.
+
+  `:illegal_generation` / `:unknown_member_id` / `:fenced_instance_id` are also
+  not retryable: the same SyncGroup (same generation/member_id) can only fail
+  the same way. They must bubble so the consumer-group manager rejoins
+  (resetting identity per the reason) or, for `:fenced_instance_id`, stops.
   """
   @spec sync_group_retryable?(error()) :: boolean()
   def sync_group_retryable?(:rebalance_in_progress), do: false
+  def sync_group_retryable?(:illegal_generation), do: false
+  def sync_group_retryable?(:unknown_member_id), do: false
+  def sync_group_retryable?(:fenced_instance_id), do: false
   def sync_group_retryable?(_), do: true
 
   @doc """
@@ -269,14 +277,18 @@ defmodule KafkaEx.Support.Retry do
   single failed heartbeat does not escalate into a full rejoin + group-wide
   rebalance — hence default-retry for unclassified errors.
 
-  The broker's two "rejoin now" signals — `:rebalance_in_progress` and
-  `:unknown_member_id` — are mapped by the heartbeat process straight to
-  `{:shutdown, :rebalance}`; retrying them at the client only delays the
-  inevitable rejoin, so they are not retryable.
+  The broker's "rejoin now" / identity signals — `:rebalance_in_progress`,
+  `:unknown_member_id` and `:illegal_generation` — are mapped by the heartbeat
+  process to a shutdown the manager turns into a rejoin; retrying them at the
+  client only delays the inevitable rejoin, so they are not retryable.
+  `:fenced_instance_id` is terminal (another member holds this
+  `group.instance.id`) — retrying cannot help, so it is not retryable either.
   """
   @spec heartbeat_retryable?(error()) :: boolean()
   def heartbeat_retryable?(:rebalance_in_progress), do: false
   def heartbeat_retryable?(:unknown_member_id), do: false
+  def heartbeat_retryable?(:illegal_generation), do: false
+  def heartbeat_retryable?(:fenced_instance_id), do: false
   def heartbeat_retryable?(_), do: true
 
   @doc """

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -495,7 +495,11 @@ defmodule KafkaEx.Telemetry do
           binary(),
           binary(),
           integer() | nil,
-          atom() | {:heartbeat_error, atom()} | {:commit_fatal, atom()} | {:sync_error, atom()}
+          atom()
+          | {:heartbeat_error, atom()}
+          | {:heartbeat_rejoin, atom()}
+          | {:commit_fatal, atom()}
+          | {:sync_error, atom()}
         ) :: :ok
   def emit_rebalance(group_id, member_id, generation_id, reason) do
     :telemetry.execute(

--- a/test/integration/consumer_group/fatal_rejoin_recovery_test.exs
+++ b/test/integration/consumer_group/fatal_rejoin_recovery_test.exs
@@ -1,0 +1,123 @@
+defmodule KafkaEx.Integration.ConsumerGroup.FatalRejoinRecoveryTest do
+  @moduledoc """
+  Exercises the H-3 in-place rejoin against the shared integration cluster
+  (start it with `./scripts/docker_up.sh`).
+
+  Forces a real `ILLEGAL_GENERATION` by corrupting the running Heartbeat
+  process's `generation_id` to a value the broker never issued. The next
+  heartbeat is rejected; the heartbeat stops with `{:shutdown, {:rejoin,
+  :illegal_generation}}`, which the Manager turns into an in-place rejoin
+  (keeping member_id, per `reset_generation/2`) — NOT a crash of the
+  one_for_all / max_restarts: 0 consumer-group supervisor.
+
+  Before this fix, `:illegal_generation` reached the Manager as an
+  unrecoverable `{:shutdown, {:error, _}}` and stopped it, taking the whole
+  member subtree (and triggering a group-wide rebalance) down.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 120_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.API
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+    topic = "cg_fatal_rejoin_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{client: client, uris: uris, topic: topic}}
+  end
+
+  test "a heartbeat :illegal_generation rejoins in place (keeps member_id), stays alive, resumes consuming",
+       %{client: client, uris: uris, topic: topic} do
+    Process.flag(:trap_exit, true)
+    group = "cg_fatal_rejoin_grp_#{:rand.uniform(1_000_000)}"
+
+    opts = [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest,
+      extra_consumer_args: %{test_pid: self()}
+    ]
+
+    {:ok, cg} = ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    gen0 = ConsumerGroup.generation_id(cg)
+    member0 = ConsumerGroup.member_id(cg)
+    assert is_integer(gen0) and is_binary(member0) and member0 != ""
+
+    # Consuming before the fault.
+    {:ok, _} = API.produce(client, topic, 0, [%{value: "before-fault"}])
+    assert_receive {:messages_received, _}, 30_000
+
+    # Corrupt the live Heartbeat's generation so its next HeartbeatRequest is
+    # rejected with ILLEGAL_GENERATION by the real coordinator.
+    manager = ConsumerGroup.get_manager_pid(cg)
+    heartbeat = :sys.get_state(manager).heartbeat_timer
+    assert is_pid(heartbeat) and Process.alive?(heartbeat)
+
+    :sys.replace_state(heartbeat, fn hb_state ->
+      %{hb_state | generation_id: hb_state.generation_id + 1_000}
+    end)
+
+    # The member rejoins in place: a NEW (valid) generation, the SAME member_id,
+    # and the supervisor never went down.
+    assert {:ok, gen1} = wait_for_generation_change(cg, gen0, 60_000)
+    assert gen1 != gen0
+    assert ConsumerGroup.member_id(cg) == member0, "illegal_generation must keep member_id"
+    assert Process.alive?(cg), "the consumer-group supervisor must survive the rejoin"
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    # Consumption resumes after the in-place rejoin.
+    {:ok, _} = API.produce(client, topic, 0, [%{value: "after-rejoin"}])
+    assert_receive {:messages_received, _}, 30_000
+  end
+
+  defp wait_for_generation_change(cg, gen0, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_for_generation_change(cg, gen0, deadline)
+  end
+
+  defp do_wait_for_generation_change(cg, gen0, deadline) do
+    current =
+      try do
+        ConsumerGroup.generation_id(cg)
+      catch
+        :exit, _ -> gen0
+      end
+
+    cond do
+      is_integer(current) and current != gen0 ->
+        {:ok, current}
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :timeout}
+
+      true ->
+        Process.sleep(200)
+        do_wait_for_generation_change(cg, gen0, deadline)
+    end
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -71,7 +71,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
       assert {:stop, {:shutdown, :rebalance}, ^state} = Heartbeat.handle_info(:timeout, state)
     end
 
-    test "stops with rebalance on unknown_member_id error" do
+    test "stops with rejoin(:unknown_member_id) so the manager resets member_id and rejoins" do
       {:ok, client} = MockClient.start_link(%{heartbeat: {:error, :unknown_member_id}})
 
       state = %Heartbeat.State{
@@ -82,7 +82,38 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
         heartbeat_interval: 1000
       }
 
-      assert {:stop, {:shutdown, :rebalance}, ^state} = Heartbeat.handle_info(:timeout, state)
+      assert {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
+    end
+
+    test "stops with rejoin(:illegal_generation) so the manager resets generation and rejoins" do
+      {:ok, client} = MockClient.start_link(%{heartbeat: {:error, :illegal_generation}})
+
+      state = %Heartbeat.State{
+        client: client,
+        group_name: "test-group",
+        member_id: "member-1",
+        generation_id: 1,
+        heartbeat_interval: 1000
+      }
+
+      assert {:stop, {:shutdown, {:rejoin, :illegal_generation}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
+    end
+
+    test "stops terminally on fenced_instance_id (static membership conflict, no rejoin)" do
+      {:ok, client} = MockClient.start_link(%{heartbeat: {:error, :fenced_instance_id}})
+
+      state = %Heartbeat.State{
+        client: client,
+        group_name: "test-group",
+        member_id: "member-1",
+        generation_id: 1,
+        heartbeat_interval: 1000
+      }
+
+      assert {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
     end
 
     test "stops with error on other error codes" do

--- a/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
@@ -1,0 +1,205 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
+  @moduledoc """
+  Regression for H-3: the broker's fatal consumer-group signals must rejoin (or
+  cleanly stop), never crash the Manager.
+
+  Before this fix, `:illegal_generation` / `:fenced_instance_id` reached the
+  Manager as `{:shutdown, {:error, _}}` (heartbeat) or an immediate
+  `SyncGroupError` raise (sync) — both tore down the one_for_all /
+  max_restarts: 0 consumer-group supervisor, escalating one member's stale
+  generation into a group-wide rebalance.
+
+  Now:
+    * `:illegal_generation` -> rejoin keeping member_id (stale generation only)
+    * `:unknown_member_id`  -> rejoin after resetting member_id (coordinator
+      forgot us)
+    * `:fenced_instance_id` -> clean terminal stop (another member holds the
+      static group.instance.id; rejoining would split-brain / be re-fenced)
+
+  Exercised through the real `handle_info/2` and the full Manager start path; no
+  private function is exposed for testing.
+  """
+  use ExUnit.Case, async: false
+
+  alias KafkaEx.Consumer.ConsumerGroup.Manager
+  alias KafkaEx.Consumer.ConsumerGroup.Manager.State
+  alias KafkaEx.Consumer.GenConsumer
+  alias KafkaEx.Messages.JoinGroup
+  alias KafkaEx.Messages.LeaveGroup
+  alias KafkaEx.Test.MockClient
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  # A pid that has already exited — mirrors reality, where the heartbeat process
+  # is dead by the time its `{:EXIT, _, _}` reaches the Manager. Using it as
+  # `heartbeat_timer` makes `stop_heartbeat_timer/1` (during rebalance) a no-op
+  # via its `Process.alive?/1` guard.
+  defp dead_pid do
+    {pid, ref} = spawn_monitor(fn -> :ok end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    end
+
+    pid
+  end
+
+  defp heartbeat_state(client, timer) do
+    {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+    on_exit(fn -> ProcessHelpers.stop_safely(sup) end)
+
+    %State{
+      client: client,
+      supervisor_pid: sup,
+      group_name: "g",
+      topics: ["t"],
+      member_id: "m",
+      generation_id: 7,
+      session_timeout: 1000,
+      session_timeout_padding: 0,
+      rebalance_timeout: 1000,
+      heartbeat_timer: timer
+    }
+  end
+
+  describe "heartbeat EXIT routing" do
+    test ":rejoin(:illegal_generation) rejoins keeping member_id, not a stop" do
+      # join_group fails non-recoverably so the rejoin raises immediately (no
+      # retry sleeps, no consumer startup). Reaching join at all proves the EXIT
+      # was routed to the rejoin path rather than {:stop, ...}.
+      {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      timer = dead_pid()
+      state = heartbeat_state(client, timer)
+
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, {:shutdown, {:rejoin, :illegal_generation}}}, state)
+      end
+
+      # :illegal_generation keeps member_id -> rejoin uses "m"
+      assert {:join_group, "g", "m"} in MockClient.get_calls(client)
+    end
+
+    test ":rejoin(:unknown_member_id) rejoins after resetting member_id" do
+      {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      timer = dead_pid()
+      state = heartbeat_state(client, timer)
+
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, {:shutdown, {:rejoin, :unknown_member_id}}}, state)
+      end
+
+      calls = MockClient.get_calls(client)
+      # :unknown_member_id clears member_id -> rejoin uses "" (broker assigns fresh)
+      assert {:join_group, "g", ""} in calls
+      refute {:join_group, "g", "m"} in calls
+    end
+
+    test ":terminal(:fenced_instance_id) stops the manager cleanly without rejoining" do
+      {:ok, client} = MockClient.start_link(%{})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      timer = dead_pid()
+      state = heartbeat_state(client, timer)
+
+      assert {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, ^state} =
+               Manager.handle_info({:EXIT, timer, {:shutdown, {:terminal, :fenced_instance_id}}}, state)
+
+      refute Enum.any?(MockClient.get_calls(client), &match?({:join_group, _, _}, &1))
+    end
+  end
+
+  describe "SyncGroup error routing" do
+    # Drives a real Manager against a scripted MockClient (the :client injection
+    # seam): JoinGroup succeeds (leader_id != member_id, so the member skips
+    # assignment and goes straight to SyncGroup), then SyncGroup always returns
+    # the error under test.
+    #
+    # Each {:sync_error, _} rebalance is captured live from telemetry (counter +
+    # the emitted member_id forwarded to the test pid) so the reset-vs-keep
+    # evidence survives the Manager terminating its client on give-up.
+    defp start_manager_with_sync_error(sync_error) do
+      Process.flag(:trap_exit, true)
+      test_pid = self()
+      rejoins = :counters.new(1, [:atomics])
+      handler_id = {__MODULE__, make_ref()}
+
+      :telemetry.attach(
+        handler_id,
+        [:kafka_ex, :consumer, :rebalance],
+        fn _event, _measurements, %{reason: reason, member_id: member_id}, _ ->
+          case reason do
+            {:sync_error, _} ->
+              :counters.add(rejoins, 1, 1)
+              send(test_pid, {:rejoin_member_id, member_id})
+
+            _ ->
+              :ok
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+      on_exit(fn -> ProcessHelpers.stop_safely(sup) end)
+
+      {:ok, mock} =
+        MockClient.start_link(%{
+          join_group: {:ok, %JoinGroup{member_id: "m1", leader_id: "m2", generation_id: 1, members: []}},
+          sync_group: {:error, sync_error},
+          leave_group: {:ok, %LeaveGroup{}}
+        })
+
+      opts = [
+        supervisor_pid: sup,
+        client: mock,
+        heartbeat_interval: 60_000,
+        session_timeout: 10_000,
+        sync_retry_backoff_ms: 5
+      ]
+
+      {:ok, manager} =
+        Manager.start_link({{GenConsumer, TestGenConsumer}, "fatal-sync-group", ["t"], opts})
+
+      {manager, rejoins}
+    end
+
+    test ":illegal_generation rejoins in place (keeps member_id) rather than crashing, bounded" do
+      {manager, rejoins} = start_manager_with_sync_error(:illegal_generation)
+
+      # Rejoins (does NOT raise SyncGroupError immediately); :illegal_generation
+      # keeps member_id, so every rejoin still carries "m1".
+      assert_receive {:rejoin_member_id, "m1"}, 30_000
+
+      # The bound still escalates a persistent failure to give-up.
+      assert_receive {:EXIT, ^manager, {%KafkaEx.SyncGroupRetriesExhaustedError{}, _stacktrace}}, 30_000
+      assert :counters.get(rejoins, 1) == 3
+    end
+
+    test ":unknown_member_id rejoins after resetting member_id, bounded" do
+      {manager, rejoins} = start_manager_with_sync_error(:unknown_member_id)
+
+      # The give-up EXIT only fires after all 3 bounded rejoins, so once we have
+      # it every {:rejoin_member_id, _} telemetry message is already delivered.
+      assert_receive {:EXIT, ^manager, {%KafkaEx.SyncGroupRetriesExhaustedError{}, _stacktrace}}, 30_000
+      assert :counters.get(rejoins, 1) == 3
+
+      # :unknown_member_id clears member_id before every rejoin -> "" is emitted,
+      # never "m1".
+      assert_received {:rejoin_member_id, ""}
+      refute_received {:rejoin_member_id, "m1"}
+    end
+
+    test ":fenced_instance_id stops terminally without rejoining or raising" do
+      {manager, rejoins} = start_manager_with_sync_error(:fenced_instance_id)
+
+      assert_receive {:EXIT, ^manager, {:shutdown, {:terminal, :fenced_instance_id}}}, 30_000
+      assert :counters.get(rejoins, 1) == 0
+    end
+  end
+end

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -391,6 +391,12 @@ defmodule KafkaEx.Support.RetryTest do
       refute Retry.sync_group_retryable?(:rebalance_in_progress)
     end
 
+    test "identity/generation errors are NOT retryable (same SyncGroup can only fail the same way)" do
+      refute Retry.sync_group_retryable?(:illegal_generation)
+      refute Retry.sync_group_retryable?(:unknown_member_id)
+      refute Retry.sync_group_retryable?(:fenced_instance_id)
+    end
+
     test "other sync errors remain retryable (manager's sync recovery handles them)" do
       assert Retry.sync_group_retryable?(:request_timed_out)
       assert Retry.sync_group_retryable?(:unknown)
@@ -399,9 +405,14 @@ defmodule KafkaEx.Support.RetryTest do
   end
 
   describe "heartbeat_retryable?/1" do
-    test "rejoin signals are NOT retryable (heartbeat maps them to {:shutdown, :rebalance})" do
+    test "rejoin signals are NOT retryable (heartbeat shuts down so the manager rejoins)" do
       refute Retry.heartbeat_retryable?(:rebalance_in_progress)
       refute Retry.heartbeat_retryable?(:unknown_member_id)
+      refute Retry.heartbeat_retryable?(:illegal_generation)
+    end
+
+    test "fenced_instance_id is NOT retryable (terminal: another member holds the static id)" do
+      refute Retry.heartbeat_retryable?(:fenced_instance_id)
     end
 
     test "transient errors remain retryable (absorb a blip, avoid a spurious rejoin)" do


### PR DESCRIPTION
## Problem

The consumer-group manager treated the broker's identity/generation signals on the **Heartbeat** and **SyncGroup** paths as unrecoverable:

- `:illegal_generation` reached the manager as `{:shutdown, {:error, _}}` and **stopped** it (`recoverable_error?/1` returns false for it).
- The sync path **raised** `SyncGroupError` for these codes.

Either outcome tore down the `one_for_all` / `max_restarts: 0` consumer-group supervisor, escalating **one member's** stale generation into a **group-wide rebalance** — the rebalance-storm class of incident.

## Fix

Route these codes per the reference clients (brod `brod_group_coordinator`, librdkafka `rdkafka_cgrp`, Java `AbstractCoordinator`/`ConsumerCoordinator`):

| Error | Action |
|---|---|
| `:illegal_generation` | rejoin in place, **keep** member_id (reset generation only) |
| `:unknown_member_id` | rejoin in place, **reset** member_id (broker forgot us → fresh broker-assigned id) |
| `:fenced_instance_id` | **clean terminal stop**, no rejoin (KIP-345: another member holds this `group.instance.id`; rejoining would split-brain / be re-fenced) |
| `:rebalance_in_progress` | unchanged (rejoin, keep id) |

Mechanics:
- **heartbeat.ex** now exits with `{:shutdown, {:rejoin, reason}}` / `{:shutdown, {:terminal, reason}}`.
- **manager.ex** gains EXIT handlers that reset identity via `reset_generation/2` and rebalance, or stop cleanly. The sync path reuses the same reset + a **bounded** rejoin (`@max_sync_retries`) instead of raising, and defers the terminal stop through `handle_info` (a `defp` mid-`join`/`sync` chain can't return `{:stop, …}`).
- **retry.ex**: `sync_group_retryable?` / `heartbeat_retryable?` no longer retry these codes at the client layer — the same-generation request can only fail identically.

`:fenced_instance_id` → terminal is a **deliberate divergence from brod** (which lacks a fenced clause and loops to `max_rejoin_attempts`, re-claiming the static slot each round); Java raises a non-retriable `FencedInstanceIdException` and librdkafka marks it fatal.

## Tests

- **Unit**: per-path coverage for heartbeat routing, the manager EXIT/sync handling, and the retry predicates (`manager_fatal_rejoin_test`, `heartbeat_test`, `retry_test`). Verified failing-first against the pre-fix code.
- **Integration**: forces a *real* `ILLEGAL_GENERATION` (corrupt the live Heartbeat's `generation_id`) and asserts in-place rejoin keeps member_id, advances the generation, keeps the supervisor alive, and resumes consuming — green on the 3-broker docker cluster.

No chaos test: Toxiproxy operates at the TCP layer and cannot induce these protocol-level error codes (same limitation noted for NOT_COORDINATOR in #547/#548).

## Checks

`mix format`, `mix credo --strict`, `mix dialyzer`, `mix compile --warnings-as-errors`, `mix test.unit` (2959/0) all green.