### PR TITLE
feat: static consumer-group membership (KIP-345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+* **Static consumer-group membership (KIP-345).** New `:group_instance_id` option on
+  `KafkaEx.Consumer.ConsumerGroup` (resolved `opts > app-env > nil`, default off). When set, the
+  member presents a stable instance id on JoinGroup/SyncGroup/Heartbeat and **does not send
+  LeaveGroup on shutdown**, so the broker retains its partition assignment across a restart
+  (until `session.timeout.ms`) instead of rebalancing. Requires Kafka >= 2.3; a too-old broker
+  logs a warning and the consumer runs dynamically. A duplicate id is fenced
+  (`:fenced_instance_id` → terminal stop, `member_terminated{terminal_class: :fenced}`).
+
 ### Fixed
 
 * **The abnormal heartbeat-crash rejoin loop is now bounded (#560).** When a

--- a/README.md
+++ b/README.md
@@ -348,7 +348,17 @@ def start(_type, _args) do
             # Optional configuration
             commit_interval: 5_000,
             commit_threshold: 100,
-            auto_offset_reset: :earliest
+            auto_offset_reset: :earliest,
+
+            # Static membership (KIP-345, Kafka >= 2.3): retains partition
+            # assignment across restarts within session_timeout instead of
+            # rebalancing. MUST be unique per member in the group — derive
+            # from POD_NAME / hostname / StatefulSet ordinal. A duplicate id
+            # fences the loser (`:fenced_instance_id` → terminal stop,
+            # `member_terminated` telemetry with `terminal_class: :fenced`).
+            # Raise session_timeout to cover your restart/deploy window.
+            # Default: nil (dynamic membership, feature off).
+            # group_instance_id: System.get_env("POD_NAME") || node() |> to_string()
           ]
         ]
       }

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ def start(_type, _args) do
             # `member_terminated` telemetry with `terminal_class: :fenced`).
             # Raise session_timeout to cover your restart/deploy window.
             # Default: nil (dynamic membership, feature off).
-            # group_instance_id: System.get_env("POD_NAME") || node() |> to_string()
+            # group_instance_id: System.get_env("POD_NAME") || (node() |> to_string())
           ]
         ]
       }

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -290,7 +290,7 @@ Derive the id per node instead:
 
 ```elixir
 # Good: resolved at runtime, unique per pod/node
-group_instance_id: System.get_env("POD_NAME") || node() |> to_string()
+group_instance_id: System.get_env("POD_NAME") || (node() |> to_string())
 
 # Or via an MFA tuple (resolved lazily by ConsumerGroup):
 group_instance_id: {MyApp.Kafka, :instance_id, []}

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,96 @@
+# Upgrading to KafkaEx 1.1.0
+
+This section covers changes since the 1.0 release. For the 0.x → 1.0 migration,
+see **Upgrading to KafkaEx 1.0** further below.
+
+## Consumer-group heartbeat crash-loop is now bounded
+
+A consumer-group member whose heartbeat process keeps dying abnormally (an
+uncatchable `:kill`, OOM, or unstructured crash) used to rejoin **forever** —
+silent, consuming nothing, never alerting. It is now bounded: more than
+`crash_rejoin_max_restarts` such crashes within `crash_rejoin_window_ms`
+(defaults `10` / `60_000` ms) stops the member terminally and emits
+`[:kafka_ex, :consumer, :member_terminated]` with `{:crash_loop, _}`.
+
+**What you must check:**
+
+- **If you start `ConsumerGroup` under your own supervisor** (the common case,
+  and what the docs recommend), there is nothing to do — on a crash-loop trip the
+  member stops and your supervisor restarts the whole `ConsumerGroup` fresh under
+  your restart strategy. Size your supervisor's `max_restarts`/`max_seconds` to
+  absorb a correlated kill wave (e.g. a fleet-wide OOM/deploy) where many members
+  can trip at nearly the same time.
+
+- **If you start `ConsumerGroup` standalone** (not under a supervisor), a
+  crash-loop trip now **permanently stops consumption** instead of looping. Wrap
+  it in a supervisor, or set `crash_rejoin_max_restarts: :infinity` to keep the
+  unbounded rejoin (no terminal give-up):
+
+  ```elixir
+  # loop forever on abnormal heartbeat crashes (unbounded rejoin, no give-up)
+  config :kafka_ex, crash_rejoin_max_restarts: :infinity
+
+  # or per consumer group
+  KafkaEx.Consumer.ConsumerGroup.start_link(
+    MyConsumer, "my-group", ["topic"],
+    crash_rejoin_max_restarts: :infinity
+  )
+  ```
+
+To tune rather than disable, raise the restart **count** rather than widening the
+window (a wider window accumulates more crashes and trips more eagerly).
+
+## Static consumer-group membership (KIP-345)
+
+`KafkaEx.Consumer.ConsumerGroup` now supports KIP-345 static membership via a
+new `:group_instance_id` option. **This feature is entirely opt-in — default
+behavior is unchanged.**
+
+When `:group_instance_id` is set, the member presents a stable instance id on
+JoinGroup/SyncGroup/Heartbeat. The broker retains its partition assignment
+across a restart (until `session.timeout.ms`) instead of triggering a rebalance.
+In addition, **LeaveGroup is suppressed on shutdown** — this is a behavior
+change that applies **only when `:group_instance_id` is set**; dynamic members
+(the default) continue to send LeaveGroup as before.
+
+**Uniqueness is mandatory.** Each member in the group must have a distinct
+`:group_instance_id`. If two members share an id, the broker fences the later
+arrival (`:fenced_instance_id` → terminal stop, `member_terminated` telemetry
+with `terminal_class: :fenced`). Common footgun: setting a bare string in
+`config.exs` — every replica shares the same value, and all but one get fenced.
+Derive the id per node instead:
+
+```elixir
+# Good: resolved at runtime, unique per pod/node
+group_instance_id: System.get_env("POD_NAME") || (node() |> to_string())
+
+# Or via an MFA tuple (resolved lazily by ConsumerGroup):
+group_instance_id: {MyApp.Kafka, :instance_id, []}
+
+# Bad: every replica shares this string → all but one FENCED
+group_instance_id: "my-consumer"
+```
+
+**Raise `session_timeout` to cover your restart/deploy window.** While the
+assignment is held for `session.timeout.ms` after the last heartbeat, a restart
+that takes longer than this window will cause the broker to expire the session
+and rebalance anyway. The broker default is typically 45 s; set it higher if
+your deployment can take longer:
+
+```elixir
+# Per consumer group (preferred)
+KafkaEx.Consumer.ConsumerGroup.start_link(
+  MyConsumer, "my-group", ["topic"],
+  group_instance_id: System.get_env("POD_NAME"),
+  session_timeout: 120_000   # 2 minutes — cover your deploy window
+)
+```
+
+Requires Kafka >= 2.3. A too-old broker logs a warning and the consumer runs
+with dynamic membership (no error, no crash).
+
+---
+
 # Upgrading to KafkaEx 1.0
 
 ## Overview
@@ -230,92 +323,6 @@ KafkaEx.Consumer.ConsumerGroup.start_link(
   # ...
 )
 ```
