### PR TITLE
fix: drop control batches and advance past them (consumer + stream)

### DIFF
--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -860,9 +860,21 @@ defmodule KafkaEx.Consumer.GenConsumer do
     end
   end
 
-  # Handle response from the new KafkaExAPI.fetch
+  # The broker returned batches but every record was filtered out (control
+  # batches — transaction commit/abort markers). Advance past them to next_offset, otherwise the
+  # next fetch lands on the same batch and the consumer spins forever without
+  # progressing. Mirrors brod/Java, which take the next position from batch
+  # metadata. next_offset comes from the raw batches, so it is strictly ahead of
+  # current_offset here.
+  defp handle_new_fetch_response(%{records: [], next_offset: next}, %State{current_offset: current} = state)
+       when is_integer(next) and is_integer(current) and next > current do
+    new_state = %State{state | acked_offset: next, current_offset: next}
+    handle_commit(:async_commit, new_state)
+  end
+
+  # No batches at all — caught up to the end of the partition. Do not advance;
+  # poll again from the same offset.
   defp handle_new_fetch_response(%{records: []} = _fetch_result, state) do
-    # No messages, just handle async commit
     handle_commit(:async_commit, state)
   end
 

--- a/lib/kafka_ex/consumer/stream.ex
+++ b/lib/kafka_ex/consumer/stream.ex
@@ -79,6 +79,18 @@ defmodule KafkaEx.Consumer.Stream do
       {:halt, offset}
     end
 
+    # control/aborted-only fetch: every record was filtered out (transaction
+    # markers) but batches were present, so advance past them via next_offset
+    # (from raw batch metadata) instead of re-fetching the same offset forever.
+    defp stream_control(
+           %{error_code: :no_error, message_set: [], next_offset: next},
+           %ConsumerStream{},
+           offset
+         )
+         when is_integer(next) and next > offset do
+      {[], next}
+    end
+
     # if we get an empty response, we block until messages are ready
     defp stream_control(
            %{error_code: :no_error, last_offset: last_offset, message_set: []},
@@ -201,7 +213,12 @@ defmodule KafkaEx.Consumer.Stream do
 
       case KafkaExAPI.fetch(data.client, data.topic, data.partition, offset, opts) do
         {:ok, fetch_result} ->
-          %{error_code: :no_error, last_offset: fetch_result.last_offset, message_set: fetch_result.records}
+          %{
+            error_code: :no_error,
+            last_offset: fetch_result.last_offset,
+            next_offset: Map.get(fetch_result, :next_offset),
+            message_set: fetch_result.records
+          }
 
         {:error, error} ->
           %{error_code: error}

--- a/lib/kafka_ex/messages/fetch.ex
+++ b/lib/kafka_ex/messages/fetch.ex
@@ -22,6 +22,7 @@ defmodule KafkaEx.Messages.Fetch do
     :records,
     :high_watermark,
     :last_offset,
+    :next_offset,
     :last_stable_offset,
     :log_start_offset,
     :preferred_read_replica,
@@ -40,6 +41,7 @@ defmodule KafkaEx.Messages.Fetch do
           records: [Record.t()],
           high_watermark: non_neg_integer(),
           last_offset: non_neg_integer() | nil,
+          next_offset: non_neg_integer() | nil,
           last_stable_offset: non_neg_integer() | nil,
           log_start_offset: non_neg_integer() | nil,
           preferred_read_replica: integer() | nil,
@@ -61,6 +63,7 @@ defmodule KafkaEx.Messages.Fetch do
       records: records,
       high_watermark: Keyword.fetch!(opts, :high_watermark),
       last_offset: last_offset,
+      next_offset: Keyword.get(opts, :next_offset),
       last_stable_offset: Keyword.get(opts, :last_stable_offset),
       log_start_offset: Keyword.get(opts, :log_start_offset),
       preferred_read_replica: Keyword.get(opts, :preferred_read_replica),
@@ -83,9 +86,16 @@ defmodule KafkaEx.Messages.Fetch do
   def record_count(%__MODULE__{records: records}), do: length(records)
 
   @doc """
-  Returns the next offset to fetch from (last_offset + 1 or high_watermark if empty).
+  Returns the offset to fetch from next.
+
+  Prefers `next_offset` — derived from the raw RecordBatch metadata, so it points
+  past control batches that were filtered out of `records` (otherwise a
+  fetch landing on a trailing control batch would never advance). Falls back to
+  `last_offset + 1` when only records are known, and finally to `high_watermark`
+  when the fetch was genuinely empty (caught up).
   """
   @spec next_offset(t()) :: non_neg_integer()
+  def next_offset(%__MODULE__{next_offset: next}) when is_integer(next), do: next
   def next_offset(%__MODULE__{last_offset: nil, high_watermark: hw}), do: hw
   def next_offset(%__MODULE__{last_offset: last}), do: last + 1
 

--- a/lib/kafka_ex/protocol/kayrock/fetch/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/fetch/response_helpers.ex
@@ -111,6 +111,44 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpers do
 
   defp control_batch?(_), do: false
 
+  # The offset to fetch from next, derived from the RAW record set (before
+  # control-batch filtering). nil means the broker returned no batches — i.e.
+  # the consumer is caught up and must NOT advance. When batches were present, it
+  # is the highest covered offset + 1, so a fetch that filters down to zero
+  # application records (all control) still advances past them. Mirrors brod's
+  # flatten_batches/3, which takes the next begin-offset from batch metadata.
+  defp raw_next_offset(nil), do: nil
+
+  defp raw_next_offset(%Kayrock.MessageSet{messages: []}), do: nil
+
+  defp raw_next_offset(%Kayrock.MessageSet{messages: messages}) do
+    (messages |> Enum.map(& &1.offset) |> Enum.max()) + 1
+  end
+
+  defp raw_next_offset([]), do: nil
+
+  defp raw_next_offset(record_batches) when is_list(record_batches) do
+    case Enum.flat_map(record_batches, &batch_last_offsets/1) do
+      [] -> nil
+      last_offsets -> Enum.max(last_offsets) + 1
+    end
+  end
+
+  defp raw_next_offset(_), do: nil
+
+  # Highest absolute offset covered by a RecordBatch. Prefer the batch metadata
+  # (base_offset + last_offset_delta) so control/empty batches still advance the
+  # fetch position even though their records are dropped; fall back to the
+  # records' own offsets when the metadata is absent.
+  defp batch_last_offsets(%{batch_offset: base, last_offset_delta: delta})
+       when is_integer(base) and is_integer(delta) and delta >= 0,
+       do: [base + delta]
+
+  defp batch_last_offsets(%{records: records}) when is_list(records),
+    do: Enum.map(records, & &1.offset)
+
+  defp batch_last_offsets(_), do: []
+
   @doc """
   Converts Kayrock RecordHeader structs to Header structs.
   """
@@ -223,7 +261,8 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpers do
           partition: partition,
           records: records,
           high_watermark: high_watermark,
-          last_offset: last_offset
+          last_offset: last_offset,
+          next_offset: raw_next_offset(record_set)
         ]
         |> Keyword.merge(field_extractor.(response, partition_resp))
 

