### PR TITLE
fix: rejoin (not crash) on abnormal heartbeat EXIT; jitter + member-terminated telemetry + join unknown_member_id reset

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -70,6 +70,12 @@ config :kafka_ex,
   # base * 2^attempt, capped at 5s per delay; after 6 attempts the consumer crashes
   # (supervisor restart) rather than silently resetting the offset. Default: 500.
   # load_offsets_retry_backoff_ms: 500,
+  # Upper bound (ms) on the randomized jitter slept before a consumer-group
+  # member rejoins after its heartbeat process dies abnormally (an OS/OOM kill,
+  # an uncaught crash, or a client-call timeout). Desynchronizes a fleet hitting
+  # a correlated heartbeat-kill so members don't stampede the coordinator with
+  # simultaneous JoinGroups. Set to 0 to disable. Default: 1000.
+  # crash_rejoin_max_jitter_ms: 1000,
   # API versions for Kafka protocol requests.
   # By default, KafkaEx uses the highest version supported by both the
   # connected broker and the protocol library. Use this config to pin

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -78,26 +78,44 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
           heartbeat_interval: heartbeat_interval
         } = state
       ) do
-    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id) do
-      {:ok, %KafkaEx.Messages.Heartbeat{}} ->
-        {:noreply, state, heartbeat_interval}
+    try do
+      case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id) do
+        {:ok, %KafkaEx.Messages.Heartbeat{}} ->
+          {:noreply, state, heartbeat_interval}
 
-      {:error, :rebalance_in_progress} ->
-        {:stop, {:shutdown, :rebalance}, state}
+        {:error, :rebalance_in_progress} ->
+          {:stop, {:shutdown, :rebalance}, state}
 
-      {:error, :illegal_generation} ->
-        {:stop, {:shutdown, {:rejoin, :illegal_generation}}, state}
+        {:error, :illegal_generation} ->
+          {:stop, {:shutdown, {:rejoin, :illegal_generation}}, state}
 
-      {:error, :unknown_member_id} ->
-        {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
+        {:error, :unknown_member_id} ->
+          {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
 
-      {:error, reason} when reason in [:fenced_instance_id, :group_authorization_failed] ->
-        Logger.error("Heartbeat hit terminal error #{inspect(reason)}; stopping without rejoin")
-        {:stop, {:shutdown, {:terminal, reason}}, state}
+        {:error, reason} when reason in [:fenced_instance_id, :group_authorization_failed] ->
+          Logger.error("Heartbeat hit terminal error #{inspect(reason)}; stopping without rejoin")
+          {:stop, {:shutdown, {:terminal, reason}}, state}
 
-      {:error, reason} ->
-        Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")
-        {:stop, {:shutdown, {:error, reason}}, state}
+        {:error, reason} ->
+          Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")
+          {:stop, {:shutdown, {:error, reason}}, state}
+      end
+    rescue
+      exception ->
+        Logger.error("Heartbeat crashed: " <> Exception.format(:error, exception, __STACKTRACE__))
+        {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, state}
+    catch
+      :throw, value ->
+        Logger.error("Heartbeat threw a value: #{inspect(value)}")
+        {:stop, {:shutdown, {:terminal, {:crashed, :throw}}}, state}
+
+      :exit, reason ->
+        Logger.warning("Heartbeat client call exited (#{inspect(reason)}); treating as recoverable")
+        {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
     end
   end
+
+  defp normalize_exit_reason({reason, _call_context}) when is_atom(reason), do: reason
+  defp normalize_exit_reason(reason) when is_atom(reason), do: reason
+  defp normalize_exit_reason(reason), do: reason
 end

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -1,32 +1,34 @@
 defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
   @moduledoc """
-   GenServer to send heartbeats to the broker
+  Sends periodic `HeartbeatRequest`s for a joined consumer-group member.
 
-   A `HeartbeatRequest` is sent periodically by each active group member (after
-   completing the join/sync phase) to inform the broker that the member is
-   still alive and participating in the group. If a group member fails to send
-   a heartbeat before the group's session timeout expires, the coordinator
-   removes that member from the group and initiates a rebalance.
+  The Manager starts this process **linked** and trapping exits. Every failure
+  this process can catch is turned into a structured `{:shutdown, reason}` exit
+  that the Manager maps to a rejoin or a terminal stop. The one failure it
+  cannot catch — `:kill` (untrappable; no callback runs) — reaches the Manager
+  as a plain `:killed` EXIT.
 
-   `HeartbeatResponse` allows the coordinating broker to communicate the
-   group's status to each member:
+  ## Lifecycle
 
-     * `:no_error` indicates that the group is up to date and no action is
-     needed.
-     * `:rebalance_in_progress` a rebalance has been initiated, so each member
-     should re-join.
-     * `:unknown_member_id` means the coordinator has forgotten this member; it
-     must re-join with a fresh (reset) member_id.
-     * `:illegal_generation` means this member's generation is stale; it must
-     re-join (keeping its member_id) to pick up the new generation.
-     * `:fenced_instance_id` (another member claimed this member's static
-     `group.instance.id`) and `:group_authorization_failed` (no access to the
-     group) are terminal; the member stops rather than re-joining.
+      Manager ──start_link (linked)──▶ Heartbeat
+                                          │  loop: every heartbeat_interval
+                                          ▼
+                            send HeartbeatRequest to the broker
+                                          │
+                       :no_error ◀────────┴────────▶ error / crash
+                          │                              │
+                    keep ticking                exit {:shutdown, reason}
 
-   For the recoverable conditions the heartbeat process exits with a
-   `{:shutdown, _}` reason that the KafkaEx.Consumer.ConsumerGroup.Manager
-   traps and turns into a re-join (resetting identity per the reason) or a
-   clean terminal stop. (see KafkaEx.Consumer.ConsumerGroup.Manager)
+      exit reason                                  ─▶ Manager action
+      ────────────────────────────────────────────────────────────────
+      :rebalance                                   ─▶ rejoin
+      {:rejoin, :illegal_generation}               ─▶ rejoin, keep member_id
+      {:rejoin, :unknown_member_id}                ─▶ rejoin, reset member_id
+      {:error, recoverable}  (e.g. :timeout)       ─▶ rejoin
+      {:error, non-recoverable} | {:terminal, _}   ─▶ terminal stop
+      :killed  (uncatchable)                       ─▶ rejoin
+
+  See `KafkaEx.Consumer.ConsumerGroup.Manager` for the EXIT-clause handling.
   """
 
   use GenServer
@@ -104,12 +106,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       Logger.error("Heartbeat crashed: " <> Exception.format(:error, exception, __STACKTRACE__))
       {:stop, {:shutdown, {:terminal, {:crashed, exception.__struct__}}}, state}
   catch
-    :throw, value ->
-      Logger.error("Heartbeat threw a value: #{inspect(value)}")
-      {:stop, {:shutdown, {:terminal, {:crashed, :throw}}}, state}
-
     :exit, reason ->
-      Logger.warning("Heartbeat client call exited (#{inspect(reason)}); stopping with a structured error")
+      Logger.warning("Heartbeat client call exited (#{inspect(reason)})")
       {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -78,41 +78,39 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
           heartbeat_interval: heartbeat_interval
         } = state
       ) do
-    try do
-      case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id) do
-        {:ok, %KafkaEx.Messages.Heartbeat{}} ->
-          {:noreply, state, heartbeat_interval}
+    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id) do
+      {:ok, %KafkaEx.Messages.Heartbeat{}} ->
+        {:noreply, state, heartbeat_interval}
 
-        {:error, :rebalance_in_progress} ->
-          {:stop, {:shutdown, :rebalance}, state}
+      {:error, :rebalance_in_progress} ->
+        {:stop, {:shutdown, :rebalance}, state}
 
-        {:error, :illegal_generation} ->
-          {:stop, {:shutdown, {:rejoin, :illegal_generation}}, state}
+      {:error, :illegal_generation} ->
+        {:stop, {:shutdown, {:rejoin, :illegal_generation}}, state}
 