-
-### Consumer-group heartbeat crash-loop is now bounded (new in 1.1.0)
-
-A consumer-group member whose heartbeat process keeps dying abnormally (an
-uncatchable `:kill`, OOM, or unstructured crash) used to rejoin **forever** —
-silent, consuming nothing, never alerting. It is now bounded: more than
-`crash_rejoin_max_restarts` such crashes within `crash_rejoin_window_ms`
-(defaults `10` / `60_000` ms) stops the member terminally and emits
-`[:kafka_ex, :consumer, :member_terminated]` with `{:crash_loop, _}`.
-
-**What you must check:**
-
-- **If you start `ConsumerGroup` under your own supervisor** (the common case,
-  and what the docs recommend), there is nothing to do — on a crash-loop trip the
-  member stops and your supervisor restarts the whole `ConsumerGroup` fresh under
-  your restart strategy. Size your supervisor's `max_restarts`/`max_seconds` to
-  absorb a correlated kill wave (e.g. a fleet-wide OOM/deploy) where many members
-  can trip at nearly the same time.
-
-- **If you start `ConsumerGroup` standalone** (not under a supervisor), a
-  crash-loop trip now **permanently stops consumption** instead of looping. Wrap
-  it in a supervisor, or set `crash_rejoin_max_restarts: :infinity` to keep the
-  unbounded rejoin (no terminal give-up):
-
-  ```elixir
-  # loop forever on abnormal heartbeat crashes (unbounded rejoin, no give-up)
-  config :kafka_ex, crash_rejoin_max_restarts: :infinity
-
-  # or per consumer group
-  KafkaEx.Consumer.ConsumerGroup.start_link(
-    MyConsumer, "my-group", ["topic"],
-    crash_rejoin_max_restarts: :infinity
-  )
-  ```
-
-To tune rather than disable, raise the restart **count** rather than widening the
-window (a wider window accumulates more crashes and trips more eagerly).
-
-### Static consumer-group membership (new in 1.1.0)
-
-`KafkaEx.Consumer.ConsumerGroup` now supports KIP-345 static membership via a
-new `:group_instance_id` option. **This feature is entirely opt-in — default
-behavior is unchanged.**
-
-When `:group_instance_id` is set, the member presents a stable instance id on
-JoinGroup/SyncGroup/Heartbeat. The broker retains its partition assignment
-across a restart (until `session.timeout.ms`) instead of triggering a rebalance.
-In addition, **LeaveGroup is suppressed on shutdown** — this is a behavior
-change that applies **only when `:group_instance_id` is set**; dynamic members
-(the default) continue to send LeaveGroup as before.
-
-**Uniqueness is mandatory.** Each member in the group must have a distinct
-`:group_instance_id`. If two members share an id, the broker fences the later
-arrival (`:fenced_instance_id` → terminal stop, `member_terminated` telemetry
-with `terminal_class: :fenced`). Common footgun: setting a bare string in
-`config.exs` — every replica shares the same value, and all but one get fenced.
-Derive the id per node instead:
-
-```elixir
-# Good: resolved at runtime, unique per pod/node
-group_instance_id: System.get_env("POD_NAME") || (node() |> to_string())
-
-# Or via an MFA tuple (resolved lazily by ConsumerGroup):
-group_instance_id: {MyApp.Kafka, :instance_id, []}
-
-# Bad: every replica shares this string → all but one FENCED
-group_instance_id: "my-consumer"
-```
-
-**Raise `session_timeout` to cover your restart/deploy window.** While the
-assignment is held for `session.timeout.ms` after the last heartbeat, a restart
-that takes longer than this window will cause the broker to expire the session
-and rebalance anyway. The broker default is typically 45 s; set it higher if
-your deployment can take longer:
-
-```elixir
-# Per consumer group (preferred)
-KafkaEx.Consumer.ConsumerGroup.start_link(
-  MyConsumer, "my-group", ["topic"],
-  group_instance_id: System.get_env("POD_NAME"),
-  session_timeout: 120_000   # 2 minutes — cover your deploy window
-)
-```
-
-Requires Kafka >= 2.3. A too-old broker logs a warning and the consumer runs
-with dynamic membership (no error, no crash).
 
 ### `KafkaEx.API.start_client()` is now unnamed by default
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -268,6 +268,55 @@ silent, consuming nothing, never alerting. It is now bounded: more than
 To tune rather than disable, raise the restart **count** rather than widening the
 window (a wider window accumulates more crashes and trips more eagerly).
 
+### Static consumer-group membership (new in 1.1.0)
+
+`KafkaEx.Consumer.ConsumerGroup` now supports KIP-345 static membership via a
+new `:group_instance_id` option. **This feature is entirely opt-in — default
+behavior is unchanged.**
+
+When `:group_instance_id` is set, the member presents a stable instance id on
+JoinGroup/SyncGroup/Heartbeat. The broker retains its partition assignment
+across a restart (until `session.timeout.ms`) instead of triggering a rebalance.
+In addition, **LeaveGroup is suppressed on shutdown** — this is a behavior
+change that applies **only when `:group_instance_id` is set**; dynamic members
+(the default) continue to send LeaveGroup as before.
+
+**Uniqueness is mandatory.** Each member in the group must have a distinct
+`:group_instance_id`. If two members share an id, the broker fences the later
+arrival (`:fenced_instance_id` → terminal stop, `member_terminated` telemetry
+with `terminal_class: :fenced`). Common footgun: setting a bare string in
+`config.exs` — every replica shares the same value, and all but one get fenced.
+Derive the id per node instead:
+
+```elixir
+# Good: resolved at runtime, unique per pod/node
+group_instance_id: System.get_env("POD_NAME") || node() |> to_string()
+
+# Or via an MFA tuple (resolved lazily by ConsumerGroup):
+group_instance_id: {MyApp.Kafka, :instance_id, []}
+
+# Bad: every replica shares this string → all but one FENCED
+group_instance_id: "my-consumer"
+```
+
+**Raise `session_timeout` to cover your restart/deploy window.** While the
+assignment is held for `session.timeout.ms` after the last heartbeat, a restart
+that takes longer than this window will cause the broker to expire the session
+and rebalance anyway. The broker default is typically 45 s; set it higher if
+your deployment can take longer:
+
+```elixir
+# Per consumer group (preferred)
+KafkaEx.Consumer.ConsumerGroup.start_link(
+  MyConsumer, "my-group", ["topic"],
+  group_instance_id: System.get_env("POD_NAME"),
+  session_timeout: 120_000   # 2 minutes — cover your deploy window
+)
+```
+
+Requires Kafka >= 2.3. A too-old broker logs a warning and the consumer runs
+with dynamic membership (no error, no crash).
+
 ### `KafkaEx.API.start_client()` is now unnamed by default
 
 Pre-v1.0 patch — and the v1.0 release prior to this fix — `start_client()`

--- a/config/config.exs
+++ b/config/config.exs
@@ -91,6 +91,21 @@ config :kafka_ex,
   # restarts / 60_000 ms.
   # crash_rejoin_max_restarts: 10,
   # crash_rejoin_window_ms: 60000,
+  #
+  # Static consumer-group membership (KIP-345). Set a STABLE, per-member-UNIQUE
+  # `group_instance_id` so a member retains its partition assignment across a
+  # restart instead of triggering a rebalance (the broker holds the assignment
+  # until `session.timeout.ms`). Default: unset (dynamic membership).
+  #
+  # The value MUST be unique per member in the group — derive it per node
+  # (e.g. from POD_NAME / hostname / StatefulSet ordinal). A duplicate id gets
+  # the loser FENCED (`:fenced_instance_id` → terminal stop). A bare string here
+  # is shared by every replica and is almost always WRONG; prefer an MFA tuple
+  # or a zero-arity function that resolves a per-node value, or set it per
+  # consumer group via the `:group_instance_id` start option.
+  # Requires Kafka >= 2.3 and a session_timeout long enough to cover a restart.
+  # group_instance_id: {MyApp.Kafka, :instance_id, []},
+  #
   # API versions for Kafka protocol requests.
   # By default, KafkaEx uses the highest version supported by both the
   # connected broker and the protocol library. Use this config to pin

--- a/lib/kafka_ex/client/request_builder.ex
+++ b/lib/kafka_ex/client/request_builder.ex
@@ -99,8 +99,14 @@ defmodule KafkaEx.Client.RequestBuilder do
         group_id = Keyword.fetch!(request_opts, :group_id)
         member_id = Keyword.fetch!(request_opts, :member_id)
         generation_id = Keyword.fetch!(request_opts, :generation_id)
+        group_instance_id = Keyword.get(request_opts, :group_instance_id)
 
-        opts = [group_id: group_id, member_id: member_id, generation_id: generation_id]
+        opts = [
+          group_id: group_id,
+          member_id: member_id,
+          generation_id: generation_id,
+          group_instance_id: group_instance_id
+        ]
 
         req = @protocol.build_request(:heartbeat, api_version, opts)
         {:ok, req}