--- a/lib/kafka_ex/protocol/kayrock/fetch/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/fetch/response_helpers.ex
@@ -7,12 +7,19 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpers do
   message formats.
   """
 
+  import Bitwise
+
   alias KafkaEx.Client.Error
   alias KafkaEx.Messages.Fetch
   alias KafkaEx.Messages.Fetch.Record
   alias KafkaEx.Messages.Header
 
   alias Kayrock.ErrorCode
+
+  # RecordBatch attributes bit 5 (0x20) marks a control batch (transaction
+  # commit/abort markers). Its records are not application data and must never
+  # be surfaced to callers — matching brod's is_control filter.
+  @control_batch_flag 0x20
 
   @doc """
   Extracts the first topic and partition response from a Fetch response.
@@ -77,7 +84,9 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpers do
   end
 
   def convert_records(record_batches, topic, partition) when is_list(record_batches) do
-    Enum.flat_map(record_batches, fn record_batch ->
+    record_batches
+    |> Enum.reject(&control_batch?/1)
+    |> Enum.flat_map(fn record_batch ->
       timestamp_type = extract_timestamp_type_from_batch(record_batch)
 
       Enum.map(record_batch.records, fn record ->
@@ -95,6 +104,12 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpers do
       end)
     end)
   end
+
+  defp control_batch?(%{attributes: attributes}) when is_integer(attributes) do
+    (attributes &&& @control_batch_flag) != 0
+  end
+
+  defp control_batch?(_), do: false
 
   @doc """
   Converts Kayrock RecordHeader structs to Header structs.

--- a/test/kafka_ex/consumer/gen_consumer_control_batch_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_control_batch_test.exs
@@ -1,0 +1,93 @@
+defmodule KafkaEx.Consumer.GenConsumerControlBatchTest do
+  @moduledoc """
+  Regression for the control/aborted-batch consume path.
+
+  When a fetch returns batches whose records are all filtered out (transaction
+  control markers / aborted records), `records` is empty but the consumer must
+  still advance past them — otherwise the next fetch lands on the same batch and
+  the consumer spins on one offset forever (cf. KafkaJS #403). The broker's raw
+  batch metadata drives the advance (`Fetch.next_offset`), exactly as brod and
+  the Java client do. A genuinely empty fetch (no batches → caught up) must NOT
+  advance.
+
+  Exercised through the real consume loop with a scripted `MockClient`.
+  """
+  use ExUnit.Case, async: false
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Consumer.GenConsumer
+  alias KafkaEx.Messages.Fetch
+  alias KafkaEx.Test.MockClient
+
+  defmodule TestConsumer do
+    use KafkaEx.Consumer.GenConsumer
+    def handle_message_set(_messages, state), do: {:async_commit, state}
+  end
+
+  defp fetch_offsets(calls) do
+    for {:fetch, _topic, _partition, offset, _opts} <- calls, do: offset
+  end
+
+  # Starts a consumer at offset 0 against a MockClient that returns `fetch_response`
+  # for every fetch, lets it run a few consume cycles, then returns the recorded calls.
+  defp run(fetch_response) do
+    {:ok, client} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: 0, error_code: :no_error}]}]},
+        fetch: fetch_response,
+        offset_commit: {:ok, []}
+      })
+
+    on_exit(fn -> stop_safely(client) end)
+
+    {:ok, pid} =
+      GenServer.start_link(GenConsumer, {TestConsumer, "g", "t", 0, [client: client]})
+
+    calls = MockClient.wait_for_calls(client, 4)
+    Process.unlink(pid)
+    stop_safely(pid)
+
+    calls
+  end
+
+  test "advances past a control-only fetch instead of re-fetching the same offset forever" do
+    # Records filtered to [], but the raw batches covered up to offset 5, so
+    # next_offset is 6. The consumer must move from 0 to 6.
+    fetch =
+      {:ok,
+       %Fetch{
+         topic: "t",
+         partition: 0,
+         records: [],
+         last_offset: nil,
+         next_offset: 6,
+         high_watermark: 100
+       }}
+
+    offsets = fetch_offsets(run(fetch))
+
+    assert 0 in offsets, "expected the initial fetch at offset 0"
+    assert 6 in offsets, "consumer must advance past the control batch to 6, not spin on 0"
+  end
+
+  test "does NOT advance when the broker returned no batches (caught up)" do
+    # No batches at all -> next_offset nil. The consumer must keep polling the
+    # same offset, never skip ahead (which would lose messages).
+    fetch =
+      {:ok,
+       %Fetch{
+         topic: "t",
+         partition: 0,
+         records: [],
+         last_offset: nil,
+         next_offset: nil,
+         high_watermark: 0
+       }}
+
+    offsets = fetch_offsets(run(fetch))
+
+    assert offsets != []
+    assert Enum.all?(offsets, &(&1 == 0)), "caught-up consumer must not advance off offset 0, got #{inspect(offsets)}"
+  end
+end

--- a/test/kafka_ex/consumer/stream_test.exs
+++ b/test/kafka_ex/consumer/stream_test.exs
@@ -281,4 +281,65 @@ defmodule KafkaEx.Consumer.StreamTest do
       assert log =~ ":illegal_generation"
     end
   end
+
+  # MockClient that records the offset of every fetch so we can assert the
+  # stream advanced past a control-only batch instead of re-fetching it.
+  defmodule OffsetRecordingMockClient do
+    @moduledoc false
+    use GenServer
+
+    def start_link(responses) when is_list(responses) do
+      GenServer.start_link(__MODULE__, %{responses: responses, offsets: []})
+    end
+
+    def fetch_offsets(pid), do: pid |> GenServer.call(:get_offsets) |> Enum.reverse()
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call({:fetch, _topic, _partition, offset, _opts}, _from, state) do
+      state = %{state | offsets: [offset | state.offsets]}
+
+      case state.responses do
+        [response | rest] -> {:reply, response, %{state | responses: rest}}
+        [] -> {:reply, {:ok, %{last_offset: nil, next_offset: nil, records: []}}, state}
+      end
+    end
+
+    def handle_call(:get_offsets, _from, state) do
+      {:reply, state.offsets, state}
+    end
+  end
+
+  describe "stream control-batch handling" do
+    alias KafkaEx.Consumer.Stream, as: ConsumerStream
+
+    test "advances past a control-only fetch instead of re-fetching the same offset" do
+      # First fetch: all records filtered out (control batch) but next_offset (raw
+      # batch metadata) points to 6. Second fetch: caught up (no batches) so the
+      # stream halts under no_wait_at_logend: true.
+      control_only = {:ok, %{last_offset: nil, next_offset: 6, records: []}}
+      caught_up = {:ok, %{last_offset: nil, next_offset: nil, records: []}}
+
+      {:ok, mock} = OffsetRecordingMockClient.start_link([control_only, caught_up])
+
+      stream = %ConsumerStream{
+        client: mock,
+        topic: "t",
+        partition: 0,
+        offset: 0,
+        no_wait_at_logend: true,
+        fetch_options: [],
+        api_versions: %{}
+      }
+
+      assert Enum.to_list(stream) == []
+
+      offsets = OffsetRecordingMockClient.fetch_offsets(mock)
+      # Pre-fix: stream halts/spins at offset 0 and never fetches 6.
+      assert 0 in offsets
+      assert 6 in offsets
+    end
+  end
 end

--- a/test/kafka_ex/messages/fetch_test.exs
+++ b/test/kafka_ex/messages/fetch_test.exs
@@ -137,7 +137,7 @@ defmodule KafkaEx.Messages.FetchTest do
       assert Fetch.next_offset(fetch) == 6
     end
 
-    test "returns high_watermark when no records" do
+    test "returns high_watermark when no records and no next_offset (caught up)" do
       fetch =
         Fetch.build(
           topic: "test_topic",
@@ -147,6 +147,22 @@ defmodule KafkaEx.Messages.FetchTest do
         )
 
       assert Fetch.next_offset(fetch) == 10
+    end
+
+    test "prefers next_offset so control/aborted-only batches advance instead of skipping to high_watermark" do
+      # The fetch landed on a batch covering offset 41 whose records were all
+      # filtered out (control batch). next_offset (from raw batch metadata) is 42;
+      # returning high_watermark (100) here would silently skip offsets 42..99.
+      fetch =
+        Fetch.build(
+          topic: "test_topic",
+          partition: 0,
+          records: [],
+          high_watermark: 100,
+          next_offset: 42
+        )
+
+      assert Fetch.next_offset(fetch) == 42
     end
   end
 

--- a/test/kafka_ex/protocol/kayrock/fetch/response_helpers_test.exs
+++ b/test/kafka_ex/protocol/kayrock/fetch/response_helpers_test.exs
@@ -408,6 +408,63 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpersTest do
       assert fetch.throttle_time_ms == 5
       assert length(fetch.records) == 1
       assert fetch.last_offset == 0
+      assert fetch.next_offset == 1
+    end
+
+    test "control-only record_set yields no records but advances next_offset past the batch" do
+      response = %{
+        responses: [
+          %{
+            topic: "test_topic",
+            partition_responses: [
+              %{
+                partition_header: %{partition: 0, error_code: 0, high_watermark: 100},
+                record_set: [
+                  %Kayrock.RecordBatch{
+                    attributes: 0x20,
+                    batch_offset: 41,
+                    last_offset_delta: 0,
+                    records: [
+                      %Kayrock.RecordBatch.Record{
+                        offset: 41,
+                        key: <<0, 0, 0, 0>>,
+                        value: <<0, 0>>,
+                        timestamp: 1,
+                        attributes: 0,
+                        headers: nil
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      field_extractor = fn _resp, _part_resp -> [] end
+
+      assert {:ok, fetch} = ResponseHelpers.parse_response(response, field_extractor)
+      assert fetch.records == []
+      # batch_offset 41 + last_offset_delta 0 + 1 — advances past the control batch
+      assert fetch.next_offset == 42
+    end
+
+    test "nil record_set leaves next_offset nil (caught up, do not advance)" do
+      response = %{
+        responses: [
+          %{
+            topic: "test_topic",
+            partition_responses: [
+              %{partition_header: %{partition: 0, error_code: 0, high_watermark: 100}, record_set: nil}
+            ]
+          }
+        ]
+      }
+
+      assert {:ok, fetch} = ResponseHelpers.parse_response(response, fn _r, _p -> [] end)
+      assert fetch.records == []
+      assert fetch.next_offset == nil
     end
 
     test "returns error for empty response" do

--- a/test/kafka_ex/protocol/kayrock/fetch/response_helpers_test.exs
+++ b/test/kafka_ex/protocol/kayrock/fetch/response_helpers_test.exs
@@ -143,6 +143,59 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.ResponseHelpersTest do
       assert rec2.timestamp_type == :log_append_time
     end
 
+    test "drops control batches (transaction markers) so they are not surfaced as messages" do
+      record_batches = [
+        # control batch (attributes bit 5 / 0x20 set) — a transaction commit/abort
+        # marker; its synthetic record must never reach the caller
+        %Kayrock.RecordBatch{
+          attributes: 0x20,
+          records: [
+            %Kayrock.RecordBatch.Record{
+              offset: 5,
+              key: <<0, 0, 0, 0>>,
+              value: <<0, 0>>,
+              timestamp: 2000,
+              attributes: 0,
+              headers: nil
+            }
+          ]
+        },
+        # normal application batch
+        %Kayrock.RecordBatch{
+          attributes: 0,
+          records: [
+            %Kayrock.RecordBatch.Record{
+              offset: 6,
+              key: "key",
+              value: "value",
+              timestamp: 2001,
+              attributes: 0,
+              headers: nil
+            }
+          ]
+        }
+      ]
+
+      records = ResponseHelpers.convert_records(record_batches, "test_topic", 0)
+
+      assert [%{offset: 6, value: "value"}] = records
+      refute Enum.any?(records, &(&1.offset == 5))
+    end
+
+    test "drops a transactional control batch (transactional + control bits set)" do
+      record_batches = [
+        %Kayrock.RecordBatch{
+          # 0x10 transactional | 0x20 control
+          attributes: 0x30,
+          records: [
+            %Kayrock.RecordBatch.Record{offset: 9, key: <<>>, value: <<>>, timestamp: 1, attributes: 0, headers: nil}
+          ]
+        }
+      ]
+
+      assert [] = ResponseHelpers.convert_records(record_batches, "t", 0)
+    end
+
     test "extracts timestamp_type from MessageSet attributes" do
       # Bit 3 = 0 means CreateTime
       message_set_create = %Kayrock.MessageSet{


### PR DESCRIPTION
## Problem
Kafka writes a **control batch** (RecordBatch `attributes` bit 5 / `0x20`) for every committed/aborted transaction. The broker delivers these to consumers at **any** isolation level and clients must filter them out (Java `CompletedFetch.isControlBatch`, kafka-python `is_control_batch`, KafkaJS `isControlRecord`, brod `is_control`). KafkaEx's `convert_records` surfaced the synthetic marker records to `handle_message_set` as if they were application messages — corrupting the stream (and crashing value-decoding consumers) on any transactional topic.

## Fix (two parts)
1. **Filter control batches** in `convert_records` (`attributes &&& 0x20`), matching all reference clients.
2. **Advance past them.** Filtering alone is only half the job: a fetch that lands on a *trailing* control batch filters to `records: []`, and the consumer left its offset unchanged → it re-fetched the same batch forever (the KafkaJS [#403](https://github.com/tulios/kafkajs/issues/403) failure mode). So we carry a `next_offset` on the `Fetch` struct, derived from **raw RecordBatch metadata** (`base_offset + last_offset_delta + 1`) before filtering — `nil` when the broker returned no batches. Both consumer entry points distinguish the two empty cases:
   - **batches present but all filtered** → advance to `next_offset` (skip past the control batch);
   - **no batches (caught up)** → hold the offset and keep polling.

   This mirrors brod's `flatten_batches/3` and the Java client's `nextFetchOffset` (next position from batch metadata, never the high-watermark). Applied to **both** `GenConsumer` and the `Stream` consumer (both had the regression). `Fetch.next_offset/1` now prefers `next_offset` over `high_watermark`, fixing a latent message-skip for manual fetch-loop callers.

## Scope note
Only **control** batches are filtered. Aborted-transaction *data* records are not dropped — that is a separate READ_COMMITTED concern and is correct as-is for KafkaEx's default READ_UNCOMMITTED isolation. (Deferred follow-up.)

## Tests
Failing-first regression tests for: control-batch filtering (`response_helpers_test`), `next_offset` from raw metadata incl. control-only (`response_helpers_test`, `fetch_test`), GenConsumer advance vs caught-up-hold (`gen_consumer_control_batch_test`), and Stream advance past control-only (`stream_test`). Verified failing on pre-fix code for both consumer paths.

## Review
Put through a four-persona panel (Elixir/OTP, Kafka protocol, brod maintainer, Java client) + general correctness review + `/review`. Core mechanism confirmed faithful to brod/Java; the Stream regression and a comment over-claim were caught and fixed.

## Checks
`mix format`, `mix credo --strict`, `mix dialyzer`, `mix compile --warnings-as-errors`, `mix test.unit` (2967/0) all green.