-        {:error, :unknown_member_id} ->
-          {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
+      {:error, :unknown_member_id} ->
+        {:stop, {:shutdown, {:rejoin, :unknown_member_id}}, state}
 
-        {:error, reason} when reason in [:fenced_instance_id, :group_authorization_failed] ->
-          Logger.error("Heartbeat hit terminal error #{inspect(reason)}; stopping without rejoin")
-          {:stop, {:shutdown, {:terminal, reason}}, state}
+      {:error, reason} when reason in [:fenced_instance_id, :group_authorization_failed] ->
+        Logger.error("Heartbeat hit terminal error #{inspect(reason)}; stopping without rejoin")
+        {:stop, {:shutdown, {:terminal, reason}}, state}
 
-        {:error, reason} ->
-          Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")
-          {:stop, {:shutdown, {:error, reason}}, state}
-      end
-    rescue
-      exception ->
-        Logger.error("Heartbeat crashed: " <> Exception.format(:error, exception, __STACKTRACE__))
-        {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, state}
-    catch
-      :throw, value ->
-        Logger.error("Heartbeat threw a value: #{inspect(value)}")
-        {:stop, {:shutdown, {:terminal, {:crashed, :throw}}}, state}
-
-      :exit, reason ->
-        Logger.warning("Heartbeat client call exited (#{inspect(reason)}); treating as recoverable")
-        {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
+      {:error, reason} ->
+        Logger.warning("Heartbeat failed, got error reason #{inspect(reason)}")
+        {:stop, {:shutdown, {:error, reason}}, state}
     end
+  rescue
+    exception ->
+      Logger.error("Heartbeat crashed: " <> Exception.format(:error, exception, __STACKTRACE__))
+      {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, state}
+  catch
+    :throw, value ->
+      Logger.error("Heartbeat threw a value: #{inspect(value)}")
+      {:stop, {:shutdown, {:terminal, {:crashed, :throw}}}, state}
+
+    :exit, reason ->
+      Logger.warning("Heartbeat client call exited (#{inspect(reason)}); treating as recoverable")
+      {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 
   defp normalize_exit_reason({reason, _call_context}) when is_atom(reason), do: reason

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -102,7 +102,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
   rescue
     exception ->
       Logger.error("Heartbeat crashed: " <> Exception.format(:error, exception, __STACKTRACE__))
-      {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, state}
+      {:stop, {:shutdown, {:terminal, {:crashed, exception.__struct__}}}, state}
   catch
     :throw, value ->
       Logger.error("Heartbeat threw a value: #{inspect(value)}")
@@ -113,6 +113,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 
-  defp normalize_exit_reason({reason, _call_context}) when is_atom(reason), do: reason
+  defp normalize_exit_reason({reason, {GenServer, :call, _}}) when is_atom(reason), do: reason
   defp normalize_exit_reason(reason), do: reason
 end

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -109,11 +109,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:stop, {:shutdown, {:terminal, {:crashed, :throw}}}, state}
 
     :exit, reason ->
-      Logger.warning("Heartbeat client call exited (#{inspect(reason)}); treating as recoverable")
+      Logger.warning("Heartbeat client call exited (#{inspect(reason)}); stopping with a structured error")
       {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 
   defp normalize_exit_reason({reason, _call_context}) when is_atom(reason), do: reason
-  defp normalize_exit_reason(reason) when is_atom(reason), do: reason
   defp normalize_exit_reason(reason), do: reason
 end

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -418,9 +418,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   # Normal exits from OTHER linked children (typically an old heartbeat timer
   # we just replaced via stop_heartbeat_timer/start_heartbeat_timer during a
-  # rebalance). Non-normal EXITs still crash the Manager loudly — this only
-  # swallows intentional-clean-shutdown signals from non-Client pids. Logged
-  # at debug so unusual quiescence patterns stay observable.
+  # rebalance). Abnormal EXITs are handled by the two clauses below — the
+  # current heartbeat's via the rejoin clause, any other pid's via the drop
+  # catch-all — so this clause only swallows intentional-clean-shutdown signals
+  # from non-Client pids. Logged at debug so unusual quiescence stays observable.
   def handle_info({:EXIT, pid, :normal}, %State{} = state) do
     Logger.debug("Manager trapping normal :EXIT from linked pid #{inspect(pid)}")
     {:noreply, state}

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -430,10 +430,13 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # matched. heartbeat.ex normalizes everything it can catch into {:shutdown, _},
   # so this is the residual — an external :kill (OOM, Process.exit/2) or a crash
   # before heartbeat.ex's try-wrapper installs. Treat a lost heartbeat as a
-  # recoverable rejoin (the sync step bounds retries), keeping member_id: an
-  # abnormal crash carries no protocol reason to reset identity. This must never
-  # fall through — an unhandled {:EXIT, _, _} would FunctionClauseError and tear
-  # down the one_for_all / max_restarts: 0 supervisor with no restart.
+  # rejoin, keeping member_id: an abnormal crash carries no protocol reason to
+  # reset identity. A heartbeat that keeps re-crashing while join/sync succeed
+  # re-loops paced by heartbeat_interval (sync_failures resets on each success,
+  # so the sync bound does not apply here) — accepted; a rejoin backoff is a
+  # deferred follow-up. This must never fall through — an unhandled
+  # {:EXIT, _, _} would FunctionClauseError and tear down the one_for_all /
+  # max_restarts: 0 supervisor with no restart.
   def handle_info({:EXIT, timer, reason}, %State{heartbeat_timer: timer} = state) do
     Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
     {:ok, state} = rebalance(state, {:heartbeat_crash, reason})
@@ -443,8 +446,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # Any other linked process exiting abnormally. The client is handled above; the
   # only remaining source is a stale heartbeat we already replaced during a
   # rebalance, whose late EXIT is obsolete by construction. Drop it — do not act
-  # on a stale signal, and never crash the Manager on an unmatched EXIT.
-  def handle_info({:EXIT, _pid, _reason}, %State{} = state) do
+  # on a stale signal, and never crash the Manager on an unmatched EXIT. Logged
+  # at debug so an unexpected linked-process death still leaves a trace.
+  def handle_info({:EXIT, pid, reason}, %State{} = state) do
+    Logger.debug("Manager dropping abnormal :EXIT from non-current linked pid #{inspect(pid)}: #{inspect(reason)}")
     {:noreply, state}
   end
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -120,11 +120,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # bounds join — a persistent failure escalates to the supervisor rebuild.
   @max_sync_retries 3
 
-  # Upper bound (ms) on the randomized jitter slept before a rejoin triggered by
-  # an ABNORMAL heartbeat crash (see the {:heartbeat_crash, _} EXIT clause).
-  # Desynchronizes a fleet hitting a correlated heartbeat-kill (e.g. OOM, bad
-  # deploy) so they don't stampede the coordinator with simultaneous JoinGroups.
-  # Overridable per group via the `:crash_rejoin_max_jitter_ms` opt (0 disables).
+  # Max jitter (ms) before an abnormal-crash rejoin, to desync a fleet hitting a
+  # correlated heartbeat-kill. Per-group via `:crash_rejoin_max_jitter_ms`; 0 off.
   @crash_rejoin_max_jitter_ms 1_000
 
   # Gets a value from opts, falling back to application config, then to default
@@ -387,9 +384,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
-  # The heartbeat hit a terminal error (:fenced_instance_id — another member
-  # holds this static group.instance.id). Rejoining would split-brain or be
-  # fenced again, so stop cleanly and let the supervisor tear the member down.
+  # Terminal heartbeat error (fenced instance id, group-auth, or a code-defect
+  # crash): rejoining would be futile, so stop cleanly (emits member_terminated).
   def handle_info({:EXIT, timer, {:shutdown, {:terminal, reason}}}, %State{heartbeat_timer: timer} = state) do
     Logger.error("Heartbeat hit terminal error #{inspect(reason)}, stopping consumer group member")
     stop_terminal(state, reason)
@@ -428,30 +424,16 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
-  # Normal exits from OTHER linked children (typically an old heartbeat timer
-  # we just replaced via stop_heartbeat_timer/start_heartbeat_timer during a
-  # rebalance). Abnormal EXITs are handled by the two clauses below — the
-  # current heartbeat's via the rejoin clause, any other pid's via the drop
-  # catch-all — so this clause only swallows intentional-clean-shutdown signals
-  # from non-Client pids. Logged at debug so unusual quiescence stays observable.
+  # Clean exit from a non-current linked child (usually a replaced heartbeat
+  # timer); abnormal EXITs fall to the two clauses below.
   def handle_info({:EXIT, pid, :normal}, %State{} = state) do
     Logger.debug("Manager trapping normal :EXIT from linked pid #{inspect(pid)}")
     {:noreply, state}
   end
 
-  # An abnormal EXIT from the CURRENT heartbeat: a reason no structured clause
-  # matched. heartbeat.ex normalizes everything it can catch into {:shutdown, _},
-  # so this is the residual — an external :kill (OOM, Process.exit/2) or a crash
-  # before heartbeat.ex's try-wrapper installs. Treat a lost heartbeat as a
-  # rejoin, keeping member_id: an abnormal crash carries no protocol reason to
-  # reset identity. A randomized jitter precedes the rejoin so a fleet hitting a
-  # correlated heartbeat-kill doesn't stampede the coordinator in lockstep. A
-  # heartbeat that keeps re-crashing while join/sync succeed still re-loops paced
-  # by heartbeat_interval (sync_failures resets on each success, so the sync
-  # bound does not apply here) — accepted; a hard rejoin bound is a deferred
-  # follow-up. This must never fall through — an unhandled {:EXIT, _, _} would
-  # FunctionClauseError and tear down the one_for_all / max_restarts: 0
-  # supervisor with no restart.
+  # Current heartbeat died abnormally — the residual heartbeat.ex can't catch
+  # (`:kill`). Rejoin keeping member_id (no protocol reason to reset it),
+  # jittered to desync correlated kills.
   def handle_info({:EXIT, timer, reason}, %State{heartbeat_timer: timer} = state) do
     Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
     maybe_crash_rejoin_jitter(state)
@@ -459,11 +441,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
-  # Any other linked process exiting abnormally. The client is handled above; the
-  # only remaining source is a stale heartbeat we already replaced during a
-  # rebalance, whose late EXIT is obsolete by construction. Drop it — do not act
-  # on a stale signal, and never crash the Manager on an unmatched EXIT. Logged
-  # at debug so an unexpected linked-process death still leaves a trace.
+  # Catch-all so no {:EXIT, _, _} ever FunctionClauseErrors the Manager (which
+  # max_restarts: 0 would turn into a no-restart teardown). The only live source
+  # is a stale heartbeat we already replaced — drop it.
   def handle_info({:EXIT, pid, reason}, %State{} = state) do
     Logger.debug("Manager dropping abnormal :EXIT from non-current linked pid #{inspect(pid)}: #{inspect(reason)}")
     {:noreply, state}
@@ -544,13 +524,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     end
   end
 
-  # Handle join errors. :unknown_member_id means the broker no longer knows this
-  # member (e.g. our session expired during an outage that also took the
-  # heartbeat down) — reset the member_id and rejoin fresh rather than crashing,
-  # per brod should_reset_member_id / Java resetStateAndGeneration. Other
-  # recoverable errors retry as-is; anything else gets the correct loud error.
-  # Recoverability is checked before the retry count so unrecoverable errors
-  # always surface their own message.
+  # :unknown_member_id — the broker forgot us; reset member_id and rejoin fresh
+  # (brod should_reset_member_id / Java resetStateAndGeneration) rather than
+  # crash. Other recoverable errors retry; the rest raise.
   defp handle_join_error(state, group_name, reason, attempt_number) do
     cond do
       reason == :unknown_member_id ->

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -460,12 +460,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # When terminating, inform the group coordinator that this member is leaving
   # the group so that the group can rebalance without waiting for a session
   # timeout.
-  def terminate(_reason, %State{generation_id: nil, member_id: nil} = state) do
+  def terminate(reason, %State{generation_id: nil, member_id: nil} = state) do
+    emit_termination_telemetry(reason, state)
     Process.unlink(state.client)
     GenServer.stop(state.client, :normal)
   end
 
-  def terminate(_reason, %State{} = state) do
+  def terminate(reason, %State{} = state) do
+    emit_termination_telemetry(reason, state)
     {:ok, _state} = leave(state)
     Process.unlink(state.client)
     GenServer.stop(state.client, :normal)
@@ -474,6 +476,26 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     # if race condition happens, client will be abandoned
     stop_heartbeat_timer(state)
   end
+
+  # Single choke point for member_terminated: every permanent, non-graceful
+  # death (terminal error, unrecoverable heartbeat error, client death, or a
+  # crash/give-up raise) flows through terminate/2; graceful :normal/:shutdown
+  # classify to nil and stay silent.
+  defp emit_termination_telemetry(reason, %State{} = state) do
+    case termination_reason(reason) do
+      nil -> :ok
+      classified -> Telemetry.emit_member_terminated(state.group_name, state.member_id || "", classified)
+    end
+  end
+
+  defp termination_reason({:shutdown, {:terminal, reason}}), do: reason
+  defp termination_reason({:shutdown, {:error, reason}}), do: {:error, reason}
+  defp termination_reason({:shutdown, {:client_died, reason}}), do: {:client_died, reason}
+  defp termination_reason({exception, stacktrace}) when is_list(stacktrace), do: {:crashed, crash_module(exception)}
+  defp termination_reason(_), do: nil
+
+  defp crash_module(%{__struct__: module}), do: module
+  defp crash_module(_), do: :unknown
 
   ### Helpers
 
@@ -733,7 +755,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   end
 
   defp stop_terminal(%State{} = state, reason) do
-    Telemetry.emit_member_terminated(state.group_name, state.member_id || "", reason)
     {:stop, {:shutdown, {:terminal, reason}}, state}
   end
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -69,6 +69,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       :assignments,
       :heartbeat_timer,
       :sync_retry_backoff_ms,
+      :crash_rejoin_max_jitter_ms,
       sync_failures: 0
     ]
 
@@ -93,6 +94,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
             assignments: [{binary(), integer()}] | nil,
             heartbeat_timer: pid() | nil,
             sync_retry_backoff_ms: non_neg_integer() | nil,
+            crash_rejoin_max_jitter_ms: non_neg_integer() | nil,
             sync_failures: non_neg_integer()
           }
   end
@@ -117,6 +119,13 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # resets on a successful sync). Bounds the rejoin loop the way @max_join_retries
   # bounds join — a persistent failure escalates to the supervisor rebuild.
   @max_sync_retries 3
+
+  # Upper bound (ms) on the randomized jitter slept before a rejoin triggered by
+  # an ABNORMAL heartbeat crash (see the {:heartbeat_crash, _} EXIT clause).
+  # Desynchronizes a fleet hitting a correlated heartbeat-kill (e.g. OOM, bad
+  # deploy) so they don't stampede the coordinator with simultaneous JoinGroups.
+  # Overridable per group via the `:crash_rejoin_max_jitter_ms` opt (0 disables).
+  @crash_rejoin_max_jitter_ms 1_000
 
   # Gets a value from opts, falling back to application config, then to default
   defp get_with_default(opts, key, default) do
@@ -147,6 +156,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     session_timeout_padding = get_with_default(opts, :session_timeout_padding, @session_timeout_padding)
     rebalance_timeout = get_with_default(opts, :rebalance_timeout, session_timeout * @rebalance_timeout_multiplier)
     sync_retry_backoff_ms = get_with_default(opts, :sync_retry_backoff_ms, @sync_retry_backoff_ms)
+    crash_rejoin_max_jitter_ms = get_with_default(opts, :crash_rejoin_max_jitter_ms, @crash_rejoin_max_jitter_ms)
 
     partition_assignment_callback =
       Keyword.get(opts, :partition_assignment_callback, &PartitionAssignment.round_robin/2)
@@ -162,7 +172,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         :rebalance_timeout,
         :partition_assignment_callback,
         :client,
-        :sync_retry_backoff_ms
+        :sync_retry_backoff_ms,
+        :crash_rejoin_max_jitter_ms
       ])
 
     # Use Config defaults for connection options if not provided