@@ -169,12 +175,14 @@ defmodule KafkaEx.Client.RequestBuilder do
         generation_id = Keyword.fetch!(request_opts, :generation_id)
         member_id = Keyword.fetch!(request_opts, :member_id)
         group_assignment = Keyword.get(request_opts, :group_assignment, [])
+        group_instance_id = Keyword.get(request_opts, :group_instance_id)
 
         opts = [
           group_id: group_id,
           generation_id: generation_id,
           member_id: member_id,
-          group_assignment: group_assignment
+          group_assignment: group_assignment,
+          group_instance_id: group_instance_id
         ]
 
         req = @protocol.build_request(:sync_group, api_version, opts)

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -233,6 +233,37 @@ defmodule KafkaEx.Config do
     raise ArgumentError, "invalid auto_offset_reset #{inspect(value)}; expected :none, :earliest, or :latest"
   end
 
+  @doc """
+  Resolves a configured `group_instance_id` value. Accepts a binary, `nil`, a
+  zero-arity function, or an `{module, function, args}` tuple (the latter two let
+  app-env supply a per-node-unique id at runtime, mirroring `:brokers`).
+  """
+  @spec resolve_group_instance_id(term()) :: term()
+  def resolve_group_instance_id({mod, fun, args}) when is_atom(mod) and is_atom(fun), do: apply(mod, fun, args)
+  def resolve_group_instance_id(fun) when is_function(fun, 0), do: fun.()
+  def resolve_group_instance_id(value), do: value
+
+  @doc """
+  Validates a resolved `group_instance_id`, returning it unchanged when valid and
+  raising `ArgumentError` otherwise. `nil` means static membership is off; any
+  other value must be a non-empty (non-whitespace) binary. Called at consumer-group
+  start so a misconfigured id fails fast.
+  """
+  @spec validate_group_instance_id!(term()) :: binary() | nil
+  def validate_group_instance_id!(nil), do: nil
+
+  def validate_group_instance_id!(value) when is_binary(value) do
+    if String.trim(value) == "" do
+      raise ArgumentError, "group_instance_id must be a non-empty string; got #{inspect(value)}"
+    end
+
+    value
+  end
+
+  def validate_group_instance_id!(value) do
+    raise ArgumentError, "group_instance_id must be a binary or nil; got #{inspect(value)}"
+  end
+
   # Broker normalization helpers
 
   defp normalize_brokers(nil), do: nil

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -234,25 +234,28 @@ defmodule KafkaEx.Config do
   end
 
   @doc """
-  Resolves a configured `group_instance_id` value. Accepts a binary, `nil`, a
-  zero-arity function, or an `{module, function, args}` tuple (the latter two let
-  app-env supply a per-node-unique id at runtime, mirroring `:brokers`).
-  """
-  @spec resolve_group_instance_id(term()) :: term()
-  def resolve_group_instance_id({mod, fun, args}) when is_atom(mod) and is_atom(fun), do: apply(mod, fun, args)
-  def resolve_group_instance_id(fun) when is_function(fun, 0), do: fun.()
-  def resolve_group_instance_id(value), do: value
+  Resolves and validates a configured `group_instance_id`.
 
-  @doc """
-  Validates a resolved `group_instance_id`, returning it unchanged when valid and
-  raising `ArgumentError` otherwise. `nil` means static membership is off; any
-  other value must be a non-empty (non-whitespace) binary. Called at consumer-group
-  start so a misconfigured id fails fast.
+  Accepts `nil` (static membership off), a non-empty binary, a zero-arity
+  function, or an `{module, function, args}` tuple (the last two let app-env
+  supply a per-node-unique id at runtime, mirroring `:brokers`). The resolved
+  value must be `nil` or a non-empty binary, otherwise raises `ArgumentError` —
+  so a misconfigured id fails fast at consumer-group start.
   """
-  @spec validate_group_instance_id!(term()) :: binary() | nil
-  def validate_group_instance_id!(nil), do: nil
+  @spec resolve_group_instance_id(term()) :: binary() | nil
+  def resolve_group_instance_id({mod, fun, args}) when is_atom(mod) and is_atom(fun) do
+    mod |> apply(fun, args) |> validate_group_instance_id()
+  end
 
-  def validate_group_instance_id!(value) when is_binary(value) do
+  def resolve_group_instance_id(fun) when is_function(fun, 0) do
+    fun.() |> validate_group_instance_id()
+  end
+
+  def resolve_group_instance_id(value), do: validate_group_instance_id(value)
+
+  defp validate_group_instance_id(nil), do: nil
+
+  defp validate_group_instance_id(value) when is_binary(value) do
     if String.trim(value) == "" do
       raise ArgumentError, "group_instance_id must be a non-empty string; got #{inspect(value)}"
     end
@@ -260,7 +263,7 @@ defmodule KafkaEx.Config do
     value
   end
 
-  def validate_group_instance_id!(value) do
+  defp validate_group_instance_id(value) do
     raise ArgumentError, "group_instance_id must be a binary or nil; got #{inspect(value)}"
   end
 

--- a/lib/kafka_ex/consumer/consumer_group.ex
+++ b/lib/kafka_ex/consumer/consumer_group.ex
@@ -136,6 +136,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
           | {:max_restarts, non_neg_integer}
           | {:max_seconds, non_neg_integer}
           | {:uris, KafkaEx.uri()}
+          | {:group_instance_id, binary | nil}
 
   @type options :: [option]
 

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -37,14 +37,15 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
 
   defmodule State do
     @moduledoc false
-    defstruct [:client, :group_name, :member_id, :generation_id, :heartbeat_interval]
+    defstruct [:client, :group_name, :member_id, :generation_id, :heartbeat_interval, :group_instance_id]
 
     @type t :: %__MODULE__{
             client: pid(),
             group_name: binary(),
             member_id: binary(),
             generation_id: integer(),
-            heartbeat_interval: pos_integer()
+            heartbeat_interval: pos_integer(),
+            group_instance_id: binary() | nil
           }
   end
 
@@ -57,14 +58,16 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
         member_id: member_id,
         generation_id: generation_id,
         client: client,
-        heartbeat_interval: heartbeat_interval
+        heartbeat_interval: heartbeat_interval,
+        group_instance_id: group_instance_id
       }) do
     state = %State{
       client: client,
       group_name: group_name,
       member_id: member_id,
       generation_id: generation_id,
-      heartbeat_interval: heartbeat_interval
+      heartbeat_interval: heartbeat_interval,
+      group_instance_id: group_instance_id
     }
 
     {:ok, state, state.heartbeat_interval}
@@ -77,10 +80,11 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
           group_name: group_name,
           member_id: member_id,
           generation_id: generation_id,
-          heartbeat_interval: heartbeat_interval
+          heartbeat_interval: heartbeat_interval,
+          group_instance_id: group_instance_id
         } = state
       ) do
-    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id) do
+    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id, group_instance_id: group_instance_id) do
       {:ok, %KafkaEx.Messages.Heartbeat{}} ->
         {:noreply, state, heartbeat_interval}
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -557,7 +557,16 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   def terminate(reason, %State{} = state) do
     emit_termination_telemetry(reason, state)
-    {:ok, _state} = leave(state)
+
+    if is_nil(state.group_instance_id) do
+      {:ok, _state} = leave(state)
+    else
+      Logger.debug(
+        "Static member (group_instance_id=#{inspect(state.group_instance_id)}); skipping LeaveGroup " <>
+          "so the broker retains the assignment until session timeout"
+      )
+    end
+
     Process.unlink(state.client)
     GenServer.stop(state.client, :normal)
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -217,7 +217,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       opts
       |> get_with_default(:group_instance_id, nil)
       |> Config.resolve_group_instance_id()
-      |> Config.validate_group_instance_id!()
 
     partition_assignment_callback =
       Keyword.get(opts, :partition_assignment_callback, &PartitionAssignment.round_robin/2)

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -612,7 +612,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
            rebalance_timeout: rebalance_timeout,
            group_name: group_name,
            topics: topics,
