### PR TITLE
fix: terminal-stop on group-authorization failure; drop stale heartbeat-error EXITs (H-3 follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## 1.0.1 (2026-06-17)
+## 1.0.1 (2026-06-26)
 
 ### Breaking Changes
 
@@ -76,8 +76,71 @@
   correct interop with Kafka 2.3+ under
   `group.initial.rebalance.delay.ms`.
 
+* **Consumer-group heartbeat and SyncGroup errors now rejoin or stop
+  cleanly instead of crashing the group (#554, #555).** Previously
+  `:illegal_generation` / `:unknown_member_id` / `:fenced_instance_id`
+  reached the manager as a generic error and crashed it under the
+  `one_for_all` / `max_restarts: 0` consumer-group supervisor, escalating
+  one member's stale generation into a group-wide rebalance. Now, matching
+  brod's identity handling (terminal codes follow the Java client):
+
+  - `:illegal_generation` → rejoin keeping `member_id` (only the
+    generation is stale).
+  - `:unknown_member_id` → rejoin after clearing `member_id` (the
+    coordinator forgot the member; the broker assigns a fresh one).
+  - `:fenced_instance_id` (KIP-345) and `:group_authorization_failed` →
+    clean terminal stop without rejoining (rejoining would split-brain
+    the static slot or fail authorization again).
+
+  Stale heartbeat-timer EXITs (from a timer already replaced during a
+  rebalance) are dropped instead of acted on. A `{:heartbeat_rejoin,
+  reason}` reason is emitted on the `[:kafka_ex, :consumer, :rebalance]`
+  telemetry event.
+
+* **Client retry loop preserves the real transport error atom (#544).**
+  A `recv` timeout to a broker was mapped to `:unknown`, which crashed the
+  consumer-group manager via `SyncGroupError` (the rebalance-storm root
+  cause). The actual transport atom (`:timeout`, `:closed`, …) is now kept
+  so it is classified and recovered correctly.
+
+* **Consumer-group sync recovery is bounded, not crash-on-error (#546).**
+  Recoverable `SyncGroup` errors now rejoin with a bounded retry budget and
+  generation reset between attempts instead of raising and tearing down the
+  group supervisor.
+
+* **The group coordinator is re-discovered on `:not_coordinator` /
+  `:coordinator_not_available` (#547).** Previously a stale cached
+  coordinator was reused after the coordinator moved (rolling restart),
+  so every subsequent request failed. The cached coordinator is now
+  invalidated and rediscovered.
+
+* **OffsetCommit / OffsetFetch correctness — no silent loss or duplicate
+  processing (#548).** The stream halts on a fatal commit error instead of
+  looping and reprocessing; `load_offsets` retries retryable errors
+  (including `:unstable_offset_commit`, KIP-447) and raises on
+  fatal/exhaustion instead of silently resetting to the earliest offset.
+
+* **Broker connect is bounded by a timeout instead of blocking
+  indefinitely (#556).** Connecting to an unreachable broker no longer
+  hangs the client; the connect is bounded by `:connect_timeout`
+  (default 10s).
+
+* **Transaction control batches are dropped from fetch results, and the
+  fetch offset advances past them (#557).** Control batches (transaction
+  commit/abort markers) were surfaced to consumers as records; they are now
+  filtered out. A fetch that contains only control batches still advances
+  the consumer/stream offset past them (via the batch metadata) instead of
+  re-fetching the same offset forever.
+
 ### Internal
 
+* Consumer-group / config test stabilization: eliminated the `on_exit`
+  teardown `:noproc` race class via `KafkaEx.TestSupport.ProcessHelpers`
+  and stabilized three flaky consumer-group / config tests (#549, #553).
+* `load_offsets` startup retry now rides the unified
+  `KafkaEx.Support.Retry.with_retry/2` with exponential backoff (#551).
+* Renamed the `KafkaEx.Support.Retry` option `:max_retries` to
+  `:max_attempts` for consistency with the retry-count semantics (#552).
 * Migrated the test suite's mocking from Hammox to Mimic (`mimic ~> 1.7`),
   dropping the unused `KafkaEx.NetworkClientMock`. No runtime/production
   changes. (#534)

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -19,9 +19,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
      must re-join with a fresh (reset) member_id.
      * `:illegal_generation` means this member's generation is stale; it must
      re-join (keeping its member_id) to pick up the new generation.
-     * `:fenced_instance_id` means another member has claimed this member's
-     static `group.instance.id`; this is terminal and the member stops rather
-     than re-joining.
+     * `:fenced_instance_id` (another member claimed this member's static
+     `group.instance.id`) and `:group_authorization_failed` (no access to the
+     group) are terminal; the member stops rather than re-joining.
 
    For the recoverable conditions the heartbeat process exits with a
    `{:shutdown, _}` reason that the KafkaEx.Consumer.ConsumerGroup.Manager
@@ -91,13 +91,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:error, :unknown_member_id} ->
         {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
 
-      {:error, :fenced_instance_id} ->
-        Logger.error(
-          "Heartbeat fenced (:fenced_instance_id): another member holds this " <>
-            "group.instance.id; stopping without rejoin"
-        )
-
-        {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, state}
+      {:error, reason} when reason in [:fenced_instance_id, :group_authorization_failed] ->
+        Logger.error("Heartbeat hit terminal error #{inspect(reason)}; stopping without rejoin")
+        {:stop, {:shutdown, {:terminal, reason}}, state}
 
       {:error, reason} ->
         Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -607,11 +607,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     end
   end
 
-  defp handle_sync_error(%State{} = state, group_name, :fenced_instance_id = reason) do
-    Logger.error(
-      "SyncGroup for #{inspect(group_name)} returned :fenced_instance_id; " <>
-        "another member holds this group.instance.id. Stopping without rejoin"
-    )
+  defp handle_sync_error(%State{} = state, group_name, reason)
+       when reason in [:fenced_instance_id, :group_authorization_failed] do
+    Logger.error("SyncGroup for #{inspect(group_name)} returned terminal #{inspect(reason)}; stopping without rejoin")
 
     send(self(), {:terminal_shutdown, reason})
     {:ok, state}

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -369,7 +369,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # applies the right reset, then we rejoin in place. This is recovery, NOT a crash,
   # so the one_for_all / max_restarts: 0 consumer-group supervisor is never torn down.
   def handle_info({:EXIT, timer, {:shutdown, {:rejoin, reason}}}, %State{heartbeat_timer: timer} = state) do
-    Logger.warning("Heartbeat signalled rejoin (#{inspect(reason)}), resetting generation and rejoining group")
+    Logger.warning("Heartbeat signalled rejoin (#{inspect(reason)}), resetting identity and rejoining group")
     state = reset_generation(state, reason)
     {:ok, state} = rebalance(state, {:heartbeat_rejoin, reason})
     {:noreply, state}

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -383,9 +383,11 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:stop, {:shutdown, {:terminal, reason}}, state}
   end
 
-  # If the heartbeat gets an error, attempt to rejoin for recoverable errors.
-  # Recoverable errors: coordinator changed or temporarily unavailable
-  def handle_info({:EXIT, _heartbeat_timer, {:shutdown, {:error, reason}}}, %State{} = state) do
+  # If the CURRENT heartbeat gets an error, attempt to rejoin for recoverable
+  # errors (coordinator changed or temporarily unavailable). Binding `timer` to
+  # the current heartbeat_timer keeps a stale heartbeat's error EXIT from
+  # triggering a spurious rebalance — it falls through to the stale-timer clause.
+  def handle_info({:EXIT, timer, {:shutdown, {:error, reason}}}, %State{heartbeat_timer: timer} = state) do
     if recoverable_error?(reason) do
       Logger.warning("Heartbeat failed with #{inspect(reason)}, attempting to rejoin group")
       {:ok, new_state} = rebalance(state, {:heartbeat_error, reason})

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -256,16 +256,18 @@ defmodule KafkaEx.Support.Retry do
   Contrast `commit_retryable?/1`, where retrying `:rebalance_in_progress` is
   correct — commits are idempotent and need no rejoin.
 
-  `:illegal_generation` / `:unknown_member_id` / `:fenced_instance_id` are also
-  not retryable: the same SyncGroup (same generation/member_id) can only fail
-  the same way. They must bubble so the consumer-group manager rejoins
-  (resetting identity per the reason) or, for `:fenced_instance_id`, stops.
+  `:illegal_generation` / `:unknown_member_id` / `:fenced_instance_id` /
+  `:group_authorization_failed` are also not retryable: the same SyncGroup can
+  only fail the same way. They must bubble so the consumer-group manager rejoins
+  (resetting identity per the reason) or, for the terminal codes
+  (`:fenced_instance_id`, `:group_authorization_failed`), stops.
   """
   @spec sync_group_retryable?(error()) :: boolean()
   def sync_group_retryable?(:rebalance_in_progress), do: false
   def sync_group_retryable?(:illegal_generation), do: false
   def sync_group_retryable?(:unknown_member_id), do: false
   def sync_group_retryable?(:fenced_instance_id), do: false
+  def sync_group_retryable?(:group_authorization_failed), do: false
   def sync_group_retryable?(_), do: true
 
   @doc """
@@ -280,15 +282,17 @@ defmodule KafkaEx.Support.Retry do
   The broker's "rejoin now" / identity signals — `:rebalance_in_progress`,
   `:unknown_member_id` and `:illegal_generation` — are mapped by the heartbeat
   process to a shutdown the manager turns into a rejoin; retrying them at the
-  client only delays the inevitable rejoin, so they are not retryable.
-  `:fenced_instance_id` is terminal (another member holds this
-  `group.instance.id`) — retrying cannot help, so it is not retryable either.
+  client only delays the inevitable rejoin, so they are not retryable. The
+  terminal codes `:fenced_instance_id` (another member holds this
+  `group.instance.id`) and `:group_authorization_failed` (no access to the
+  group) cannot be helped by retry either, so they are not retryable.
   """
   @spec heartbeat_retryable?(error()) :: boolean()
   def heartbeat_retryable?(:rebalance_in_progress), do: false
   def heartbeat_retryable?(:unknown_member_id), do: false
   def heartbeat_retryable?(:illegal_generation), do: false
   def heartbeat_retryable?(:fenced_instance_id), do: false
+  def heartbeat_retryable?(:group_authorization_failed), do: false
   def heartbeat_retryable?(_), do: true
 
   @doc """

--- a/test/integration/consumer_group/fatal_rejoin_recovery_test.exs
+++ b/test/integration/consumer_group/fatal_rejoin_recovery_test.exs
@@ -82,7 +82,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.FatalRejoinRecoveryTest do
 
     # The member rejoins in place: a NEW (valid) generation, the SAME member_id,
     # and the supervisor never went down.
-    assert {:ok, gen1} = wait_for_generation_change(cg, gen0, 60_000)
+    assert {:ok, gen1} = ConsumerGroupHelpers.wait_for_generation_change(cg, gen0, timeout: 60_000)
     assert gen1 != gen0
     assert ConsumerGroup.member_id(cg) == member0, "illegal_generation must keep member_id"
     assert Process.alive?(cg), "the consumer-group supervisor must survive the rejoin"
@@ -93,31 +93,5 @@ defmodule KafkaEx.Integration.ConsumerGroup.FatalRejoinRecoveryTest do
     # Consumption resumes after the in-place rejoin.
     {:ok, _} = API.produce(client, topic, 0, [%{value: "after-rejoin"}])
     assert_receive {:messages_received, _}, 30_000
-  end
-
-  defp wait_for_generation_change(cg, gen0, timeout) do
-    deadline = System.monotonic_time(:millisecond) + timeout
-    do_wait_for_generation_change(cg, gen0, deadline)
-  end
-
-  defp do_wait_for_generation_change(cg, gen0, deadline) do
-    current =
-      try do
-        ConsumerGroup.generation_id(cg)
-      catch
-        :exit, _ -> gen0
-      end
-
-    cond do
-      is_integer(current) and current != gen0 ->
-        {:ok, current}
-
-      System.monotonic_time(:millisecond) >= deadline ->
-        {:error, :timeout}
-
-      true ->
-        Process.sleep(200)
-        do_wait_for_generation_change(cg, gen0, deadline)
-    end
   end
 end

--- a/test/integration/consumer_group_rejoin_test.exs
+++ b/test/integration/consumer_group_rejoin_test.exs
@@ -128,34 +128,10 @@ defmodule KafkaEx.Integration.ConsumerGroupRejoinTest do
     assert wait_for_message_count(1, timeout: 15_000) >= 1
   end
 
-  # Poll generation_id with a short call-timeout; the Manager is busy during
-  # rebalance and cannot respond to the default 5s timeout. Catches exits so
-  # the poll keeps trying until the rebalance completes and a new generation
-  # is assigned.
   defp wait_for_new_generation(cg_pid, gen_before, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_new_generation(cg_pid, gen_before, deadline)
-  end
-
-  defp do_wait_for_new_generation(cg_pid, gen_before, deadline) do
-    if System.monotonic_time(:millisecond) >= deadline do
-      flunk("generation_id did not change from #{inspect(gen_before)} within timeout")
-    end
-
-    result =
-      try do
-        ConsumerGroup.generation_id(cg_pid, 500)
-      catch
-        :exit, _ -> :call_timeout
-      end
-
-    cond do
-      is_integer(result) and result != gen_before ->
-        :ok
-
-      true ->
-        Process.sleep(200)
-        do_wait_for_new_generation(cg_pid, gen_before, deadline)
+    case wait_for_generation_change(cg_pid, gen_before, timeout: timeout_ms) do
+      {:ok, _} -> :ok
+      {:error, :timeout} -> flunk("generation_id did not change from #{inspect(gen_before)} within timeout")
     end
   end
 end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -116,6 +116,21 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
                Heartbeat.handle_info(:timeout, state)
     end
 
+    test "stops terminally on group_authorization_failed (no group access, no rejoin)" do
+      {:ok, client} = MockClient.start_link(%{heartbeat: {:error, :group_authorization_failed}})
+
+      state = %Heartbeat.State{
+        client: client,
+        group_name: "test-group",
+        member_id: "member-1",
+        generation_id: 1,
+        heartbeat_interval: 1000
+      }
+
+      assert {:stop, {:shutdown, {:terminal, :group_authorization_failed}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
+    end
+
     test "stops with error on other error codes" do
       {:ok, client} = MockClient.start_link(%{heartbeat: {:error, :coordinator_not_available}})
 

--- a/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
@@ -112,6 +112,70 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
     end
   end
 
+  describe "stale heartbeat-timer EXIT routing (#555)" do
+    # A {:shutdown, _} EXIT whose pid is NOT the current heartbeat_timer comes
+    # from a timer we already swapped out during a rebalance, so it is obsolete
+    # by construction. The Manager drops it ({:noreply, state}) instead of acting
+    # on a stale signal; only the current timer drives state transitions. For the
+    # one terminal case (:fenced_instance_id) the condition is persistent, so the
+    # live timer re-detects it and stops on its next cycle.
+
+    test "stale {:terminal, _} is dropped, not stopped or rejoined" do
+      {:ok, client} = MockClient.start_link(%{})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      current = dead_pid()
+      stale = dead_pid()
+      state = heartbeat_state(client, current)
+
+      assert {:noreply, ^state} =
+               Manager.handle_info({:EXIT, stale, {:shutdown, {:terminal, :fenced_instance_id}}}, state)
+
+      refute Enum.any?(MockClient.get_calls(client), &match?({:join_group, _, _}, &1))
+    end
+
+    test "stale {:rejoin, _} is dropped, no rejoin attempted" do
+      # join_group is scripted to fail non-recoverably: if the stale EXIT were
+      # (wrongly) routed to the rejoin path, join would run and we'd see a call.
+      {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      current = dead_pid()
+      stale = dead_pid()
+      state = heartbeat_state(client, current)
+
+      assert {:noreply, ^state} =
+               Manager.handle_info({:EXIT, stale, {:shutdown, {:rejoin, :illegal_generation}}}, state)
+
+      refute Enum.any?(MockClient.get_calls(client), &match?({:join_group, _, _}, &1))
+    end
+
+    test "stale {:shutdown, :rebalance} is dropped, no rejoin attempted" do
+      {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      current = dead_pid()
+      stale = dead_pid()
+      state = heartbeat_state(client, current)
+
+      assert {:noreply, ^state} =
+               Manager.handle_info({:EXIT, stale, {:shutdown, :rebalance}}, state)
+
+      refute Enum.any?(MockClient.get_calls(client), &match?({:join_group, _, _}, &1))
+    end
+
+    test "current {:terminal, _} still stops (contrast: only the live timer acts)" do
+      {:ok, client} = MockClient.start_link(%{})
+      on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+      current = dead_pid()
+      state = heartbeat_state(client, current)
+
+      assert {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, ^state} =
+               Manager.handle_info({:EXIT, current, {:shutdown, {:terminal, :fenced_instance_id}}}, state)
+    end
+  end
+
   describe "SyncGroup error routing" do
     # Drives a real Manager against a scripted MockClient (the :client injection
     # seam): JoinGroup succeeds (leader_id != member_id, so the member skips

--- a/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
@@ -201,5 +201,12 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
       assert_receive {:EXIT, ^manager, {:shutdown, {:terminal, :fenced_instance_id}}}, 30_000
       assert :counters.get(rejoins, 1) == 0
     end
+
+    test ":group_authorization_failed stops terminally without rejoining or raising" do
+      {manager, rejoins} = start_manager_with_sync_error(:group_authorization_failed)
+
+      assert_receive {:EXIT, ^manager, {:shutdown, {:terminal, :group_authorization_failed}}}, 30_000
+      assert :counters.get(rejoins, 1) == 0
+    end
   end
 end

--- a/test/kafka_ex/consumer/consumer_group/manager_recoverable_error_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_recoverable_error_test.exs
@@ -17,13 +17,27 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerRecoverableErrorTest do
   alias KafkaEx.Consumer.ConsumerGroup.Manager.State
   alias KafkaEx.Test.MockClient
 
-  defp heartbeat_exit(reason), do: {:EXIT, make_ref(), {:shutdown, {:error, reason}}}
+  defp heartbeat_exit(timer, reason), do: {:EXIT, timer, {:shutdown, {:error, reason}}}
+
+  # A pid that has already exited — the heartbeat-error EXIT clause only acts on
+  # the CURRENT heartbeat_timer, so the EXIT pid must equal state.heartbeat_timer.
+  # A dead pid keeps stop_heartbeat_timer/1 (during rebalance) a no-op.
+  defp dead_pid do
+    {pid, ref} = spawn_monitor(fn -> :ok end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    end
+
+    pid
+  end
 
   test "a fatal heartbeat error stops the manager" do
-    state = %State{group_name: "g", member_id: "m", generation_id: 1}
+    timer = dead_pid()
+    state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: timer}
 
     assert {:stop, {:shutdown, {:error, :topic_authorization_failed}}, ^state} =
-             Manager.handle_info(heartbeat_exit(:topic_authorization_failed), state)
+             Manager.handle_info(heartbeat_exit(timer, :topic_authorization_failed), state)
   end
 
   test "a :closed transport error is recoverable and drives a rejoin, not a stop" do
@@ -36,6 +50,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerRecoverableErrorTest do
     {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
     on_exit(fn -> stop_safely(sup) end)
 
+    timer = dead_pid()
+
     state = %State{
       client: client,
       supervisor_pid: sup,
@@ -46,14 +62,28 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerRecoverableErrorTest do
       session_timeout: 1000,
       session_timeout_padding: 0,
       rebalance_timeout: 1000,
-      heartbeat_timer: nil
+      heartbeat_timer: timer
     }
 
     assert_raise KafkaEx.JoinGroupError, fn ->
-      Manager.handle_info(heartbeat_exit(:closed), state)
+      Manager.handle_info(heartbeat_exit(timer, :closed), state)
     end
 
     # the recoverable path actually attempted a rejoin against the coordinator
     assert {:join_group, "g", "m"} in MockClient.get_calls(client)
+  end
+
+  test "a stale heartbeat error EXIT (non-current timer) is dropped, not acted on" do
+    # A heartbeat that was already replaced during a rebalance can deliver its
+    # error EXIT late. It must NOT drive a rebalance off the current state — it is
+    # dropped by the stale-timer clause. (No client/supervisor needed: a spurious
+    # rebalance here would crash on the nil supervisor_pid.)
+    current = dead_pid()
+    stale = dead_pid()
+
+    state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: current}
+
+    assert {:noreply, ^state} =
+             Manager.handle_info(heartbeat_exit(stale, :coordinator_not_available), state)
   end
 end

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -391,10 +391,11 @@ defmodule KafkaEx.Support.RetryTest do
       refute Retry.sync_group_retryable?(:rebalance_in_progress)
     end
 
-    test "identity/generation errors are NOT retryable (same SyncGroup can only fail the same way)" do
+    test "identity/generation/terminal errors are NOT retryable (same SyncGroup can only fail the same way)" do
       refute Retry.sync_group_retryable?(:illegal_generation)
       refute Retry.sync_group_retryable?(:unknown_member_id)
       refute Retry.sync_group_retryable?(:fenced_instance_id)
+      refute Retry.sync_group_retryable?(:group_authorization_failed)
     end
 
     test "other sync errors remain retryable (manager's sync recovery handles them)" do
@@ -411,8 +412,9 @@ defmodule KafkaEx.Support.RetryTest do
       refute Retry.heartbeat_retryable?(:illegal_generation)
     end
 
-    test "fenced_instance_id is NOT retryable (terminal: another member holds the static id)" do
+    test "terminal errors are NOT retryable (fenced static id / no group access)" do
       refute Retry.heartbeat_retryable?(:fenced_instance_id)
+      refute Retry.heartbeat_retryable?(:group_authorization_failed)
     end
 
     test "transient errors remain retryable (absorb a blip, avoid a spurious rejoin)" do

--- a/test/support/consumer_group_test_helpers.ex
+++ b/test/support/consumer_group_test_helpers.ex
@@ -101,6 +101,46 @@ defmodule KafkaEx.TestSupport.ConsumerGroupHelpers do
   end
 
   @doc """
+  Wait until the consumer group's `generation_id` changes from `gen_before`.
+
+  Polls with a short call-timeout because the Manager is unresponsive while
+  rebalancing (a `:exit` from that timeout is treated as "no change yet").
+
+  Returns `{:ok, new_generation}` or `{:error, :timeout}`.
+
+  ## Options
+    * `:timeout` - Maximum time to wait in milliseconds (default: #{@default_timeout})
+  """
+  @spec wait_for_generation_change(pid(), integer() | nil, keyword()) ::
+          {:ok, integer()} | {:error, :timeout}
+  def wait_for_generation_change(cg_pid, gen_before, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_for_generation_change(cg_pid, gen_before, deadline)
+  end
+
+  defp do_wait_for_generation_change(cg_pid, gen_before, deadline) do
+    current =
+      try do
+        ConsumerGroup.generation_id(cg_pid, 500)
+      catch
+        :exit, _ -> gen_before
+      end
+
+    cond do
+      is_integer(current) and current != gen_before ->
+        {:ok, current}
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :timeout}
+
+      true ->
+        Process.sleep(@poll_interval)
+        do_wait_for_generation_change(cg_pid, gen_before, deadline)
+    end
+  end
+
+  @doc """
   Start a consumer group with test-friendly defaults.
 
   Uses `TestGenConsumer` as the consumer module and configures reasonable


### PR DESCRIPTION
Three small follow-ups to #554 (consumer-group resilience), each an independent commit.

### 1. `:group_authorization_failed` → terminal on Heartbeat/SyncGroup
A group-authorization failure is non-retriable and cannot be fixed by rejoining (Java raises `GroupAuthorizationException` out of `poll()`; librdkafka marks it fatal). Previously it stopped the heartbeat path with `{:shutdown, {:error, _}}` and **raised** `SyncGroupError` on the sync path. Now it routes to the same clean `{:terminal, _}` stop as `:fenced_instance_id`, and is marked non-retryable in `sync_group_retryable?` / `heartbeat_retryable?` so the client retry budget isn't spent on a doomed request. This also makes auth failures visible on the terminal-stop path instead of looking like a transient `{:error}` stop.

### 2. Only act on the current heartbeat's error EXIT
The heartbeat-error EXIT handler matched **any** pid, so a heartbeat process already replaced during a rebalance could deliver its error EXIT late and trigger a spurious second rebalance. The clause now binds the current `heartbeat_timer` (matching how the `:rebalance` / `:rejoin` / `:terminal` EXITs are already guarded); stale error EXITs fall through to the stale-timer clause and are dropped. Adds a stale-drop regression test.

### 3. Share the generation-poll test helper
`wait_for_generation_change/3` (short call-timeout for the busy Manager, `:exit` caught) is promoted into `ConsumerGroupHelpers`; `fatal_rejoin_recovery_test` and `consumer_group_rejoin_test` now use it instead of two private copies.

## Checks
`mix format`, `mix credo --strict`, `mix dialyzer`, `mix compile --warnings-as-errors`, `mix test.unit` (2962/0), consumer-group integration (3/3) all green. Behavioral changes verified failing-first (5 reds on pre-fix code → 0).