@@ -200,7 +211,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           group_name: group_name,
           topics: topics,
           member_id: nil,
-          sync_retry_backoff_ms: sync_retry_backoff_ms
+          sync_retry_backoff_ms: sync_retry_backoff_ms,
+          crash_rejoin_max_jitter_ms: crash_rejoin_max_jitter_ms
         }
 
         Process.flag(:trap_exit, true)
@@ -380,7 +392,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # fenced again, so stop cleanly and let the supervisor tear the member down.
   def handle_info({:EXIT, timer, {:shutdown, {:terminal, reason}}}, %State{heartbeat_timer: timer} = state) do
     Logger.error("Heartbeat hit terminal error #{inspect(reason)}, stopping consumer group member")
-    {:stop, {:shutdown, {:terminal, reason}}, state}
+    stop_terminal(state, reason)
   end
 
   # If the CURRENT heartbeat gets an error, attempt to rejoin for recoverable
@@ -432,14 +444,17 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # so this is the residual — an external :kill (OOM, Process.exit/2) or a crash
   # before heartbeat.ex's try-wrapper installs. Treat a lost heartbeat as a
   # rejoin, keeping member_id: an abnormal crash carries no protocol reason to
-  # reset identity. A heartbeat that keeps re-crashing while join/sync succeed
-  # re-loops paced by heartbeat_interval (sync_failures resets on each success,
-  # so the sync bound does not apply here) — accepted; a rejoin backoff is a
-  # deferred follow-up. This must never fall through — an unhandled
-  # {:EXIT, _, _} would FunctionClauseError and tear down the one_for_all /
-  # max_restarts: 0 supervisor with no restart.
+  # reset identity. A randomized jitter precedes the rejoin so a fleet hitting a
+  # correlated heartbeat-kill doesn't stampede the coordinator in lockstep. A
+  # heartbeat that keeps re-crashing while join/sync succeed still re-loops paced
+  # by heartbeat_interval (sync_failures resets on each success, so the sync
+  # bound does not apply here) — accepted; a hard rejoin bound is a deferred
+  # follow-up. This must never fall through — an unhandled {:EXIT, _, _} would
+  # FunctionClauseError and tear down the one_for_all / max_restarts: 0
+  # supervisor with no restart.
   def handle_info({:EXIT, timer, reason}, %State{heartbeat_timer: timer} = state) do
     Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