-           member_id: member_id
+           member_id: member_id,
+           group_instance_id: group_instance_id
          } = state,
          attempt_number
        ) do
@@ -620,7 +621,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       topics: topics,
       session_timeout: session_timeout,
       rebalance_timeout: rebalance_timeout,
-      timeout: session_timeout + session_timeout_padding
+      timeout: session_timeout + session_timeout_padding,
+      group_instance_id: group_instance_id
     ]
 
     join_response = KafkaExAPI.join_group(client, group_name, member_id || "", opts)
@@ -723,6 +725,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
            group_name: group_name,
            member_id: member_id,
            generation_id: generation_id,
+           group_instance_id: group_instance_id,
            session_timeout: session_timeout,
            session_timeout_padding: session_timeout_padding
          } = state,
@@ -730,7 +733,12 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
        ) do
     # Convert assignments to protocol-agnostic format (protocol layer handles Kayrock conversion)
     group_assignment = format_assignments_for_sync_group(assignments)
-    opts = [group_assignment: group_assignment, timeout: session_timeout + session_timeout_padding]
+
+    opts = [
+      group_assignment: group_assignment,
+      timeout: session_timeout + session_timeout_padding,
+      group_instance_id: group_instance_id
+    ]
 
     case KafkaExAPI.sync_group(client, group_name, generation_id, member_id, opts) do
       {:ok, sync_response} ->

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -260,6 +260,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
     case client_result do
       {:ok, client} ->
+        maybe_warn_static_membership_unsupported(client, group_instance_id)
+
         state = %State{
           supervisor_pid: supervisor_pid,
           client: client,
@@ -1057,4 +1059,30 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   defp recoverable_error?(:not_connected), do: true
   defp recoverable_error?(:unknown), do: true
   defp recoverable_error?(_), do: false
+
+  defp maybe_warn_static_membership_unsupported(_client, nil), do: :ok
+
+  defp maybe_warn_static_membership_unsupported(client, _group_instance_id) do
+    case KafkaExAPI.api_versions(client) do
+      {:ok, %KafkaEx.Messages.ApiVersions{} = versions} ->
+        case KafkaEx.Messages.ApiVersions.max_version_for_api(versions, 11) do
+          {:ok, max_version} when max_version >= 5 ->
+            :ok
+
+          _ ->
+            Logger.warning(
+              "group_instance_id is set but the broker does not support JoinGroup v5+ " <>
+                "(requires Kafka 2.3+); static membership (KIP-345) will not take effect and " <>
+                "the consumer will join as a dynamic member"
+            )
+        end
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
 end

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -80,6 +80,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   alias KafkaEx.Consumer.ConsumerGroup
   alias KafkaEx.Consumer.ConsumerGroup.Heartbeat
   alias KafkaEx.Consumer.ConsumerGroup.PartitionAssignment
+  alias KafkaEx.Messages.ApiVersions
   alias KafkaEx.Telemetry
   require Logger
 
@@ -1064,8 +1065,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   defp maybe_warn_static_membership_unsupported(client, _group_instance_id) do
     case KafkaExAPI.api_versions(client) do
-      {:ok, %KafkaEx.Messages.ApiVersions{} = versions} ->
-        case KafkaEx.Messages.ApiVersions.max_version_for_api(versions, 11) do
+      {:ok, %ApiVersions{} = versions} ->
+        case ApiVersions.max_version_for_api(versions, 11) do
           {:ok, max_version} when max_version >= 5 ->
             :ok
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -109,6 +109,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       :crash_rejoin_max_jitter_ms,
       :crash_rejoin_max_restarts,
       :crash_rejoin_window_ms,
+      :group_instance_id,
       sync_failures: 0,
       heartbeat_crash_times: []
     ]
@@ -137,6 +138,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
             crash_rejoin_max_jitter_ms: non_neg_integer() | nil,
             crash_rejoin_max_restarts: non_neg_integer() | :infinity | nil,
             crash_rejoin_window_ms: non_neg_integer() | nil,
+            group_instance_id: binary() | nil,
             sync_failures: non_neg_integer(),
             heartbeat_crash_times: [integer()]
           }
@@ -210,6 +212,12 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     crash_rejoin_max_restarts = get_with_default(opts, :crash_rejoin_max_restarts, @crash_rejoin_max_restarts)
     crash_rejoin_window_ms = get_with_default(opts, :crash_rejoin_window_ms, @crash_rejoin_window_ms)
 
+    group_instance_id =
+      opts
+      |> get_with_default(:group_instance_id, nil)
+      |> Config.resolve_group_instance_id()
+      |> Config.validate_group_instance_id!()
+
     partition_assignment_callback =
       Keyword.get(opts, :partition_assignment_callback, &PartitionAssignment.round_robin/2)
 
@@ -227,7 +235,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         :sync_retry_backoff_ms,
         :crash_rejoin_max_jitter_ms,
         :crash_rejoin_max_restarts,
-        :crash_rejoin_window_ms
+        :crash_rejoin_window_ms,
+        :group_instance_id
       ])
 
     # Use Config defaults for connection options if not provided
@@ -268,7 +277,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           sync_retry_backoff_ms: sync_retry_backoff_ms,
           crash_rejoin_max_jitter_ms: crash_rejoin_max_jitter_ms,
           crash_rejoin_max_restarts: crash_rejoin_max_restarts,
-          crash_rejoin_window_ms: crash_rejoin_window_ms
+          crash_rejoin_window_ms: crash_rejoin_window_ms,
+          group_instance_id: group_instance_id
         }
 
         Process.flag(:trap_exit, true)

