### PR TITLE
fix: bound the abnormal heartbeat-crash rejoin loop (crash-loop give-up + telemetry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # KafkaEx Changelog
 
+## Unreleased
+
+### Fixed
+
+* **The abnormal heartbeat-crash rejoin loop is now bounded (#560).** When a
+  consumer-group member's heartbeat process dies abnormally — an uncatchable
+  `:kill`, OOM, or unstructured crash — the manager rejoins in place, but if it
+  keeps dying more than `crash_rejoin_max_restarts` times within
+  `crash_rejoin_window_ms` (defaults `10` / `60_000` ms; OTP
+  `max_restarts`/`max_seconds` semantics) the member now stops terminally
+  instead of looping forever. **Behavior change:** such a member previously
+  looped indefinitely (silent, consuming nothing); it now stops, emits
+  `[:kafka_ex, :consumer, :member_terminated]` with reason `{:crash_loop, _}`,
+  and is torn down by its supervisor — delegating recovery to *your* supervisor.
+  Set `crash_rejoin_max_restarts: :infinity` to restore the old unbounded
+  behavior. A `ConsumerGroup` started **without** a supervising parent now stops
+  on a crash-loop instead of looping — see UPGRADING.md. New observability: a
+  `[:kafka_ex, :consumer, :heartbeat_crash]` event fires on each abnormal-crash
+  rejoin (with `crashes_in_window`) for pre-terminal alerting, and
+  `member_terminated` metadata gains a low-cardinality `terminal_class` atom
+  (`:fenced | :auth | :crash_loop | :crashed | :error | :client_died | :other`)
+  for alert routing.
+
 ## 1.0.1 (2026-06-26)
 
 ### Breaking Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -231,6 +231,43 @@ KafkaEx.Consumer.ConsumerGroup.start_link(
 )
 ```
 
+### Consumer-group heartbeat crash-loop is now bounded (new in 1.1.0)
+
+A consumer-group member whose heartbeat process keeps dying abnormally (an
+uncatchable `:kill`, OOM, or unstructured crash) used to rejoin **forever** —
+silent, consuming nothing, never alerting. It is now bounded: more than
+`crash_rejoin_max_restarts` such crashes within `crash_rejoin_window_ms`
+(defaults `10` / `60_000` ms) stops the member terminally and emits
+`[:kafka_ex, :consumer, :member_terminated]` with `{:crash_loop, _}`.
+
+**What you must check:**
+
+- **If you start `ConsumerGroup` under your own supervisor** (the common case,
+  and what the docs recommend), there is nothing to do — on a crash-loop trip the
+  member stops and your supervisor restarts the whole `ConsumerGroup` fresh under
+  your restart strategy. Size your supervisor's `max_restarts`/`max_seconds` to
+  absorb a correlated kill wave (e.g. a fleet-wide OOM/deploy) where many members
+  can trip at nearly the same time.
+
+- **If you start `ConsumerGroup` standalone** (not under a supervisor), a
+  crash-loop trip now **permanently stops consumption** instead of looping. Wrap
+  it in a supervisor, or set `crash_rejoin_max_restarts: :infinity` to keep the
+  unbounded rejoin (no terminal give-up):
+
+  ```elixir
+  # loop forever on abnormal heartbeat crashes (unbounded rejoin, no give-up)
+  config :kafka_ex, crash_rejoin_max_restarts: :infinity
+
+  # or per consumer group
+  KafkaEx.Consumer.ConsumerGroup.start_link(
+    MyConsumer, "my-group", ["topic"],
+    crash_rejoin_max_restarts: :infinity
+  )
+  ```
+
+To tune rather than disable, raise the restart **count** rather than widening the
+window (a wider window accumulates more crashes and trips more eagerly).
+
 ### `KafkaEx.API.start_client()` is now unnamed by default
 
 Pre-v1.0 patch — and the v1.0 release prior to this fix — `start_client()`

--- a/config/config.exs
+++ b/config/config.exs
@@ -76,6 +76,21 @@ config :kafka_ex,
   # a correlated heartbeat-kill so members don't stampede the coordinator with
   # simultaneous JoinGroups. Set to 0 to disable. Default: 1000.
   # crash_rejoin_max_jitter_ms: 1000,
+  # Heartbeat-crash-loop bound. If a consumer-group member's heartbeat process
+  # dies abnormally more than `crash_rejoin_max_restarts` times within
+  # `crash_rejoin_window_ms`, the member stops terminally (emitting
+  # `[:kafka_ex, :consumer, :member_terminated]`) and is torn down by its
+  # supervisor instead of rejoining forever — so a deterministically broken
+  # member fails fast and alertably rather than looping silently. Mirrors OTP's
+  # max_restarts/max_seconds. To tolerate a transient kill burst, raise the
+  # restart count rather than widening the window (a wider window accumulates
+  # more crashes and trips more eagerly). Set restarts to `:infinity` to disable
+  # the bound (loop forever) — use that rather than a 0 window (which effectively
+  # disables it for any restarts > 0) or a huge restart count. (0 restarts is the
+  # opposite extreme: it trips on the very first abnormal crash.) Defaults: 10
+  # restarts / 60_000 ms.
+  # crash_rejoin_max_restarts: 10,
+  # crash_rejoin_window_ms: 60000,
   # API versions for Kafka protocol requests.
   # By default, KafkaEx uses the highest version supported by both the
   # connected broker and the protocol library. Use this config to pin

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -32,8 +32,45 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   - `:session_timeout_padding` - Extra time added to request timeouts (default: 10000)
   - `:rebalance_timeout` - Time allowed for consumers to rejoin during rebalance (default: `session_timeout * 3`)
   - `:partition_assignment_callback` - Function for custom partition assignment (default: round-robin)
+  - `:crash_rejoin_max_restarts` - Abnormal heartbeat-crash rejoins tolerated within
+    `crash_rejoin_window_ms` before a terminal stop (default: 10; `:infinity` disables the bound)
+  - `:crash_rejoin_window_ms` - Sliding window (ms) for `crash_rejoin_max_restarts` (default: 60000)
 
   Options can also be configured globally via application config under `:kafka_ex`.
+
+  ## Crash-loop bound and recovery
+
+  This bound governs only an **abnormal, uncatchable** heartbeat death — an
+  `:kill` or an unstructured process crash that reaches the manager as a bare
+  `{:EXIT, _, reason}` from the current heartbeat. Every *catchable* heartbeat
+  failure is already classified
+  by the heartbeat process itself (recoverable errors → rejoin; a code exception
+  or `:fenced_instance_id` / `:group_authorization_failed` → immediate terminal
+  stop), so those do not go through this counter.
+
+  Such an abnormal death triggers an in-place rejoin (and a
+  `[:kafka_ex, :consumer, :heartbeat_crash]` event). If they keep happening —
+  more than `crash_rejoin_max_restarts` times within `crash_rejoin_window_ms`
+  (defaults 10 / 60_000 ms; OTP `max_restarts`/`max_seconds` semantics) — the
+  member stops terminally, emits `[:kafka_ex, :consumer, :member_terminated]` with
+  `{:crash_loop, reason}`, and is torn down by its `one_for_all` /
+  `max_restarts: 0` supervisor (whose `max_restarts: 0` is intentional and
+  load-bearing for this escalation). The window is a pure sliding time-window: it
+  is never reset on a successful rejoin, only aged out, so crashes are counted
+  across the member's whole lifetime within the window. **Prior to this change the
+  loop was unbounded; the bound is active by default.**
+
+  To get automatic recovery from a terminal stop, run `ConsumerGroup` under your
+  own supervisor (the common case); it is then restarted fresh under your restart
+  strategy. **A `ConsumerGroup` started standalone will simply stop** (see
+  `UPGRADING.md`). A correlated kill wave (e.g. a fleet-wide OOM or deploy) can
+  trip many members at nearly the same time — per-member windowing limits each
+  member, but jitter does NOT desync the trip itself, so size your own
+  supervisor's `max_restarts`/`max_seconds` to absorb a simultaneous restart; it
+  is the real backstop. The bound counts one crash per heartbeat failure, so with
+  a short `heartbeat_interval` crashes accumulate faster within the window — raise
+  `crash_rejoin_max_restarts` to give more headroom before tripping. Set
+  `crash_rejoin_max_restarts: :infinity` to disable the bound.
   """
   use GenServer
 
@@ -70,7 +107,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       :heartbeat_timer,
       :sync_retry_backoff_ms,
       :crash_rejoin_max_jitter_ms,
-      sync_failures: 0
+      :crash_rejoin_max_restarts,
+      :crash_rejoin_window_ms,
+      sync_failures: 0,
+      heartbeat_crash_times: []
     ]
 
     @type t :: %__MODULE__{
@@ -95,7 +135,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
             heartbeat_timer: pid() | nil,
             sync_retry_backoff_ms: non_neg_integer() | nil,
             crash_rejoin_max_jitter_ms: non_neg_integer() | nil,
-            sync_failures: non_neg_integer()
+            crash_rejoin_max_restarts: non_neg_integer() | :infinity | nil,
+            crash_rejoin_window_ms: non_neg_integer() | nil,
+            sync_failures: non_neg_integer(),
+            heartbeat_crash_times: [integer()]
           }
   end
 
@@ -123,6 +166,16 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # Max jitter (ms) before an abnormal-crash rejoin, to desync a fleet hitting a
   # correlated heartbeat-kill. Per-group via `:crash_rejoin_max_jitter_ms`; 0 off.
   @crash_rejoin_max_jitter_ms 1_000
+
+  # Heartbeat-crash-loop bound (OTP max_restarts/max_seconds applied to the
+  # abnormal-crash rejoin path): more than @crash_rejoin_max_restarts abnormal
+  # heartbeat-crash rejoins within @crash_rejoin_window_ms stops the member
+  # terminally instead of looping forever. Per-group via :crash_rejoin_max_restarts
+  # / :crash_rejoin_window_ms; :infinity restarts disables the bound. Raising the
+  # restart count (not widening the window) is the lever to tolerate a transient
+  # kill burst — a wider window accumulates more crashes and trips more eagerly.
+  @crash_rejoin_max_restarts 10
+  @crash_rejoin_window_ms 60_000
 
   # Gets a value from opts, falling back to application config, then to default
   defp get_with_default(opts, key, default) do
@@ -154,6 +207,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     rebalance_timeout = get_with_default(opts, :rebalance_timeout, session_timeout * @rebalance_timeout_multiplier)
     sync_retry_backoff_ms = get_with_default(opts, :sync_retry_backoff_ms, @sync_retry_backoff_ms)
     crash_rejoin_max_jitter_ms = get_with_default(opts, :crash_rejoin_max_jitter_ms, @crash_rejoin_max_jitter_ms)
+    crash_rejoin_max_restarts = get_with_default(opts, :crash_rejoin_max_restarts, @crash_rejoin_max_restarts)
+    crash_rejoin_window_ms = get_with_default(opts, :crash_rejoin_window_ms, @crash_rejoin_window_ms)
 
     partition_assignment_callback =
       Keyword.get(opts, :partition_assignment_callback, &PartitionAssignment.round_robin/2)
@@ -170,7 +225,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         :partition_assignment_callback,
         :client,
         :sync_retry_backoff_ms,
-        :crash_rejoin_max_jitter_ms
+        :crash_rejoin_max_jitter_ms,
+        :crash_rejoin_max_restarts,
+        :crash_rejoin_window_ms
       ])
 
     # Use Config defaults for connection options if not provided
@@ -209,7 +266,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           topics: topics,
           member_id: nil,
           sync_retry_backoff_ms: sync_retry_backoff_ms,
-          crash_rejoin_max_jitter_ms: crash_rejoin_max_jitter_ms
+          crash_rejoin_max_jitter_ms: crash_rejoin_max_jitter_ms,
+          crash_rejoin_max_restarts: crash_rejoin_max_restarts,
+          crash_rejoin_window_ms: crash_rejoin_window_ms
         }
 
         Process.flag(:trap_exit, true)
@@ -433,12 +492,32 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   # Current heartbeat died abnormally — the residual heartbeat.ex can't catch
   # (`:kill`). Rejoin keeping member_id (no protocol reason to reset it),
-  # jittered to desync correlated kills.
+  # jittered to desync correlated kills — unless this member is crash-looping,
+  # in which case stop terminally and let the supervisor decide.
   def handle_info({:EXIT, timer, reason}, %State{heartbeat_timer: timer} = state) do
-    Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
-    maybe_crash_rejoin_jitter(state)
-    {:ok, state} = rebalance(state, {:heartbeat_crash, reason})
-    {:noreply, state}
+    case register_heartbeat_crash(state) do
+      {:trip, state} ->
+        Logger.error(
+          "Heartbeat crashed #{length(state.heartbeat_crash_times)} times within " <>
+            "#{state.crash_rejoin_window_ms}ms (limit #{state.crash_rejoin_max_restarts}); " <>
+            "stopping member instead of rejoining"
+        )
+
+        stop_terminal(state, {:crash_loop, reason})
+
+      {:rejoin, state} ->
+        Telemetry.emit_heartbeat_crash(
+          state.group_name,
+          state.member_id || "",
+          reason,
+          length(state.heartbeat_crash_times)
+        )
+
+        Logger.warning("Heartbeat exited abnormally (#{inspect(reason)}); rejoining group")
+        maybe_crash_rejoin_jitter(state)
+        {:ok, state} = rebalance(state, {:heartbeat_crash, reason})
+        {:noreply, state}
+    end
   end
 
   # Catch-all so no {:EXIT, _, _} ever FunctionClauseErrors the Manager (which
@@ -764,6 +843,23 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   end
 
   defp maybe_crash_rejoin_jitter(%State{}), do: :ok
+
+  # Sliding-window restart intensity: keep crash timestamps within the window,
+  # trip terminal once they exceed the budget (current crash included). The
+  # window is never cleared on a successful rejoin — it only ages out — so the
+  # bound counts crashes across the member's whole lifetime within the window.
+  defp register_heartbeat_crash(%State{crash_rejoin_max_restarts: max, crash_rejoin_window_ms: window} = state)
+       when is_integer(max) and max >= 0 and is_integer(window) do
+    now = System.monotonic_time(:millisecond)
+    recent = Enum.filter([now | state.heartbeat_crash_times], &(now - &1 <= window))
+    state = %State{state | heartbeat_crash_times: recent}
+
+    if length(recent) > max, do: {:trip, state}, else: {:rejoin, state}
+  end
+
+  # :infinity (or an unset/invalid budget or window) means never bound — loop
+  # forever (old behaviour).
+  defp register_heartbeat_crash(%State{} = state), do: {:rejoin, state}
 
   ### Timer Management
 

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -201,9 +201,26 @@ defmodule KafkaEx.Telemetry do
     won't come back. `reason` distinguishes the cause: `:fenced_instance_id` /
     `:group_authorization_failed` (terminal), `{:crashed, module}` (an uncaught
     exception or give-up raise), `{:error, atom}` (an unrecoverable heartbeat
-    error), or `{:client_died, term}`.
+    error), `{:client_died, term}`, or `{:crash_loop, term}` (the heartbeat
+    crashed repeatedly within the configured window and the member gave up — see
+    `crash_rejoin_max_restarts` / `crash_rejoin_window_ms`). `terminal_class` is a
+    flat, low-cardinality atom (`:fenced | :auth | :crash_loop | :crashed |
+    :error | :client_died | :other`) derived from `reason` — tag alerts on it
+    rather than on `reason`, whose tuple shape carries an unbounded inner term.
     * Measurements: `%{count: 1}`
-    * Metadata: `%{group_id: binary(), member_id: binary(), reason: atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()}}`
+    * Metadata: `%{group_id: binary(), member_id: binary(), reason: atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()} | {:crash_loop, term()}, terminal_class: atom()}`
+
+  * `[:kafka_ex, :consumer, :heartbeat_crash]` - Emitted each time a member's
+    heartbeat process dies abnormally and the member rejoins in place. NOT
+    emitted on the crash that exceeds the budget — that one trips a terminal stop
+    and surfaces as `member_terminated` with `{:crash_loop, _}` instead. Attach to
+    a rate metric (on `count`) to spot a flapping-but-recovering member before it
+    trips. Do not tag by `reason` — it carries an unbounded EXIT term; use it for
+    logs/debugging. `crashes_in_window` is the current sliding-window count
+    (decays as old crashes age out of the window; drops to zero only when the
+    member restarts fresh), not a monotonic gauge.
+    * Measurements: `%{count: 1, crashes_in_window: non_neg_integer()}`
+    * Metadata: `%{group_id: binary(), member_id: binary(), reason: term()}`
 
   ### Metadata Events
 
@@ -286,6 +303,7 @@ defmodule KafkaEx.Telemetry do
   @consumer_commit_failed [:kafka_ex, :consumer, :commit_failed]
   @consumer_offset_reset [:kafka_ex, :consumer, :offset_reset]
   @consumer_member_terminated [:kafka_ex, :consumer, :member_terminated]
+  @consumer_heartbeat_crash [:kafka_ex, :consumer, :heartbeat_crash]
 
   @metadata_update_start [:kafka_ex, :metadata, :update, :start]
   @metadata_update_stop [:kafka_ex, :metadata, :update, :stop]
@@ -313,7 +331,8 @@ defmodule KafkaEx.Telemetry do
                              @consumer_rebalance,
                              @consumer_commit_failed,
                              @consumer_offset_reset,
-                             @consumer_member_terminated
+                             @consumer_member_terminated,
+                             @consumer_heartbeat_crash
                            ]
   @consumer_process_events [@consumer_process_start, @consumer_process_stop, @consumer_process_exception]
   @consumer_events @consumer_commit_events ++ @consumer_group_events ++ @consumer_process_events
@@ -537,13 +556,19 @@ defmodule KafkaEx.Telemetry do
   and is NOT restarted (under the `one_for_all`/`max_restarts: 0` supervisor).
   Unlike a graceful `[:kafka_ex, :consumer, :leave, :stop]`, this signals an
   abnormal, operator-actionable death. `reason` is the terminal cause:
-  `:fenced_instance_id`, `:group_authorization_failed`, or `{:crashed, module}`
-  (the exception module that crashed the heartbeat).
+  `:fenced_instance_id`, `:group_authorization_failed`, `{:crashed, module}` (the
+  exception module that crashed the heartbeat), `{:error, atom}` (an unrecoverable
+  heartbeat error), `{:client_died, term}`, or `{:crash_loop, term}` (the heartbeat
+  crashed repeatedly within the window and the member gave up — see
+  `crash_rejoin_max_restarts`). The emitted metadata also carries a flat,
+  low-cardinality `terminal_class` atom derived from `reason` — tag alerts on it;
+  see the `[:kafka_ex, :consumer, :member_terminated]` module-doc entry for the
+  full mapping.
   """
   @spec emit_member_terminated(
           binary(),
           binary(),
-          atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()}
+          atom() | {:crashed, module()} | {:error, atom()} | {:client_died, term()} | {:crash_loop, term()}
         ) :: :ok
   def emit_member_terminated(group_id, member_id, reason) do
     :telemetry.execute(
@@ -552,8 +577,34 @@ defmodule KafkaEx.Telemetry do
       %{
         group_id: group_id,
         member_id: member_id,
-        reason: reason
+        reason: reason,
+        terminal_class: terminal_class(reason)
       }
+    )
+  end
+
+  defp terminal_class(:fenced_instance_id), do: :fenced
+  defp terminal_class(:group_authorization_failed), do: :auth
+  defp terminal_class({:crash_loop, _}), do: :crash_loop
+  defp terminal_class({:crashed, _}), do: :crashed
+  defp terminal_class({:error, _}), do: :error
+  defp terminal_class({:client_died, _}), do: :client_died
+  defp terminal_class(_), do: :other
+
+  @doc """
+  Emits `[:kafka_ex, :consumer, :heartbeat_crash]` on an abnormal heartbeat-crash
+  rejoin. NOT emitted on the crash that trips the budget — that surfaces as
+  `member_terminated` with `{:crash_loop, _}`. `crashes_in_window` is the count of
+  recent crashes within the bound's window, including this one — attach a rate
+  metric to spot a flapping-but-recovering member before it trips into
+  `member_terminated`.
+  """
+  @spec emit_heartbeat_crash(binary(), binary(), term(), non_neg_integer()) :: :ok
+  def emit_heartbeat_crash(group_id, member_id, reason, crashes_in_window) do
+    :telemetry.execute(
+      @consumer_heartbeat_crash,
+      %{count: 1, crashes_in_window: crashes_in_window},
+      %{group_id: group_id, member_id: member_id, reason: reason}
     )
   end
 

--- a/test/integration/consumer_group/heartbeat_crash_loop_test.exs
+++ b/test/integration/consumer_group/heartbeat_crash_loop_test.exs
@@ -1,0 +1,139 @@
+defmodule KafkaEx.Integration.ConsumerGroup.HeartbeatCrashLoopTest do
+  @moduledoc """
+  Exercises the heartbeat-crash-loop bound against the shared integration cluster
+  (start it with `./scripts/docker_up.sh`).
+
+  Repeatedly hard-kills the live Heartbeat (Process.exit/2 :kill, an abnormal
+  reason heartbeat.ex cannot catch). Each kill drives an in-place rejoin until the
+  crash count exceeds `crash_rejoin_max_restarts` within `crash_rejoin_window_ms`,
+  at which point the member STOPS terminally (emitting member_terminated with a
+  {:crash_loop, _} reason) and is torn down by the one_for_all / max_restarts: 0
+  supervisor — proving the loop is bounded, not infinite.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 120_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+    topic = "cg_hb_crash_loop_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{uris: uris, topic: topic}}
+  end
+
+  test "repeated heartbeat kills past the budget stop the member and emit member_terminated",
+       %{uris: uris, topic: topic} do
+    Process.flag(:trap_exit, true)
+    group = "cg_hb_crash_loop_grp_#{:rand.uniform(1_000_000)}"
+
+    test_pid = self()
+    handler_id = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :member_terminated],
+      fn _event, _measurements, %{group_id: ^group} = meta, _ -> send(test_pid, {:member_terminated, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    max_restarts = 2
+
+    opts = [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest,
+      crash_rejoin_max_restarts: max_restarts,
+      crash_rejoin_window_ms: 60_000,
+      crash_rejoin_max_jitter_ms: 0,
+      extra_consumer_args: %{test_pid: self()}
+    ]
+
+    {:ok, cg} = ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg) end)
+
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+
+    cg_ref = Process.monitor(cg)
+
+    # Hard-kill the live heartbeat repeatedly until the member trips terminal.
+    # Each kill drives an in-place rejoin (a fresh heartbeat pid); once crashes
+    # exceed the budget within the window the member stops and the cg goes DOWN.
+    kill_until_down(cg)
+
+    assert_receive {:member_terminated, %{reason: {:crash_loop, _}, member_id: member_id}}, 60_000
+    assert is_binary(member_id)
+
+    assert_receive {:DOWN, ^cg_ref, :process, ^cg, _}, 60_000
+    refute Process.alive?(cg)
+  end
+
+  # Generous anti-hang backstop; the real timeout is the test's assert_receive.
+  @kill_cap 600
+
+  # Repeatedly hard-kill the live heartbeat until the member trips terminal (the
+  # cg dies). Robust to the Manager being mid-rebalance: a transient nil/dead
+  # heartbeat (e.g. heartbeat_timer not yet swapped) is retried, not treated as
+  # "done", so the loop never ends early before the budget is exceeded. Stops on
+  # `Process.alive?(cg)` rather than receiving the `:DOWN` — leaving that message
+  # in the mailbox for the test's own assert_receive.
+  defp kill_until_down(cg, cap \\ @kill_cap)
+  defp kill_until_down(_cg, 0), do: :timeout
+
+  defp kill_until_down(cg, cap) do
+    if Process.alive?(cg) do
+      case live_heartbeat(cg) do
+        nil -> Process.sleep(50)
+        hb -> Process.exit(hb, :kill)
+      end
+
+      kill_until_down(cg, cap - 1)
+    else
+      :down
+    end
+  end
+
+  defp live_heartbeat(cg) do
+    case current_heartbeat(cg) do
+      hb when is_pid(hb) -> if Process.alive?(hb), do: hb, else: nil
+      _ -> nil
+    end
+  end
+
+  # NOTE: :sys.get_state has a 5s default timeout. While the Manager is mid-rebalance
+  # (a synchronous join/sync chain) it won't reply until that returns; we absorb the
+  # timeout/exit as nil and let the caller retry. Self-correcting, not a hard failure.
+  defp current_heartbeat(cg) do
+    case ConsumerGroup.get_manager_pid(cg) do
+      pid when is_pid(pid) ->
+        if Process.alive?(pid), do: :sys.get_state(pid).heartbeat_timer, else: nil
+
+      _ ->
+        nil
+    end
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_abnormal_exit_test.exs
@@ -166,7 +166,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
     test "terminal error emits the terminal cause" do
       Manager.terminate({:shutdown, {:terminal, :fenced_instance_id}}, terminate_state())
 
-      assert_receive {:member_terminated, %{count: 1}, %{group_id: "g", member_id: "m", reason: :fenced_instance_id}}
+      assert_receive {:member_terminated, %{count: 1},
+                      %{group_id: "g", member_id: "m", reason: :fenced_instance_id, terminal_class: :fenced}}
     end
 
     test "non-recoverable heartbeat {:error, _} emits {:error, _}" do
@@ -197,6 +198,146 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerAbnormalExitTest do
       Manager.terminate(:normal, terminate_state())
 
       refute_receive {:member_terminated, _, _}, 100
+    end
+
+    test "a crash-loop give-up emits {:crash_loop, _}" do
+      Manager.terminate({:shutdown, {:terminal, {:crash_loop, :killed}}}, terminate_state())
+
+      assert_receive {:member_terminated, _, %{reason: {:crash_loop, :killed}, terminal_class: :crash_loop}}
+    end
+  end
+
+  describe "heartbeat-crash-loop bound" do
+    # The bound counts abnormal heartbeat-crash rejoins in a sliding window. Past
+    # the budget the member stops terminally instead of rejoining forever. These
+    # drive the real handle_info/2 with pre-seeded crash timestamps: the trip path
+    # returns before rebalance (no client needed), while a non-tripping crash falls
+    # through to join, where the failing-join MockClient raises JoinGroupError —
+    # proving the rejoin branch ran.
+    setup do
+      {:ok, client} = MockClient.start_link(%{join_group: {:error, :illegal_generation}})
+      {:ok, sup} = Supervisor.start_link([], strategy: :one_for_one)
+      on_exit(fn -> stop_safely(client) end)
+      on_exit(fn -> stop_safely(sup) end)
+      %{client: client, sup: sup}
+    end
+
+    defp recent_times(n) do
+      now = System.monotonic_time(:millisecond)
+      List.duplicate(now, n)
+    end
+
+    defp bound_state(overrides) do
+      base = %State{
+        group_name: "g",
+        member_id: "m",
+        generation_id: 1,
+        heartbeat_timer: dead_pid(),
+        crash_rejoin_max_restarts: 3,
+        crash_rejoin_window_ms: 10_000,
+        crash_rejoin_max_jitter_ms: 0,
+        heartbeat_crash_times: []
+      }
+
+      struct!(base, overrides)
+    end
+
+    # A state wired for the rejoin path: the setup's failing-join client + a
+    # supervisor, so a non-tripping crash reaches join and raises JoinGroupError.
+    defp rejoin_state(%{client: client, sup: sup}, overrides) do
+      defaults = [
+        client: client,
+        supervisor_pid: sup,
+        topics: ["t"],
+        session_timeout: 1000,
+        session_timeout_padding: 0,
+        rebalance_timeout: 1000
+      ]
+
+      bound_state(Keyword.merge(defaults, overrides))
+    end
+
+    test "trips to a terminal stop once crashes exceed the budget within the window" do
+      timer = dead_pid()
+      state = bound_state(heartbeat_timer: timer, heartbeat_crash_times: recent_times(3))
+
+      assert {:stop, {:shutdown, {:terminal, {:crash_loop, :killed}}}, _state} =
+               Manager.handle_info({:EXIT, timer, :killed}, state)
+    end
+
+    test "appends and prunes timestamps: the tripped state carries the windowed list" do
+      timer = dead_pid()
+
+      state =
+        bound_state(heartbeat_timer: timer, crash_rejoin_max_restarts: 2, heartbeat_crash_times: recent_times(2))
+
+      assert {:stop, {:shutdown, {:terminal, {:crash_loop, :killed}}}, tripped} =
+               Manager.handle_info({:EXIT, timer, :killed}, state)
+
+      # 2 prior (recent) + this crash = 3 entries, all within the window.
+      assert length(tripped.heartbeat_crash_times) == 3
+    end
+
+    test "does not trip when crashes are spread beyond the window (they age out)", ctx do
+      timer = dead_pid()
+      old = System.monotonic_time(:millisecond) - 10_000 - 1_000
+      state = rejoin_state(ctx, heartbeat_timer: timer, heartbeat_crash_times: List.duplicate(old, 3))
+
+      # Old timestamps are pruned, so this lone crash rejoins (failing join raises)
+      # rather than tripping the bound.
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, :killed}, state)
+      end
+    end
+
+    test "does not trip while crashes stay at or below the budget", ctx do
+      timer = dead_pid()
+      state = rejoin_state(ctx, heartbeat_timer: timer, heartbeat_crash_times: recent_times(2))
+
+      # 2 prior + this one = 3 = budget (not > budget) -> rejoin.
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, :killed}, state)
+      end
+    end
+
+    test "emits heartbeat_crash on each abnormal-crash rejoin (before terminal)", ctx do
+      test_pid = self()
+      handler_id = {__MODULE__, :heartbeat_crash, make_ref()}
+
+      :telemetry.attach(
+        handler_id,
+        [:kafka_ex, :consumer, :heartbeat_crash],
+        fn _e, meas, meta, _ -> send(test_pid, {:heartbeat_crash, meas, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      timer = dead_pid()
+      state = rejoin_state(ctx, heartbeat_timer: timer, heartbeat_crash_times: recent_times(1))
+
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, :killed}, state)
+      end
+
+      # 1 prior + this crash = 2 within the window.
+      assert_received {:heartbeat_crash, %{count: 1, crashes_in_window: 2},
+                       %{group_id: "g", member_id: "m", reason: :killed}}
+    end
+
+    test "an :infinity budget never trips", ctx do
+      timer = dead_pid()
+
+      state =
+        rejoin_state(ctx,
+          heartbeat_timer: timer,
+          crash_rejoin_max_restarts: :infinity,
+          heartbeat_crash_times: recent_times(50)
+        )
+
+      assert_raise KafkaEx.JoinGroupError, fn ->
+        Manager.handle_info({:EXIT, timer, :killed}, state)
+      end
     end
   end
 end

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -180,8 +180,8 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_events()
 
       # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 1 member_terminated + 3 process = 22
-      assert length(events) == 22
+      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash + 3 process = 23
+      assert length(events) == 23
 
       # Commit events
       assert [:kafka_ex, :consumer, :commit, :start] in events
@@ -204,6 +204,7 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :consumer, :rebalance] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
       assert [:kafka_ex, :consumer, :member_terminated] in events
+      assert [:kafka_ex, :consumer, :heartbeat_crash] in events
 
       # Process events
       assert [:kafka_ex, :consumer, :process, :start] in events
@@ -217,12 +218,13 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_group_events()
 
       # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 1 member_terminated = 16
-      assert length(events) == 16
+      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash = 17
+      assert length(events) == 17
 
       assert [:kafka_ex, :consumer, :commit_failed] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
       assert [:kafka_ex, :consumer, :member_terminated] in events
+      assert [:kafka_ex, :consumer, :heartbeat_crash] in events
 
       # Group lifecycle events
       assert [:kafka_ex, :consumer, :join, :start] in events


### PR DESCRIPTION
## What & why

Bounds the abnormal heartbeat-crash rejoin loop introduced with the recovery work in #559. Today a heartbeat that keeps dying (a `:kill` storm, a deterministic process crash, sustained node memory pressure) re-loops **forever** — paced only by `heartbeat_interval` + a join/sync round-trip per cycle. The member consumes nothing, emits steady JoinGroup/SyncGroup load, and **never fires `member_terminated`**, so nobody is paged and the user's own supervision strategy never gets a say.

This adds OTP `max_restarts`/`max_seconds` semantics (aged by monotonic time) to the **abnormal-crash rejoin path only** (`Manager` clause for `{:EXIT, timer, reason}` when `heartbeat_timer == timer`). Once more than `crash_rejoin_max_restarts` crashes occur within `crash_rejoin_window_ms`, the member stops terminally and is torn down by its `one_for_all`/`max_restarts: 0` supervisor — **delegating the recovery verdict to the caller's supervisor** instead of presuming it inside KafkaEx.

### Scope

Only the abnormal-crash path is bounded. Two sibling paths stay unbounded **by design**:
- recoverable transport/coordinator errors (`{:shutdown, {:error, _}}`) — a broker outage must self-heal; giving up would turn a transient blip into a dead consumer needing a manual restart.
- protocol-driven rejoins (`{:shutdown, {:rejoin, _}}`, illegal_generation / unknown_member_id) — self-limiting once the coordinator stabilizes.

### Why windowed (not brod's counter)

brod's `max_rejoin_attempts` resets on a successful (re)join. In KafkaEx's split architecture the heartbeat is a separate `spawn_link`'d process, so join+sync keep succeeding every cycle while only the heartbeat dies — a reset-on-success counter would reset forever and never bound it. A time-windowed counter with no reset-on-success closes that gap.

## Configuration

Per-group opt → app config → default, mirroring `crash_rejoin_max_jitter_ms`:

| Knob | Default | Notes |
|---|---|---|
| `crash_rejoin_max_restarts` | `10` | `:infinity` disables the bound (loop forever, prior behavior) |
| `crash_rejoin_window_ms` | `60_000` | sliding window |

To tolerate a transient kill burst, **raise the count, not the window** — a wider window accumulates more crashes and trips more eagerly.

## Telemetry

- `member_terminated` `reason` now includes `{:crash_loop, term}` (flows through the existing `terminate/2` centralization; `@spec`/docs widened).
- New `[:kafka_ex, :consumer, :heartbeat_crash]` emitted on **each** abnormal-crash rejoin (`%{count: 1, crashes_in_window: n}`), so a flapping-but-recovering member is alertable *before* it trips terminal.

## Tests

- Unit: trip / window-math / ages-out / under-limit / `:infinity` / emit-on-rejoin — deterministic via pre-seeded crash timestamps (failing-first verified).
- Integration (`heartbeat_crash_loop_test`): hard-kills the live heartbeat past the budget → `member_terminated {:crash_loop, _}` + member teardown. An `:infinity` flip was used to regression-prove the bound (not some other teardown) is what stops the member.
- Gates: `format`, `compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0), `test.unit` (2993/0), integration green on the 3-broker cluster.

## ⚠️ Behavior change — needs CHANGELOG + UPGRADING at release

A `ConsumerGroup` started **standalone** (not under a user supervisor) that crash-loops now **stops** rather than zombie-looping forever. Users who want automatic recovery should run `ConsumerGroup` under their own supervisor (the common case) — it is then restarted fresh under their restart strategy. `crash_rejoin_max_restarts: :infinity` restores the old loop-forever behavior. Documented in the `Manager` moduledoc; CHANGELOG/UPGRADING entries to be added at release.