+    maybe_crash_rejoin_jitter(state)
     {:ok, state} = rebalance(state, {:heartbeat_crash, reason})
     {:noreply, state}
   end
@@ -459,7 +474,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # this on a terminal SyncGroup error (:fenced_instance_id) so the member stops
   # cleanly without rejoining.
   def handle_info({:terminal_shutdown, reason}, %State{} = state) do
-    {:stop, {:shutdown, {:terminal, reason}}, state}
+    stop_terminal(state, reason)
   end
 
   # When terminating, inform the group coordinator that this member is leaving
@@ -529,13 +544,23 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     end
   end
 
-  # Handle join errors - check recoverability FIRST, then check retry count
-  # This ensures unrecoverable errors always get the correct error message
+  # Handle join errors. :unknown_member_id means the broker no longer knows this
+  # member (e.g. our session expired during an outage that also took the
+  # heartbeat down) — reset the member_id and rejoin fresh rather than crashing,
+  # per brod should_reset_member_id / Java resetStateAndGeneration. Other
+  # recoverable errors retry as-is; anything else gets the correct loud error.
+  # Recoverability is checked before the retry count so unrecoverable errors
+  # always surface their own message.
   defp handle_join_error(state, group_name, reason, attempt_number) do
-    if recoverable_error?(reason) do
-      handle_recoverable_join_error(state, group_name, reason, attempt_number)
-    else
-      raise KafkaEx.JoinGroupError, group_name: group_name, reason: reason
+    cond do
+      reason == :unknown_member_id ->
+        handle_recoverable_join_error(reset_generation(state, :unknown_member_id), group_name, reason, attempt_number)
+
+      recoverable_error?(reason) ->
+        handle_recoverable_join_error(state, group_name, reason, attempt_number)
+
+      true ->
+        raise KafkaEx.JoinGroupError, group_name: group_name, reason: reason
     end
   end
 
@@ -730,6 +755,18 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:ok, state} = stop_consumer(state)
     join(state)
   end
+
+  defp stop_terminal(%State{} = state, reason) do
+    Telemetry.emit_member_terminated(state.group_name, state.member_id || "", reason)
+    {:stop, {:shutdown, {:terminal, reason}}, state}
+  end
+
+  defp maybe_crash_rejoin_jitter(%State{crash_rejoin_max_jitter_ms: max})
+       when is_integer(max) and max > 0 do
+    :timer.sleep(:rand.uniform(max))
+  end
+
+  defp maybe_crash_rejoin_jitter(%State{}), do: :ok
 
   ### Timer Management
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -426,6 +426,28 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     {:noreply, state}
   end
 
+  # An abnormal EXIT from the CURRENT heartbeat: a reason no structured clause
+  # matched. heartbeat.ex normalizes everything it can catch into {:shutdown, _},
+  # so this is the residual — an external :kill (OOM, Process.exit/2) or a crash
+  # before heartbeat.ex's try-wrapper installs. Treat a lost heartbeat as a
+  # recoverable rejoin (the sync step bounds retries), keeping member_id: an
+  # abnormal crash carries no protocol reason to reset identity. This must never
+  # fall through — an unhandled {:EXIT, _, _} would FunctionClauseError and tear
+  # down the one_for_all / max_restarts: 0 supervisor with no restart.
+  def handle_info({:EXIT, timer, reason}, %State{heartbeat_timer: timer} = state) do
+    Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
+    {:ok, state} = rebalance(state, {:heartbeat_crash, reason})
+    {:noreply, state}
+  end
+
+  # Any other linked process exiting abnormally. The client is handled above; the
+  # only remaining source is a stale heartbeat we already replaced during a
+  # rebalance, whose late EXIT is obsolete by construction. Drop it — do not act
+  # on a stale signal, and never crash the Manager on an unmatched EXIT.
+  def handle_info({:EXIT, _pid, _reason}, %State{} = state) do
+    {:noreply, state}
+  end
+
   # Deferred terminal stop requested from inside the synchronous join/sync call
   # chain, which can't return {:stop, _, _} directly. handle_sync_error/3 sends
   # this on a terminal SyncGroup error (:fenced_instance_id) so the member stops

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -498,6 +498,7 @@ defmodule KafkaEx.Telemetry do
           atom()
           | {:heartbeat_error, atom()}
           | {:heartbeat_rejoin, atom()}
+          | {:heartbeat_crash, term()}
           | {:commit_fatal, atom()}
           | {:sync_error, atom()}
         ) :: :ok

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -194,6 +194,16 @@ defmodule KafkaEx.Telemetry do
     * Measurements: `%{offset: integer()}`
     * Metadata: `%{group_id: binary(), topic: binary(), partition: integer(), reset: :earliest | :latest, reason: :no_committed_offset | :offset_out_of_range}`
 