--- a/test/integration/consumer_group/static_membership_test.exs
+++ b/test/integration/consumer_group/static_membership_test.exs
@@ -1,0 +1,108 @@
+defmodule KafkaEx.Integration.ConsumerGroup.StaticMembershipTest do
+  @moduledoc """
+  KIP-345 static membership against the shared integration cluster
+  (start it with `./scripts/docker_up.sh`).
+
+  A static member (group_instance_id set) keeps its partition assignment across
+  a graceful restart within session_timeout — the broker does NOT rebalance, so
+  the generation is unchanged. The broker may issue a fresh member_id when the
+  restarted process rejoins with an empty member_id; the preserved invariant is
+  the assignment/generation (no rebalance), not member_id identity. The dynamic
+  control proves the retention is caused by static membership: without
+  group_instance_id the graceful stop sends LeaveGroup and the restart advances
+  the generation.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :consumer_group
+  @moduletag timeout: 120_000
+
+  import KafkaEx.IntegrationHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.Consumer.ConsumerGroup
+  alias KafkaEx.TestSupport.ConsumerGroupHelpers
+  alias KafkaEx.TestSupport.ProcessHelpers
+  alias KafkaEx.TestSupport.TestGenConsumer
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    uris = Keyword.fetch!(args, :uris)
+
+    {:ok, client} = Client.start_link(args, :no_name)
+    on_exit(fn -> ProcessHelpers.stop_safely(client) end)
+
+    topic = "cg_static_#{:rand.uniform(1_000_000)}"
+    create_topic(client, topic, partitions: 1)
+    wait_for_topic_in_metadata(client, topic)
+
+    {:ok, %{uris: uris, topic: topic}}
+  end
+
+  defp base_opts(uris) do
+    [
+      uris: uris,
+      heartbeat_interval: 1_000,
+      session_timeout: 30_000,
+      commit_interval: 1_000,
+      auto_offset_reset: :earliest
+    ]
+  end
+
+  defp start_active(group, topic, opts) do
+    {:ok, cg} = ConsumerGroup.start_link(TestGenConsumer, group, [topic], opts)
+    assert {:ok, :active} = ConsumerGroupHelpers.wait_for_active(cg, timeout: 60_000)
+    assert {:ok, _} = ConsumerGroupHelpers.wait_for_assignments(cg, timeout: 30_000)
+    cg
+  end
+
+  test "a static member keeps its assignment and member_id across a restart (no rebalance)",
+       %{uris: uris, topic: topic} do
+    group = "cg_static_grp_#{:rand.uniform(1_000_000)}"
+    opts = Keyword.put(base_opts(uris), :group_instance_id, "inst-1")
+
+    cg1 = start_active(group, topic, opts)
+    gen0 = ConsumerGroup.generation_id(cg1)
+    member0 = ConsumerGroup.member_id(cg1)
+    assert is_integer(gen0) and is_binary(member0) and member0 != ""
+
+    # Graceful stop: a static member does NOT send LeaveGroup, so the broker
+    # holds the assignment until session_timeout.
+    ConsumerGroupHelpers.stop_consumer_group(cg1)
+
+    # Restart with the SAME instance id, well within session_timeout.
+    cg2 = start_active(group, topic, opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg2) end)
+
+    # KIP-345 preserves the ASSIGNMENT and GENERATION (no rebalance), not
+    # member_id identity: a process restarting with an empty member_id is
+    # recognized via group_instance_id and keeps the assignment, but the broker
+    # (Kafka 3.1.0) issues a fresh member_id. The generation staying put is the
+    # proof no rebalance occurred.
+    assert ConsumerGroup.generation_id(cg2) == gen0,
+           "a static rejoin within session_timeout must NOT trigger a rebalance"
+
+    member2 = ConsumerGroup.member_id(cg2)
+
+    assert is_binary(member2) and member2 != "",
+           "the rejoined static member must still hold a valid member_id"
+  end
+
+  test "a dynamic member triggers a rebalance across a restart (negative control)",
+       %{uris: uris, topic: topic} do
+    group = "cg_dynamic_grp_#{:rand.uniform(1_000_000)}"
+    opts = base_opts(uris)
+
+    cg1 = start_active(group, topic, opts)
+    gen0 = ConsumerGroup.generation_id(cg1)
+
+    # Graceful stop: a dynamic member sends LeaveGroup -> rebalance.
+    ConsumerGroupHelpers.stop_consumer_group(cg1)
+
+    cg2 = start_active(group, topic, opts)
+    on_exit(fn -> ConsumerGroupHelpers.stop_consumer_group(cg2) end)
+
+    assert ConsumerGroup.generation_id(cg2) > gen0,
+           "a dynamic restart must advance the generation (rebalance occurred)"
+  end
+end

--- a/test/integration/consumer_group/static_membership_test.exs
+++ b/test/integration/consumer_group/static_membership_test.exs
@@ -56,7 +56,7 @@ defmodule KafkaEx.Integration.ConsumerGroup.StaticMembershipTest do
     cg
   end
 
-  test "a static member keeps its assignment and member_id across a restart (no rebalance)",
+  test "a static member keeps its assignment and generation across a restart (no rebalance)",
        %{uris: uris, topic: topic} do
     group = "cg_static_grp_#{:rand.uniform(1_000_000)}"
     opts = Keyword.put(base_opts(uris), :group_instance_id, "inst-1")

--- a/test/kafka_ex/client/request_builder_test.exs
+++ b/test/kafka_ex/client/request_builder_test.exs
@@ -1299,6 +1299,53 @@ defmodule KafkaEx.Client.RequestBuilderTest do
     end
   end
 
+  describe "group_instance_id (KIP-345)" do
+    test "heartbeat_request carries group_instance_id on V3+" do
+      state = %KafkaEx.Client.State{api_versions: %{12 => {0, 3}}}
+
+      {:ok, request} =
+        RequestBuilder.heartbeat_request(
+          [group_id: "g", member_id: "m", generation_id: 1, group_instance_id: "inst-1"],
+          state
+        )
+
+      assert request.group_instance_id == "inst-1"
+    end
+
+    test "heartbeat_request leaves group_instance_id nil when not provided" do
+      state = %KafkaEx.Client.State{api_versions: %{12 => {0, 3}}}
+
+      {:ok, request} =
+        RequestBuilder.heartbeat_request([group_id: "g", member_id: "m", generation_id: 1], state)
+
+      assert request.group_instance_id == nil
+    end
+
+    test "sync_group_request carries group_instance_id on V3+" do
+      state = %KafkaEx.Client.State{api_versions: %{14 => {0, 3}}}
+
+      {:ok, request} =
+        RequestBuilder.sync_group_request(
+          [group_id: "g", generation_id: 1, member_id: "m", group_assignment: [], group_instance_id: "inst-1"],
+          state
+        )
+
+      assert request.group_instance_id == "inst-1"
+    end
+
+    test "sync_group_request leaves group_instance_id nil when not provided" do
+      state = %KafkaEx.Client.State{api_versions: %{14 => {0, 3}}}
+
+      {:ok, request} =
+        RequestBuilder.sync_group_request(
+          [group_id: "g", generation_id: 1, member_id: "m", group_assignment: []],
+          state
+        )
+
+      assert request.group_instance_id == nil
+    end
+  end
+
   describe "produce_request/2" do
     test "returns request for Produce API v3 (default)" do
       state = %KafkaEx.Client.State{api_versions: %{0 => {0, 3}}}

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -269,49 +269,45 @@ defmodule KafkaEx.ConfigTest do
     end
   end
 
-  describe "validate_group_instance_id!/1" do
+  describe "resolve_group_instance_id/1" do
     test "nil is allowed (static membership off)" do
-      assert KafkaEx.Config.validate_group_instance_id!(nil) == nil
+      assert KafkaEx.Config.resolve_group_instance_id(nil) == nil
     end
 
     test "a non-empty binary is returned unchanged" do
-      assert KafkaEx.Config.validate_group_instance_id!("inst-1") == "inst-1"
+      assert KafkaEx.Config.resolve_group_instance_id("inst-1") == "inst-1"
+    end
+
+    test "calls a zero-arity function and validates the result" do
+      assert KafkaEx.Config.resolve_group_instance_id(fn -> "from-fun" end) == "from-fun"
+    end
+
+    test "applies an MFA tuple and validates the result" do
+      assert KafkaEx.Config.resolve_group_instance_id({String, :upcase, ["inst-1"]}) == "INST-1"
     end
 
     test "an empty string raises" do
       assert_raise ArgumentError, ~r/non-empty/, fn ->
-        KafkaEx.Config.validate_group_instance_id!("")
+        KafkaEx.Config.resolve_group_instance_id("")
       end
     end
 
     test "a whitespace-only string raises" do
       assert_raise ArgumentError, ~r/non-empty/, fn ->
-        KafkaEx.Config.validate_group_instance_id!("   ")
+        KafkaEx.Config.resolve_group_instance_id("   ")
       end
     end
 
     test "a non-binary raises" do
       assert_raise ArgumentError, ~r/binary or nil/, fn ->
-        KafkaEx.Config.validate_group_instance_id!(123)
+        KafkaEx.Config.resolve_group_instance_id(123)
       end
     end
-  end
 
-  describe "resolve_group_instance_id/1" do
-    test "passes a binary through" do
-      assert KafkaEx.Config.resolve_group_instance_id("inst-1") == "inst-1"
-    end
-
-    test "passes nil through" do
-      assert KafkaEx.Config.resolve_group_instance_id(nil) == nil
-    end
-
-    test "calls a zero-arity function" do
-      assert KafkaEx.Config.resolve_group_instance_id(fn -> "from-fun" end) == "from-fun"
-    end
-
-    test "applies an MFA tuple" do
-      assert KafkaEx.Config.resolve_group_instance_id({String, :upcase, ["inst-1"]}) == "INST-1"
+    test "validates the value produced by a function (blank result raises)" do
+      assert_raise ArgumentError, ~r/non-empty/, fn ->
+        KafkaEx.Config.resolve_group_instance_id(fn -> "" end)
+      end
     end
   end
 

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -269,6 +269,52 @@ defmodule KafkaEx.ConfigTest do
     end
   end
 
+  describe "validate_group_instance_id!/1" do
+    test "nil is allowed (static membership off)" do
+      assert KafkaEx.Config.validate_group_instance_id!(nil) == nil
+    end
+
+    test "a non-empty binary is returned unchanged" do
+      assert KafkaEx.Config.validate_group_instance_id!("inst-1") == "inst-1"
+    end
+
+    test "an empty string raises" do
+      assert_raise ArgumentError, ~r/non-empty/, fn ->
+        KafkaEx.Config.validate_group_instance_id!("")
+      end
+    end
+
+    test "a whitespace-only string raises" do
+      assert_raise ArgumentError, ~r/non-empty/, fn ->
+        KafkaEx.Config.validate_group_instance_id!("   ")
+      end
+    end
+
+    test "a non-binary raises" do
+      assert_raise ArgumentError, ~r/binary or nil/, fn ->
+        KafkaEx.Config.validate_group_instance_id!(123)
+      end
+    end
+  end
+
+  describe "resolve_group_instance_id/1" do
+    test "passes a binary through" do
+      assert KafkaEx.Config.resolve_group_instance_id("inst-1") == "inst-1"
+    end
+
+    test "passes nil through" do
+      assert KafkaEx.Config.resolve_group_instance_id(nil) == nil
+    end
+
+    test "calls a zero-arity function" do
+      assert KafkaEx.Config.resolve_group_instance_id(fn -> "from-fun" end) == "from-fun"
+    end
+
+    test "applies an MFA tuple" do
+      assert KafkaEx.Config.resolve_group_instance_id({String, :upcase, ["inst-1"]}) == "INST-1"
+    end
+  end
+
   def get_brokers(opts) do
     port = Keyword.get(opts, :port)
 

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -25,6 +25,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
       assert state.generation_id == 1
       assert state.client == client
       assert state.heartbeat_interval == 5000
+      assert state.group_instance_id == nil
       assert timeout == 5000
     end
   end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -14,7 +14,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
         member_id: "member-1",
         generation_id: 1,
         client: client,
-        heartbeat_interval: 5000
+        heartbeat_interval: 5000,
+        group_instance_id: nil
       }
 
       {:ok, state, timeout} = Heartbeat.init(init_args)

--- a/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
@@ -1,0 +1,55 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
+  @moduledoc """
+  KIP-345 static membership wiring through the Manager: option resolution/
+  validation, group_instance_id threaded into join/sync/heartbeat, LeaveGroup
+  suppression on terminate, and the too-old-broker warning. Exercised through
+  public behavior only; no private function is exposed for testing.
+  """
+  use ExUnit.Case, async: false
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Consumer.ConsumerGroup.Manager
+  alias KafkaEx.Consumer.ConsumerGroup.Manager.State
+
+  describe "init/1 group_instance_id resolution" do
+    test "a valid group_instance_id opt is stored on the State" do
+      {:ok, client} = KafkaEx.Test.MockClient.start_link(%{})
+      on_exit(fn -> stop_safely(client) end)
+
+      opts = [supervisor_pid: self(), client: client, group_instance_id: "inst-1"]
+
+      {:ok, state, _timeout} =
+        Manager.init({{KafkaEx.GenConsumer, __MODULE__.NoopConsumer}, "g", ["t"], opts})
+
+      assert %State{group_instance_id: "inst-1"} = state
+    end
+
+    test "no group_instance_id opt leaves it nil (dynamic membership)" do
+      {:ok, client} = KafkaEx.Test.MockClient.start_link(%{})
+      on_exit(fn -> stop_safely(client) end)
+
+      opts = [supervisor_pid: self(), client: client]
+
+      {:ok, state, _timeout} =
+        Manager.init({{KafkaEx.GenConsumer, __MODULE__.NoopConsumer}, "g", ["t"], opts})
+
+      assert %State{group_instance_id: nil} = state
+    end
+
+    test "a blank group_instance_id opt raises ArgumentError" do
+      {:ok, client} = KafkaEx.Test.MockClient.start_link(%{})
+      on_exit(fn -> stop_safely(client) end)
+
+      opts = [supervisor_pid: self(), client: client, group_instance_id: ""]
+
+      assert_raise ArgumentError, ~r/non-empty/, fn ->
+        Manager.init({{KafkaEx.GenConsumer, __MODULE__.NoopConsumer}, "g", ["t"], opts})
+      end
+    end
+  end
+
+  defmodule NoopConsumer do
+    @moduledoc false
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
@@ -2,31 +2,45 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMo
   @moduledoc false
   # Records the full opts of join/sync/heartbeat/leave so tests can assert
   # group_instance_id was threaded through. Returns benign success responses.
+  # Sends {:captured_calls, calls} to watcher (if set) on terminate, so tests
+  # can read the call list even after Manager.terminate/2 stops the client.
   use GenServer
 
   def start_link, do: GenServer.start_link(__MODULE__, nil)
   def calls(pid), do: GenServer.call(pid, :calls)
+  def set_watcher(pid, watcher), do: GenServer.call(pid, {:set_watcher, watcher})
 
-  def init(_), do: {:ok, []}
-  def handle_call(:calls, _from, calls), do: {:reply, Enum.reverse(calls), calls}
+  def init(_), do: {:ok, {[], nil}}
 
-  def handle_call({:join_group, group, member_id, opts}, _from, calls) do
+  def handle_call(:calls, _from, {calls, watcher}),
+    do: {:reply, Enum.reverse(calls), {calls, watcher}}
+
+  def handle_call({:set_watcher, watcher}, _from, {calls, _}),
+    do: {:reply, :ok, {calls, watcher}}
+
+  def handle_call({:join_group, group, member_id, opts}, _from, {calls, watcher}) do
     resp = {:ok, %KafkaEx.Messages.JoinGroup{generation_id: 1, member_id: "m", leader_id: "x", members: []}}
-    {:reply, resp, [{:join_group, group, member_id, opts} | calls]}
+    {:reply, resp, {[{:join_group, group, member_id, opts} | calls], watcher}}
   end
 
-  def handle_call({:sync_group, group, gen, member_id, opts}, _from, calls) do
+  def handle_call({:sync_group, group, gen, member_id, opts}, _from, {calls, watcher}) do
     resp = {:ok, %KafkaEx.Messages.SyncGroup{partition_assignments: []}}
-    {:reply, resp, [{:sync_group, group, gen, member_id, opts} | calls]}
+    {:reply, resp, {[{:sync_group, group, gen, member_id, opts} | calls], watcher}}
   end
 
-  def handle_call({:heartbeat, group, member_id, gen, opts}, _from, calls) do
-    {:reply, {:ok, %KafkaEx.Messages.Heartbeat{}}, [{:heartbeat, group, member_id, gen, opts} | calls]}
+  def handle_call({:heartbeat, group, member_id, gen, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %KafkaEx.Messages.Heartbeat{}}, {[{:heartbeat, group, member_id, gen, opts} | calls], watcher}}
   end
 
-  def handle_call({:leave_group, group, member_id, opts}, _from, calls) do
-    {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, [{:leave_group, group, member_id, opts} | calls]}
+  def handle_call({:leave_group, group, member_id, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, {[{:leave_group, group, member_id, opts} | calls], watcher}}
   end
+
+  def terminate(_reason, {calls, watcher}) when is_pid(watcher) do
+    send(watcher, {:captured_calls, Enum.reverse(calls)})
+  end
+
+  def terminate(_reason, _state), do: :ok
 end
 
 defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
@@ -128,6 +142,58 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
 
       assert [{:heartbeat, "g", "m", 1, opts}] = CapturingMockClient.calls(client)
       assert Keyword.get(opts, :group_instance_id) == nil
+    end
+  end
+
+  describe "LeaveGroup suppression on terminate" do
+    alias KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient
+
+    defp leave_calls(calls) do
+      Enum.filter(calls, &match?({:leave_group, _, _, _}, &1))
+    end
+
+    defp await_captured_calls do
+      receive do
+        {:captured_calls, calls} -> calls
+      after
+        1000 -> flunk("CapturingMockClient did not send captured_calls on terminate")
+      end
+    end
+
+    test "a static member does NOT send LeaveGroup on terminate" do
+      {:ok, client} = CapturingMockClient.start_link()
+      CapturingMockClient.set_watcher(client, self())
+
+      state = %State{
+        client: client,
+        group_name: "g",
+        member_id: "m",
+        generation_id: 1,
+        group_instance_id: "inst-1"
+      }
+
+      Manager.terminate(:shutdown, state)
+
+      calls = await_captured_calls()
+      assert leave_calls(calls) == []
+    end
+
+    test "a dynamic member DOES send LeaveGroup on terminate" do
+      {:ok, client} = CapturingMockClient.start_link()
+      CapturingMockClient.set_watcher(client, self())
+
+      state = %State{
+        client: client,
+        group_name: "g",
+        member_id: "m",
+        generation_id: 1,
+        group_instance_id: nil
+      }
+
+      Manager.terminate(:shutdown, state)
+
+      calls = await_captured_calls()
+      assert [{:leave_group, "g", "m", _opts}] = leave_calls(calls)
     end
   end
 

--- a/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
@@ -1,48 +1,3 @@
-defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient do
-  @moduledoc false
-  # Records the full opts of join/sync/heartbeat/leave so tests can assert
-  # group_instance_id was threaded through. Returns benign success responses.
-  # Sends {:captured_calls, calls} to watcher (if set) on terminate, so tests
-  # can read the call list even after Manager.terminate/2 stops the client.
-  use GenServer
-
-  def start_link, do: GenServer.start_link(__MODULE__, nil)
-  def calls(pid), do: GenServer.call(pid, :calls)
-  def set_watcher(pid, watcher), do: GenServer.call(pid, {:set_watcher, watcher})
-
-  def init(_), do: {:ok, {[], nil}}
-
-  def handle_call(:calls, _from, {calls, watcher}),
-    do: {:reply, Enum.reverse(calls), {calls, watcher}}
-
-  def handle_call({:set_watcher, watcher}, _from, {calls, _}),
-    do: {:reply, :ok, {calls, watcher}}
-
-  def handle_call({:join_group, group, member_id, opts}, _from, {calls, watcher}) do
-    resp = {:ok, %KafkaEx.Messages.JoinGroup{generation_id: 1, member_id: "m", leader_id: "x", members: []}}
-    {:reply, resp, {[{:join_group, group, member_id, opts} | calls], watcher}}
-  end
-
-  def handle_call({:sync_group, group, gen, member_id, opts}, _from, {calls, watcher}) do
-    resp = {:ok, %KafkaEx.Messages.SyncGroup{partition_assignments: []}}
-    {:reply, resp, {[{:sync_group, group, gen, member_id, opts} | calls], watcher}}
-  end
-
-  def handle_call({:heartbeat, group, member_id, gen, opts}, _from, {calls, watcher}) do
-    {:reply, {:ok, %KafkaEx.Messages.Heartbeat{}}, {[{:heartbeat, group, member_id, gen, opts} | calls], watcher}}
-  end
-
-  def handle_call({:leave_group, group, member_id, opts}, _from, {calls, watcher}) do
-    {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, {[{:leave_group, group, member_id, opts} | calls], watcher}}
-  end
-
-  def terminate(_reason, {calls, watcher}) when is_pid(watcher) do
-    send(watcher, {:captured_calls, Enum.reverse(calls)})
-  end
-
-  def terminate(_reason, _state), do: :ok
-end
-
 defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
   @moduledoc """
   KIP-345 static membership wiring through the Manager: option resolution/
