### PR TITLE
fix: bound broker connect with a timeout instead of blocking indefinitely

### DIFF
--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -159,6 +159,15 @@ defmodule KafkaEx.Config do
   def use_ssl, do: Application.get_env(:kafka_ex, :use_ssl, false)
 
   @doc """
+  Timeout (ms) for establishing a broker TCP/SSL connection.
+
+  Bounds `:gen_tcp.connect` / `:ssl.connect`, which otherwise block for the full
+  OS TCP timeout (tens of seconds to minutes) against an unreachable broker.
+  """
+  @spec connect_timeout() :: timeout()
+  def connect_timeout, do: Application.get_env(:kafka_ex, :connect_timeout, 10_000)
+
+  @doc """
   Returns SSL options for connections.
 
   Validates that ssl_options is a keyword list when SSL is enabled.

--- a/lib/kafka_ex/network/network_client.ex
+++ b/lib/kafka_ex/network/network_client.ex
@@ -21,7 +21,9 @@ defmodule KafkaEx.Network.NetworkClient do
   end
 
   defp do_create_socket(host, port, ssl_options, use_ssl, auth_opts) do
-    case Socket.create(format_host(host), port, build_socket_options(ssl_options), use_ssl) do
+    connect_timeout = KafkaEx.Config.connect_timeout()
+
+    case Socket.create(format_host(host), port, build_socket_options(ssl_options), use_ssl, connect_timeout) do
       {:ok, socket} ->
         finish_socket_setup(socket, enrich_auth_opts(auth_opts, host, port), host, port)
 

--- a/lib/kafka_ex/network/socket.ex
+++ b/lib/kafka_ex/network/socket.ex
@@ -11,9 +11,15 @@ defmodule KafkaEx.Network.Socket do
   Creates a socket.
   For more information about the available options, see `:ssl.connect/3` for ssl or `:gen_tcp.connect/3` for non ssl.
   """
-  @spec create(:inet.ip_address(), non_neg_integer, [] | [...]) :: {:ok, KafkaEx.Network.Socket.t()} | {:error, any}
-  def create(host, port, socket_options \\ [], is_ssl \\ false) do
-    case create_socket(host, port, is_ssl, socket_options) do
+  # Bounds :gen_tcp.connect / :ssl.connect, which otherwise default to
+  # :infinity and block the calling process for the full OS TCP timeout
+  # (tens of seconds to minutes) against an unreachable/black-holed broker.
+  @default_connect_timeout 10_000
+
+  @spec create(:inet.ip_address(), non_neg_integer, [] | [...], boolean, timeout) ::
+          {:ok, KafkaEx.Network.Socket.t()} | {:error, any}
+  def create(host, port, socket_options \\ [], is_ssl \\ false, connect_timeout \\ @default_connect_timeout) do
+    case create_socket(host, port, is_ssl, socket_options, connect_timeout) do
       {:ok, socket} -> {:ok, %KafkaEx.Network.Socket{socket: socket, ssl: is_ssl}}
       {:error, reason} -> {:error, reason}
     end
@@ -105,6 +111,9 @@ defmodule KafkaEx.Network.Socket do
 
   defp extract_port(socket), do: socket.socket
 
-  defp create_socket(host, port, true, socket_options), do: :ssl.connect(host, port, socket_options)
-  defp create_socket(host, port, false, socket_options), do: :gen_tcp.connect(host, port, socket_options)
+  defp create_socket(host, port, true, socket_options, timeout),
+    do: :ssl.connect(host, port, socket_options, timeout)
+
+  defp create_socket(host, port, false, socket_options, timeout),
+    do: :gen_tcp.connect(host, port, socket_options, timeout)
 end

--- a/test/kafka_ex/network/socket_test.exs
+++ b/test/kafka_ex/network/socket_test.exs
@@ -102,4 +102,16 @@ defmodule KafkaEx.Network.Socket.Test do
       assert KafkaEx.Network.Socket.send(socket, ~c"ping") in [{:error, :closed}, {:error, :einval}]
     end
   end
+
+  describe "connect timeout" do
+    # 192.0.2.1 is RFC 5737 TEST-NET-1 — guaranteed unrouted, so the SYN is
+    # black-holed and connect can only return via the connect timeout. Without a
+    # timeout (the pre-fix :infinity default) this call blocks for the full OS
+    # TCP timeout and the test would hang until the ExUnit case timeout below.
+    @tag timeout: 5_000
+    test "create/5 bounds a connect to an unreachable host by connect_timeout" do
+      assert {:error, :timeout} =
+               KafkaEx.Network.Socket.create({192, 0, 2, 1}, 9092, [:binary, {:packet, 4}], false, 200)
+    end
+  end
 end


### PR DESCRIPTION
## Problem
`Socket.create` called `:gen_tcp.connect/3` and `:ssl.connect/3`, both of which default the connect timeout to `:infinity`. Against an unreachable or black-holed broker (firewall/security-group change, network partition, hard-down node), the connect blocks for the full OS TCP timeout — tens of seconds on macOS, up to ~127s on Linux. Because reconnect runs inside the client `GenServer`'s `handle_call`/`handle_info`, **every other caller** (produce/fetch/heartbeat/commit) stalls behind it; reconnect retries × multiple brokers multiply the stall into minutes. This is a notable gap for a resilience-focused release — the client freezes precisely when a broker goes away.

## Fix
Thread a connect timeout (the 4th arg to `connect`) through `Socket.create`, sourced from the new `KafkaEx.Config.connect_timeout/0` (default **10_000 ms**, overridable via `config :kafka_ex, :connect_timeout`). Matches brod, which always passes a connect timeout to `gen_tcp:connect/4`.

`Socket.create/5` adds the timeout as a defaulted 5th param, so existing 4-arg callers are unaffected.

## Test
`socket_test.exs` connects to `192.0.2.1` (RFC 5737 TEST-NET-1, guaranteed unrouted) with a 200 ms timeout and asserts `{:error, :timeout}` — reachable only if the timeout is applied. Verified failing-first: with the pre-fix timeout-less connect the test hangs to the 5 s case timeout; with the fix it returns in ~200 ms.

## Checks
`mix format`, `mix credo --strict`, `mix dialyzer`, `mix compile --warnings-as-errors`, `mix test.unit` (2960/0) all green.