+  * `[:kafka_ex, :consumer, :member_terminated]` - Emitted when a consumer-group
+    member stops terminally: it leaves the group and is NOT restarted (under the
+    `one_for_all`/`max_restarts: 0` supervisor). Distinct from a graceful
+    `[:kafka_ex, :consumer, :leave, :stop]` — this is an abnormal,
+    operator-actionable death. Attach to alert on members dying from a fenced
+    static `group.instance.id`, a group authorization failure, or a heartbeat
+    code defect (`{:crashed, module}`).
+    * Measurements: `%{count: 1}`
+    * Metadata: `%{group_id: binary(), member_id: binary(), reason: atom() | {:crashed, module()}}`
+
   ### Metadata Events
 
   * `[:kafka_ex, :metadata, :update, :start]` - Emitted when a metadata request begins
@@ -274,6 +284,7 @@ defmodule KafkaEx.Telemetry do
   @consumer_rebalance [:kafka_ex, :consumer, :rebalance]
   @consumer_commit_failed [:kafka_ex, :consumer, :commit_failed]
   @consumer_offset_reset [:kafka_ex, :consumer, :offset_reset]
+  @consumer_member_terminated [:kafka_ex, :consumer, :member_terminated]
 
   @metadata_update_start [:kafka_ex, :metadata, :update, :start]
   @metadata_update_stop [:kafka_ex, :metadata, :update, :stop]
@@ -297,7 +308,12 @@ defmodule KafkaEx.Telemetry do
                            @consumer_sync_events ++
                            @consumer_heartbeat_events ++
                            @consumer_leave_events ++
-                           [@consumer_rebalance, @consumer_commit_failed, @consumer_offset_reset]
+                           [
+                             @consumer_rebalance,
+                             @consumer_commit_failed,
+                             @consumer_offset_reset,
+                             @consumer_member_terminated
+                           ]
   @consumer_process_events [@consumer_process_start, @consumer_process_stop, @consumer_process_exception]
   @consumer_events @consumer_commit_events ++ @consumer_group_events ++ @consumer_process_events
   @metadata_events [@metadata_update_start, @metadata_update_stop, @metadata_update_exception]
@@ -510,6 +526,31 @@ defmodule KafkaEx.Telemetry do
         group_id: group_id,
         member_id: member_id,
         generation_id: generation_id,
+        reason: reason
+      }
+    )
+  end
+
+  @doc """
+  Emitted when a consumer-group member stops terminally — it leaves the group
+  and is NOT restarted (under the `one_for_all`/`max_restarts: 0` supervisor).
+  Unlike a graceful `[:kafka_ex, :consumer, :leave, :stop]`, this signals an
+  abnormal, operator-actionable death. `reason` is the terminal cause:
+  `:fenced_instance_id`, `:group_authorization_failed`, or `{:crashed, module}`
+  (the exception module that crashed the heartbeat).
+  """
+  @spec emit_member_terminated(
+          binary(),
+          binary(),
+          atom() | {:crashed, module()}
+        ) :: :ok
+  def emit_member_terminated(group_id, member_id, reason) do
+    :telemetry.execute(
+      @consumer_member_terminated,
+      %{count: 1},
+      %{
+        group_id: group_id,
+        member_id: member_id,
         reason: reason
       }
     )

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -195,14 +195,15 @@ defmodule KafkaEx.Telemetry do
     * Metadata: `%{group_id: binary(), topic: binary(), partition: integer(), reset: :earliest | :latest, reason: :no_committed_offset | :offset_out_of_range}`
 
   * `[:kafka_ex, :consumer, :member_terminated]` - Emitted when a consumer-group
-    member stops terminally: it leaves the group and is NOT restarted (under the
-    `one_for_all`/`max_restarts: 0` supervisor). Distinct from a graceful
-    `[:kafka_ex, :consumer, :leave, :stop]` — this is an abnormal,
-    operator-actionable death. Attach to alert on members dying from a fenced
-    static `group.instance.id`, a group authorization failure, or a heartbeat
-    code defect (`{:crashed, module}`).
+    member dies permanently — it stops (or crashes) and is NOT restarted (under
+    the `one_for_all`/`max_restarts: 0` supervisor). Distinct from a graceful
+    `[:kafka_ex, :consumer, :leave, :stop]`; attach to alert on members that
+    won't come back. `reason` distinguishes the cause: `:fenced_instance_id` /
+    `:group_authorization_failed` (terminal), `{:crashed, module}` (an uncaught
+    exception or give-up raise), `{:error, atom}` (an unrecoverable heartbeat
+    error), or `{:client_died, term}`.
     * Measurements: `%{count: 1}`
-    * Metadata: `%{group_id: binary(), member_id: binary(), reason: atom() | {:crashed, module()}}`
+    * Metadata: `%{group_id: binary(), member_id: binary(), reason: atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()}}`
 
   ### Metadata Events
 