@@ -56,6 +11,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
 
   alias KafkaEx.Consumer.ConsumerGroup.Manager
   alias KafkaEx.Consumer.ConsumerGroup.Manager.State
+  alias KafkaEx.Test.CapturingMockClient
 
   describe "init/1 group_instance_id resolution" do
     test "a valid group_instance_id opt is stored on the State" do
@@ -95,7 +51,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
   end
 
   describe "group_instance_id threading" do
-    alias KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient
     alias KafkaEx.Consumer.ConsumerGroup.Heartbeat
 
     test "heartbeat sends group_instance_id when static" do
@@ -146,8 +101,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
   end
 
   describe "LeaveGroup suppression on terminate" do
-    alias KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient
-
     defp leave_calls(calls) do
       Enum.filter(calls, &match?({:leave_group, _, _, _}, &1))
     end

--- a/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
@@ -1,3 +1,34 @@
+defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient do
+  @moduledoc false
+  # Records the full opts of join/sync/heartbeat/leave so tests can assert
+  # group_instance_id was threaded through. Returns benign success responses.
+  use GenServer
+
+  def start_link, do: GenServer.start_link(__MODULE__, nil)
+  def calls(pid), do: GenServer.call(pid, :calls)
+
+  def init(_), do: {:ok, []}
+  def handle_call(:calls, _from, calls), do: {:reply, Enum.reverse(calls), calls}
+
+  def handle_call({:join_group, group, member_id, opts}, _from, calls) do
+    resp = {:ok, %KafkaEx.Messages.JoinGroup{generation_id: 1, member_id: "m", leader_id: "x", members: []}}
+    {:reply, resp, [{:join_group, group, member_id, opts} | calls]}
+  end
+
+  def handle_call({:sync_group, group, gen, member_id, opts}, _from, calls) do
+    resp = {:ok, %KafkaEx.Messages.SyncGroup{partition_assignments: []}}
+    {:reply, resp, [{:sync_group, group, gen, member_id, opts} | calls]}
+  end
+
+  def handle_call({:heartbeat, group, member_id, gen, opts}, _from, calls) do
+    {:reply, {:ok, %KafkaEx.Messages.Heartbeat{}}, [{:heartbeat, group, member_id, gen, opts} | calls]}
+  end
+
+  def handle_call({:leave_group, group, member_id, opts}, _from, calls) do
+    {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, [{:leave_group, group, member_id, opts} | calls]}
+  end
+end
+
 defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
   @moduledoc """
   KIP-345 static membership wiring through the Manager: option resolution/
@@ -46,6 +77,57 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
       assert_raise ArgumentError, ~r/non-empty/, fn ->
         Manager.init({{KafkaEx.GenConsumer, __MODULE__.NoopConsumer}, "g", ["t"], opts})
       end
+    end
+  end
+
+  describe "group_instance_id threading" do
+    alias KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest.CapturingMockClient
+    alias KafkaEx.Consumer.ConsumerGroup.Heartbeat
+
+    test "heartbeat sends group_instance_id when static" do
+      {:ok, client} = CapturingMockClient.start_link()
+      on_exit(fn -> stop_safely(client) end)
+
+      {:ok, hb} =
+        Heartbeat.start_link(%{
+          client: client,
+          group_name: "g",
+          member_id: "m",
+          generation_id: 1,
+          heartbeat_interval: 60_000,
+          group_instance_id: "inst-1"
+        })
+
+      on_exit(fn -> stop_safely(hb) end)
+      send(hb, :timeout)
+
+      # let the heartbeat call land
+      Process.sleep(100)
+
+      assert [{:heartbeat, "g", "m", 1, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :group_instance_id) == "inst-1"
+    end
+
+    test "heartbeat sends nil group_instance_id when dynamic" do
+      {:ok, client} = CapturingMockClient.start_link()
+      on_exit(fn -> stop_safely(client) end)
+
+      {:ok, hb} =
+        Heartbeat.start_link(%{
+          client: client,
+          group_name: "g",
+          member_id: "m",
+          generation_id: 1,
+          heartbeat_interval: 60_000,
+          group_instance_id: nil
+        })
+
+      on_exit(fn -> stop_safely(hb) end)
+      send(hb, :timeout)
+      Process.sleep(100)
+
+      assert [{:heartbeat, "g", "m", 1, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :group_instance_id) == nil
     end
   end
 

--- a/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/manager_static_membership_test.exs
@@ -197,6 +197,48 @@ defmodule KafkaEx.Consumer.ConsumerGroup.ManagerStaticMembershipTest do
     end
   end
 
+  describe "too-old-broker warning" do
+    import ExUnit.CaptureLog
+
+    defp init_with(api_versions_resp, group_instance_id) do
+      {:ok, client} =
+        KafkaEx.Test.MockClient.start_link(%{
+          api_versions: api_versions_resp,
+          # recoverable error keeps the Manager alive (retry w/ backoff) instead of raising
+          join_group: {:error, :coordinator_not_available}
+        })
+
+      opts = [supervisor_pid: self(), client: client, group_instance_id: group_instance_id]
+
+      log =
+        capture_log(fn ->
+          {:ok, _state, _t} =
+            Manager.init({{KafkaEx.GenConsumer, __MODULE__.NoopConsumer}, "g", ["t"], opts})
+        end)
+
+      stop_safely(client)
+      log
+    end
+
+    test "warns when the broker's max JoinGroup version is < 5" do
+      versions = {:ok, %KafkaEx.Messages.ApiVersions{api_versions: %{11 => %{min_version: 0, max_version: 4}}}}
+      log = init_with(versions, "inst-1")
+      assert log =~ "static membership"
+    end
+
+    test "does not warn when the broker supports JoinGroup v5+" do
+      versions = {:ok, %KafkaEx.Messages.ApiVersions{api_versions: %{11 => %{min_version: 0, max_version: 5}}}}
+      log = init_with(versions, "inst-1")
+      refute log =~ "static membership"
+    end
+
+    test "does not warn for a dynamic member" do
+      versions = {:ok, %KafkaEx.Messages.ApiVersions{api_versions: %{11 => %{min_version: 0, max_version: 4}}}}
+      log = init_with(versions, nil)
+      refute log =~ "static membership"
+    end
+  end
+
   defmodule NoopConsumer do
     @moduledoc false
   end

--- a/test/support/capturing_mock_client.ex
+++ b/test/support/capturing_mock_client.ex
@@ -1,0 +1,66 @@
+defmodule KafkaEx.Test.CapturingMockClient do
+  @moduledoc """
+  A consumer-group mock client that records the full `opts` of every
+  join/sync/heartbeat/leave call, so tests can assert what the Manager and
+  Heartbeat actually threaded through (e.g. `group_instance_id`). Unlike
+  `KafkaEx.Test.MockClient`, it keeps the opts (that mock drops them) and returns
+  benign success structs so a driven Manager/Heartbeat keeps running.
+
+  ## Reading calls after the client is stopped
+
+  `KafkaEx.Consumer.ConsumerGroup.Manager.terminate/2` calls
+  `GenServer.stop(client)` on its client, so a test asserting on calls *after*
+  a terminate cannot use `calls/1` (the process is gone). Register a watcher
+  with `set_watcher/2`; on terminate the mock sends `{:captured_calls, calls}`
+  to it, which the test can `receive`.
+
+      {:ok, client} = CapturingMockClient.start_link()
+      CapturingMockClient.set_watcher(client, self())
+      # ... drive Manager.terminate/2 with this client ...
+      assert_receive {:captured_calls, calls}
+  """
+  use GenServer
+
+  def start_link, do: GenServer.start_link(__MODULE__, nil)
+
+  @doc "Returns the recorded calls (oldest first). Only valid while alive."
+  def calls(pid), do: GenServer.call(pid, :calls)
+
+  @doc "Registers a pid to receive `{:captured_calls, calls}` on terminate."
+  def set_watcher(pid, watcher), do: GenServer.call(pid, {:set_watcher, watcher})
+
+  @impl true
+  def init(_), do: {:ok, {[], nil}}
+
+  @impl true
+  def handle_call(:calls, _from, {calls, watcher}),
+    do: {:reply, Enum.reverse(calls), {calls, watcher}}
+
+  def handle_call({:set_watcher, watcher}, _from, {calls, _}),
+    do: {:reply, :ok, {calls, watcher}}
+
+  def handle_call({:join_group, group, member_id, opts}, _from, {calls, watcher}) do
+    resp = {:ok, %KafkaEx.Messages.JoinGroup{generation_id: 1, member_id: "m", leader_id: "x", members: []}}
+    {:reply, resp, {[{:join_group, group, member_id, opts} | calls], watcher}}
+  end
+
+  def handle_call({:sync_group, group, gen, member_id, opts}, _from, {calls, watcher}) do
+    resp = {:ok, %KafkaEx.Messages.SyncGroup{partition_assignments: []}}
+    {:reply, resp, {[{:sync_group, group, gen, member_id, opts} | calls], watcher}}
+  end
+
+  def handle_call({:heartbeat, group, member_id, gen, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %KafkaEx.Messages.Heartbeat{}}, {[{:heartbeat, group, member_id, gen, opts} | calls], watcher}}
+  end
+
+  def handle_call({:leave_group, group, member_id, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, {[{:leave_group, group, member_id, opts} | calls], watcher}}
+  end
+
+  @impl true
+  def terminate(_reason, {calls, watcher}) when is_pid(watcher) do
+    send(watcher, {:captured_calls, Enum.reverse(calls)})
+  end
+
+  def terminate(_reason, _state), do: :ok
+end


### PR DESCRIPTION
## Static consumer-group membership (KIP-345)

Adds an opt-in `:group_instance_id` option to `KafkaEx.Consumer.ConsumerGroup`. When set, a member presents a **stable instance id** so it keeps its partition assignment across a restart instead of triggering a full rebalance — closing the rolling-restart slice of the rebalance-storm incident class. **Default off (`nil`) → today's dynamic membership, byte-for-byte unchanged.**

### What it does
- Sends `group_instance_id` on **JoinGroup, SyncGroup, and Heartbeat** (only `join_group_request` already passed opts through; `sync_group_request` and `heartbeat_request` both dropped them — both fixed).
- **Suppresses the on-shutdown `LeaveGroup` when static**, so the broker retains the member's assignment until `session.timeout.ms` rather than rebalancing on every restart. The dynamic (default) path is unchanged.
- Resolution `opts > app-env > nil`; app-env honored in `{m,f,a}` / zero-arity-fun form (per-node resolution, like `:brokers`). **Fail-fast validation:** a blank/non-binary id raises `ArgumentError` at init.
- **Best-effort warning** (never blocks startup) when the broker's max JoinGroup version is `< 5` (Kafka `< 2.3`): the consumer logs and runs dynamically.
- A duplicate instance id is fenced by the broker → `:fenced_instance_id` → existing terminal stop (`member_terminated{terminal_class: :fenced}`); composes cleanly with the #560 crash-loop bound (no rejoin loop).

### Semantics (verified live against Kafka 3.1.0)
The preserved invariants are the **partition assignment and generation (no rebalance)** — proven by an integration test with a dynamic negative control. The broker issues a **fresh `member_id`** when a restarted process rejoins with an empty member_id, so this PR does **not** claim member_id retention anywhere (docs and tests assert assignment/no-rebalance only). Reference model is the Java client / KIP-345 (Java/librdkafka/Sarama/kafka-python all suppress LeaveGroup for static members; brod is the lone outlier and is incomplete).

### Tests
- Unit: config resolution/validation; RequestBuilder forwarding (sync + heartbeat); Manager/Heartbeat threading; LeaveGroup suppression vs. dynamic; the too-old-broker warning.
- Integration (live 3-broker cluster): static restart retains the generation (no rebalance) + dynamic negative control that advances it.

### Docs (this PR)
- `CHANGELOG.md` (`## Unreleased` → Added) and `UPGRADING.md` (new "1.1.0" subsection): the behavior change applies **only when `:group_instance_id` is set**.
- `config/config.exs` commented knob + `README.md` option docs, both stressing the **per-member-uniqueness requirement** (derive per node from `POD_NAME`/hostname/ordinal; a bare shared app-env string is a footgun) and the Kafka ≥ 2.3 / larger `session_timeout` guidance.

### Gates
`mix format` · `mix compile --warnings-as-errors` · `mix credo --strict` · `mix dialyzer` (0) · `mix test.unit` (3016/0) · integration 2/2 live — all green.

### Deferred follow-ups (out of scope)
- OffsetCommit V7+ static fencing (own PR — crosses into the `GenConsumer` commit path).
- An explicit-leave escape hatch for intentional scale-down (Java's `CloseOptions.LEAVE_GROUP` analogue) / the `RemoveMembersFromConsumerGroup` admin call.