@@ -542,7 +543,7 @@ defmodule KafkaEx.Telemetry do
   @spec emit_member_terminated(
           binary(),
           binary(),
-          atom() | {:crashed, module()}
+          atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()}
         ) :: :ok
   def emit_member_terminated(group_id, member_id, reason) do
     :telemetry.execute(

--- a/test/integration/consumer_group/abnormal_heartbeat_recovery_test.exs
+++ b/test/integration/consumer_group/abnormal_heartbeat_recovery_test.exs
@@ -74,15 +74,19 @@ defmodule KafkaEx.Integration.ConsumerGroup.AbnormalHeartbeatRecoveryTest do
     assert is_pid(heartbeat) and Process.alive?(heartbeat)
     Process.exit(heartbeat, :kill)
 
-    # The member rejoins in place: a NEW generation, the SAME member_id, and the
-    # supervisor never went down.
+    # The member rejoins in place: a NEW generation, and the supervisor never
+    # went down.
     assert {:ok, gen1} = ConsumerGroupHelpers.wait_for_generation_change(cg, gen0, timeout: 60_000)
     assert gen1 != gen0
-    assert ConsumerGroup.member_id(cg) == member0, "an abnormal heartbeat crash must keep member_id"
     assert Process.alive?(cg), "the consumer-group supervisor must survive the rejoin"
 
     assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
     assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    # member_id is read only after the rejoin has fully settled (active +
+    # assignments), so it can't catch a transient mid-rejoin state. An abnormal
+    # crash carries no identity-reset, so the SAME member_id must come back.
+    assert ConsumerGroup.member_id(cg) == member0, "an abnormal heartbeat crash must keep member_id"
 
     # Consumption resumes after the in-place rejoin.
     {:ok, _} = API.produce(client, topic, 0, [%{value: "after-rejoin"}])

--- a/test/integration/consumer_group/abnormal_heartbeat_recovery_test.exs
+++ b/test/integration/consumer_group/abnormal_heartbeat_recovery_test.exs
@@ -1,0 +1,91 @@
+defmodule KafkaEx.Integration.ConsumerGroup.AbnormalHeartbeatRecoveryTest do
+  @moduledoc """
+  Exercises the abnormal-EXIT recovery against the shared integration cluster
+  (start it with `./scripts/docker_up.sh`).
+
+  Hard-kills the live Heartbeat process (Process.exit/2 :kill) — an abnormal
+  reason heartbeat.ex cannot catch. The Manager must treat it as a lost
+  heartbeat and rejoin in place (keeping member_id), NOT crash the one_for_all /
+  max_restarts: 0 consumer-group supervisor.
+
+  Before this fix, the killed heartbeat's {:EXIT, _, :killed} matched no Manager
+  clause -> FunctionClauseError -> the whole member subtree went down with no
+  restart.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 120_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.API
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+    topic = "cg_abnormal_hb_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{client: client, uris: uris, topic: topic}}
+  end
+
+  test "a hard-killed heartbeat rejoins in place (keeps member_id), stays alive, resumes consuming",
+       %{client: client, uris: uris, topic: topic} do
+    Process.flag(:trap_exit, true)
+    group = "cg_abnormal_hb_grp_#{:rand.uniform(1_000_000)}"
+
+    opts = [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest,
+      extra_consumer_args: %{test_pid: self()}
+    ]
+
+    {:ok, cg} = ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    gen0 = ConsumerGroup.generation_id(cg)
+    member0 = ConsumerGroup.member_id(cg)
+    assert is_integer(gen0) and is_binary(member0) and member0 != ""
+
+    # Consuming before the fault.
+    {:ok, _} = API.produce(client, topic, 0, [%{value: "before-fault"}])
+    assert_receive {:messages_received, _}, 30_000
+
+    # Hard-kill the live Heartbeat: an abnormal reason heartbeat.ex cannot catch.
+    manager = ConsumerGroup.get_manager_pid(cg)
+    heartbeat = :sys.get_state(manager).heartbeat_timer
+    assert is_pid(heartbeat) and Process.alive?(heartbeat)
+    Process.exit(heartbeat, :kill)
+
+    # The member rejoins in place: a NEW generation, the SAME member_id, and the
+    # supervisor never went down.
+    assert {:ok, gen1} = ConsumerGroupHelpers.wait_for_generation_change(cg, gen0, timeout: 60_000)
+    assert gen1 != gen0
+    assert ConsumerGroup.member_id(cg) == member0, "an abnormal heartbeat crash must keep member_id"
+    assert Process.alive?(cg), "the consumer-group supervisor must survive the rejoin"
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    # Consumption resumes after the in-place rejoin.
+    {:ok, _} = API.produce(client, topic, 0, [%{value: "after-rejoin"}])
+    assert_receive {:messages_received, _}, 30_000
+  end
+end

--- a/test/integration/consumer_group/member_terminated_test.exs
+++ b/test/integration/consumer_group/member_terminated_test.exs
@@ -1,0 +1,96 @@
+defmodule KafkaEx.Integration.ConsumerGroup.MemberTerminatedTest do
+  @moduledoc """
+  Exercises the terminal/permanent-death path against the shared integration
+  cluster (start it with `./scripts/docker_up.sh`).
+
+  A real broker terminal (fenced static instance id, group-auth failure) needs
+  static-membership or ACL infrastructure the test cluster lacks, so we force a
+  deterministic NON-recoverable death instead: corrupt the live Heartbeat's
+  `client` to a dead pid, so its next `KafkaExAPI.heartbeat/4` call exits
+  `:noproc` → `{:shutdown, {:error, :noproc}}` → the Manager stops terminally.
+
+  Asserts the new `[:kafka_ex, :consumer, :member_terminated]` telemetry fires
+  (so a permanent death is alertable, not aliased onto a graceful leave) and the
+  one_for_all / max_restarts: 0 member subtree is torn down.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 120_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+    topic = "cg_member_terminated_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{uris: uris, topic: topic}}
+  end
+
+  test "a non-recoverable heartbeat failure stops the member and emits member_terminated",
+       %{uris: uris, topic: topic} do
+    Process.flag(:trap_exit, true)
+    group = "cg_member_terminated_grp_#{:rand.uniform(1_000_000)}"
+
+    test_pid = self()
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :member_terminated],
+      fn _event, _measurements, %{group_id: ^group} = meta, _ -> send(test_pid, {:member_terminated, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    opts = [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest,
+      extra_consumer_args: %{test_pid: self()}
+    ]
+
+    {:ok, cg} = ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    # Point the live Heartbeat at a dead client so its next call exits :noproc —
+    # a non-recoverable error the Manager turns into a terminal stop.
+    {pid, ref} = spawn_monitor(fn -> :ok end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    end
+
+    manager = ConsumerGroup.get_manager_pid(cg)
+    heartbeat = :sys.get_state(manager).heartbeat_timer
+    :sys.replace_state(heartbeat, fn hb_state -> %{hb_state | client: pid} end)
+
+    # member_terminated fires with a non-recoverable {:error, _} reason...
+    assert_receive {:member_terminated, %{reason: {:error, _}, member_id: member_id}}, 30_000
+    assert is_binary(member_id)
+
+    # ...and the member subtree is torn down (max_restarts: 0, no restart).
+    ref = Process.monitor(cg)
+    assert_receive {:DOWN, ^ref, :process, ^cg, _}, 30_000
+    refute Process.alive?(cg)
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -158,5 +158,50 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
 
       assert {:stop, {:shutdown, {:error, :network_error}}, ^state} = Heartbeat.handle_info(:timeout, state)
     end
+
+    test "an unexpected response shape is rescued into a terminal {:crashed, _} stop" do
+      # API.heartbeat/4 pattern-matches the client reply in a case; an unknown
+      # shape raises CaseClauseError inside the heartbeat process. The wrapper
+      # must convert that code-defect crash into a clean terminal stop, not let
+      # it escape as a bare abnormal exit.
+      {:ok, client} = MockClient.start_link(%{heartbeat: :unexpected_garbage})
+
+      state = %Heartbeat.State{
+        client: client,
+        group_name: "test-group",
+        member_id: "member-1",
+        generation_id: 1,
+        heartbeat_interval: 1000
+      }
+
+      assert {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
+    end
+
+    test "a client-call exit is caught and converted to a structured {:error, _} stop" do
+      # A dead client makes API.heartbeat's GenServer.call exit
+      # {:noproc, {GenServer, :call, _}}. The wrapper must catch it and exit with
+      # a structured {:shutdown, {:error, :noproc}} the Manager can route, rather
+      # than dying with a bare abnormal reason the Manager can't match.
+      {:ok, client} = MockClient.start_link(%{})
+      Process.unlink(client)
+      ref = Process.monitor(client)
+      Process.exit(client, :kill)
+
+      receive do
+        {:DOWN, ^ref, :process, ^client, _} -> :ok
+      end
+
+      state = %Heartbeat.State{
+        client: client,
+        group_name: "test-group",
+        member_id: "member-1",
+        generation_id: 1,
+        heartbeat_interval: 1000
+      }
+
+      assert {:stop, {:shutdown, {:error, :noproc}}, ^state} =
+               Heartbeat.handle_info(:timeout, state)
+    end
   end
 end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -174,7 +174,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
         heartbeat_interval: 1000
       }
 
-      assert {:stop, {:shutdown, {:terminal, {:crashed, :error}}}, ^state} =
+      assert {:stop, {:shutdown, {:terminal, {:crashed, CaseClauseError}}}, ^state} =
                Heartbeat.handle_info(:timeout, state)
     end
 

--- a/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
@@ -1,0 +1,78 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
+  @moduledoc """
+  Regression for the abnormal-EXIT teardown gap: when the linked Heartbeat dies
+  with a reason no structured clause matched (e.g. :killed, or a crash before
+  heartbeat.ex's try-wrapper), the Manager previously raised FunctionClauseError
+  and was torn down by the one_for_all / max_restarts: 0 consumer-group
+  supervisor with no restart.
+
+  Now an abnormal EXIT from the CURRENT heartbeat drives a bounded rejoin
+  (keeping member_id — no protocol reason to reset it), and an abnormal EXIT
+  from a STALE (already-replaced) heartbeat is dropped. Exercised through the
+  real handle_info/2; no private function is exposed for testing.
+  """
+  use ExUnit.Case, async: false
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Consumer.ConsumerGroup.Manager
+  alias KafkaEx.Consumer.ConsumerGroup.Manager.State
+  alias KafkaEx.Test.MockClient
+
+  # A pid that has already exited — mirrors reality, where the heartbeat is dead
+  # by the time its {:EXIT, _, _} reaches the Manager. As heartbeat_timer it also
+  # makes stop_heartbeat_timer/1 a no-op via its Process.alive?/1 guard.
+  defp dead_pid do
+    {pid, ref} = spawn_monitor(fn -> :ok end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    end
+
+    pid
+  end
+
+  test "an abnormal EXIT from the current heartbeat rejoins (keeps member_id), not a crash" do
+    # join_group fails non-recoverably so the rejoin raises immediately (no retry
+    # sleeps, no consumer startup). Reaching join at all proves the abnormal EXIT
+    # was routed to the rejoin path rather than crashing the Manager.
+    {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+    on_exit(fn -> stop_safely(client) end)
+
+    {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+    on_exit(fn -> stop_safely(sup) end)
+
+    timer = dead_pid()
+
+    state = %State{
+      client: client,
+      supervisor_pid: sup,
+      group_name: "g",
+      topics: ["t"],
+      member_id: "m",
+      generation_id: 1,
+      session_timeout: 1000,
+      session_timeout_padding: 0,
+      rebalance_timeout: 1000,
+      heartbeat_timer: timer
+    }
+
+    assert_raise KafkaEx.JoinGroupError, fn ->
+      Manager.handle_info({:EXIT, timer, :killed}, state)
+    end
+
+    # An abnormal crash carries no identity-reset semantics -> keep member_id.
+    assert {:join_group, "g", "m"} in MockClient.get_calls(client)
+  end
+
+  test "an abnormal EXIT from a stale (non-current) heartbeat is dropped" do
+    # No client/supervisor: a spurious rebalance here would crash on nil
+    # supervisor_pid, so {:noreply, state} also proves nothing was acted on.
+    current = dead_pid()
+    stale = dead_pid()
+
+    state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: current}
+
+    assert {:noreply, ^state} = Manager.handle_info({:EXIT, stale, :killed}, state)
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
@@ -56,6 +56,11 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
     pid
   end
 
+  defp terminate_state do
+    {:ok, client} = MockClient.start_link(%{leave_group: {:ok, %KafkaEx.Messages.LeaveGroup{}}})
+    %State{client: client, group_name: "g", member_id: "m", generation_id: 1}
+  end
+
   test "an abnormal EXIT from the current heartbeat rejoins (keeps member_id), not a crash" do
     # join_group fails non-recoverably so the rejoin raises immediately (no retry
     # sleeps, no consumer startup). Reaching join at all proves the abnormal EXIT
@@ -138,25 +143,60 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
     assert {:join_group, "g", ""} in calls, ":unknown_member_id must reset member_id and rejoin fresh"
   end
 
-  test "a terminal heartbeat EXIT emits a member_terminated telemetry event" do
-    test_pid = self()
-    handler_id = {__MODULE__, :member_terminated, make_ref()}
+  describe "member_terminated telemetry (via terminate/2)" do
+    # terminate/2 is the single choke point every permanent member death flows
+    # through (clean {:stop, _} returns AND callback raises); a graceful
+    # :normal/:shutdown must stay silent. State carries a real MockClient so the
+    # terminate path's leave/unlink/stop run.
+    setup do
+      test_pid = self()
+      handler_id = {__MODULE__, :member_terminated, make_ref()}
 
-    :telemetry.attach(
-      handler_id,
-      [:kafka_ex, :consumer, :member_terminated],
-      fn _event, measurements, metadata, _ -> send(test_pid, {:member_terminated, measurements, metadata}) end,
-      nil
-    )
+      :telemetry.attach(
+        handler_id,
+        [:kafka_ex, :consumer, :member_terminated],
+        fn _event, measurements, metadata, _ -> send(test_pid, {:member_terminated, measurements, metadata}) end,
+        nil
+      )
 
-    on_exit(fn -> :telemetry.detach(handler_id) end)
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
 
-    timer = dead_pid()
-    state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: timer}
+    test "terminal error emits the terminal cause" do
+      Manager.terminate({:shutdown, {:terminal, :fenced_instance_id}}, terminate_state())
 
-    assert {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, ^state} =
-             Manager.handle_info({:EXIT, timer, {:shutdown, {:terminal, :fenced_instance_id}}}, state)
+      assert_receive {:member_terminated, %{count: 1}, %{group_id: "g", member_id: "m", reason: :fenced_instance_id}}
+    end
 
-    assert_receive {:member_terminated, %{count: 1}, %{group_id: "g", member_id: "m", reason: :fenced_instance_id}}
+    test "non-recoverable heartbeat {:error, _} emits {:error, _}" do
+      Manager.terminate({:shutdown, {:error, :some_fatal}}, terminate_state())
+
+      assert_receive {:member_terminated, _, %{reason: {:error, :some_fatal}}}
+    end
+
+    test "client death emits {:client_died, _}" do
+      Manager.terminate({:shutdown, {:client_died, :killed}}, terminate_state())
+
+      assert_receive {:member_terminated, _, %{reason: {:client_died, :killed}}}
+    end
+
+    test "a callback raise / give-up emits {:crashed, module}" do
+      Manager.terminate({%RuntimeError{message: "boom"}, []}, terminate_state())
+
+      assert_receive {:member_terminated, _, %{reason: {:crashed, RuntimeError}}}
+    end
+
+    test "a graceful :shutdown does NOT emit" do
+      Manager.terminate(:shutdown, terminate_state())
+
+      refute_receive {:member_terminated, _, _}, 100
+    end
+
+    test "a graceful :normal does NOT emit" do
+      Manager.terminate(:normal, terminate_state())
+
+      refute_receive {:member_terminated, _, _}, 100
+    end
   end
 end

--- a/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
@@ -1,3 +1,27 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest.JoinResetMockClient do
+  @moduledoc false
+  # A client whose JoinGroup response is keyed on the member_id: the stale "m"
+  # gets :unknown_member_id (broker forgot us); the fresh "" rejoin (after a
+  # reset) gets a non-recoverable error so the retry loop halts after one
+  # reset+retry instead of exhausting @max_join_retries.
+  use GenServer
+
+  def start_link, do: GenServer.start_link(__MODULE__, nil)
+  def get_calls(pid), do: GenServer.call(pid, :get_calls)
+
+  def init(_), do: {:ok, []}
+
+  def handle_call(:get_calls, _from, calls), do: {:reply, Enum.reverse(calls), calls}
+
+  def handle_call({:join_group, group, "m", _opts}, _from, calls) do
+    {:reply, {:error, :unknown_member_id}, [{:join_group, group, "m"} | calls]}
+  end
+
+  def handle_call({:join_group, group, member_id, _opts}, _from, calls) do
+    {:reply, {:error, :illegal_generation}, [{:join_group, group, member_id} | calls]}
+  end
+end
+
 defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
   @moduledoc """
   Regression for the abnormal-EXIT teardown gap: when the linked Heartbeat dies
@@ -74,5 +98,65 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
     state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: current}
 
     assert {:noreply, ^state} = Manager.handle_info({:EXIT, stale, :killed}, state)
+  end
+
+  alias KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest.JoinResetMockClient
+
+  test "a JoinGroup :unknown_member_id resets member_id and rejoins fresh, not an immediate crash" do
+    # The broker forgot us (session expired during the outage that killed the
+    # heartbeat): JoinGroup with the stale "m" returns :unknown_member_id. The
+    # fix must RESET member_id and rejoin with "" instead of raising on the spot.
+    # Before the fix, :unknown_member_id raised JoinGroupError immediately and ""
+    # was never tried — re-creating the no-restart teardown via the join path.
+    {:ok, client} = JoinResetMockClient.start_link()
+    on_exit(fn -> stop_safely(client) end)
+
+    {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+    on_exit(fn -> stop_safely(sup) end)
+
+    timer = dead_pid()
+
+    state = %State{
+      client: client,
+      supervisor_pid: sup,
+      group_name: "g",
+      topics: ["t"],
+      member_id: "m",
+      generation_id: 1,
+      session_timeout: 1000,
+      session_timeout_padding: 0,
+      rebalance_timeout: 1000,
+      heartbeat_timer: timer
+    }
+
+    assert_raise KafkaEx.JoinGroupError, fn ->
+      Manager.handle_info({:EXIT, timer, :killed}, state)
+    end
+
+    calls = JoinResetMockClient.get_calls(client)
+    assert {:join_group, "g", "m"} in calls, "the stale member_id must be tried first"
+    assert {:join_group, "g", ""} in calls, ":unknown_member_id must reset member_id and rejoin fresh"
+  end
+
+  test "a terminal heartbeat EXIT emits a member_terminated telemetry event" do
+    test_pid = self()
+    handler_id = {__MODULE__, :member_terminated, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :member_terminated],
+      fn _event, measurements, metadata, _ -> send(test_pid, {:member_terminated, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    timer = dead_pid()
+    state = %State{group_name: "g", member_id: "m", generation_id: 1, heartbeat_timer: timer}
+
+    assert {:stop, {:shutdown, {:terminal, :fenced_instance_id}}, ^state} =
+             Manager.handle_info({:EXIT, timer, {:shutdown, {:terminal, :fenced_instance_id}}}, state)
+
+    assert_receive {:member_terminated, %{count: 1}, %{group_id: "g", member_id: "m", reason: :fenced_instance_id}}
   end
 end

--- a/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_fatal_rejoin_test.exs
@@ -209,6 +209,17 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
 
       on_exit(fn -> :telemetry.detach(handler_id) end)
 
+      term_handler_id = {__MODULE__, :member_terminated, make_ref()}
+
+      :telemetry.attach(
+        term_handler_id,
+        [:kafka_ex, :consumer, :member_terminated],
+        fn _event, _measurements, %{reason: reason}, _ -> send(test_pid, {:member_terminated, reason}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(term_handler_id) end)
+
       {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
       on_exit(fn -> ProcessHelpers.stop_safely(sup) end)
 
@@ -243,6 +254,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
       # The bound still escalates a persistent failure to give-up.
       assert_receive {:EXIT, ^manager, {%KafkaEx.SyncGroupRetriesExhaustedError{}, _stacktrace}}, 30_000
       assert :counters.get(rejoins, 1) == 3
+
+      # The give-up raise is a permanent death -> member_terminated fires.
+      assert_receive {:member_terminated, {:crashed, KafkaEx.SyncGroupRetriesExhaustedError}}, 30_000
     end
 
     test ":unknown_member_id rejoins after resetting member_id, bounded" do
@@ -264,6 +278,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
 
       assert_receive {:EXIT, ^manager, {:shutdown, {:terminal, :fenced_instance_id}}}, 30_000
       assert :counters.get(rejoins, 1) == 0
+      assert_receive {:member_terminated, :fenced_instance_id}, 30_000
     end
 
     test ":group_authorization_failed stops terminally without rejoining or raising" do
@@ -271,6 +286,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerFatalRejoinTest do
 
       assert_receive {:EXIT, ^manager, {:shutdown, {:terminal, :group_authorization_failed}}}, 30_000
       assert :counters.get(rejoins, 1) == 0
+      assert_receive {:member_terminated, :group_authorization_failed}, 30_000
     end
   end
 end

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -180,8 +180,8 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_events()
 
       # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 3 process = 21
-      assert length(events) == 21
+      # + 1 offset_reset + 1 member_terminated + 3 process = 22
+      assert length(events) == 22
 
       # Commit events
       assert [:kafka_ex, :consumer, :commit, :start] in events
@@ -203,6 +203,7 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :consumer, :leave, :exception] in events
       assert [:kafka_ex, :consumer, :rebalance] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
+      assert [:kafka_ex, :consumer, :member_terminated] in events
 
       # Process events
       assert [:kafka_ex, :consumer, :process, :start] in events
@@ -216,11 +217,12 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_group_events()
 
       # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset = 15
-      assert length(events) == 15
+      # + 1 offset_reset + 1 member_terminated = 16
+      assert length(events) == 16
 
       assert [:kafka_ex, :consumer, :commit_failed] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
+      assert [:kafka_ex, :consumer, :member_terminated] in events
 
       # Group lifecycle events
       assert [:kafka_ex, :consumer, :join, :start] in events


### PR DESCRIPTION
## Problem

The consumer-group `Manager` runs with `trap_exit: true` and links the `Heartbeat` GenServer, but defines its own `handle_info/2` clauses (overriding the `use GenServer` default). An **abnormal** EXIT from the heartbeat — a `GenServer.call` timeout (`{:timeout, _}`), an uncaught exception, or `:killed` (OOM / external kill) — matched **no clause** → `FunctionClauseError` → the `one_for_all` / `max_restarts: 0` consumer-group supervisor tore down the **whole member with no restart**.

The most likely trigger is the original incident class: a degraded broker → slow client → the heartbeat's `GenServer.call` times out (5 s) → the member dies and its partitions only re-home after the full session timeout.

## Fix — two layers

- **`heartbeat.ex`** wraps `handle_info(:timeout, _)` in `try/rescue/catch` so the process *always* exits with a structured `{:shutdown, _}` reason: a caught exit → `{:shutdown, {:error, <atom>}}` (`{:timeout, _}` → `:timeout`, already recoverable → rejoin); an uncaught exception/throw → `{:shutdown, {:terminal, {:crashed, module}}}` (clean terminal stop).
- **`manager.ex`** adds two trailing `{:EXIT, …}` clauses: an abnormal EXIT from the **current** heartbeat → bounded in-place rejoin (keeping `member_id`); any other/stale pid → drop. The Manager can **never `FunctionClauseError` on a linked EXIT again**.

### Recover-vs-terminal
Environmental failures (timeout, `:killed`) → rejoin; an internal **code-defect exception → clean terminal stop**, *not* rejoin — because `join`+`sync` keep succeeding (so `sync_failures` resets) and a rejoin loop would be unbounded. This matches Java re-raising unexpected exceptions and is *safer* than kafka-python (which silently loses heartbeats on a non-`RuntimeError`). Identity-reset semantics (`illegal_generation` keeps `member_id`, `unknown_member_id` clears it) are an exact match to the Java client's `resetStateAndGeneration()`.

## Hardening (from a multi-client review battery: Elixir/OTP · brod · Java · kafka-python/librdkafka · SRE)

- **Anti-thundering-herd jitter** — a randomized `0..crash_rejoin_max_jitter_ms` (default 1000 ms, `0` disables) sleeps before a heartbeat-crash rejoin, so a fleet hitting a correlated heartbeat-kill (OOM, bad deploy) doesn't stampede the coordinator in lockstep.
- **`[:kafka_ex, :consumer, :member_terminated]` telemetry** — emitted on *every* terminal stop (fenced static instance id, group-authorization failure, `{:crashed, module}`), so a permanently-dying member is alertable instead of aliasing onto a graceful `[:kafka_ex, :consumer, :leave, :stop]`.
- **`join/2` resets `member_id` + retries on a JoinGroup `:unknown_member_id`** (per brod `should_reset_member_id` / Java `resetStateAndGeneration`) instead of raising — closing a pre-existing teardown path reachable when the broker evicts a member during an outage longer than the session timeout.

## Compatibility
Internal behavior only — no public API change. Additive: one new config knob (`:crash_rejoin_max_jitter_ms`) and one new telemetry event; existing reasons/return types unchanged.

## Tests
- Unit: heartbeat catch/classify (timeout-exit, dead-client exit, crash→terminal), Manager abnormal-EXIT routing (current → rejoin, stale → drop), the `unknown_member_id` reset+retry, and the terminal-stop telemetry event — all failing-first verified.
- Integration (3-broker cluster): hard-kills the live heartbeat and asserts the member rejoins in place (member_id preserved, generation advances, supervisor survives, consumption resumes); proven to fail (FunctionClauseError) if the Manager clauses are reverted.
- Gates: `mix format`, `compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0), `mix test.unit` (2981/0), integration consumer_group green.

## Follow-up (deferred)
A *hard* rejoin bound/counter — jitter desynchronizes a fleet, but a deterministically re-crashing heartbeat still re-loops at `heartbeat_interval` cadence.
