### PR TITLE
refactor: simplify fetch request-level max_bytes, remove dead default (#269)

### DIFF
--- a/lib/kafka_ex/protocol/kayrock/fetch/request_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/fetch/request_helpers.ex
@@ -88,9 +88,15 @@ defmodule KafkaEx.Protocol.Kayrock.Fetch.RequestHelpers do
   """
   @spec add_max_bytes(struct(), map(), integer()) :: struct()
   def add_max_bytes(request, fields, api_version) when api_version >= 3 do
-    # For V3+, max_bytes is at the request level as well
-    request_max_bytes = Keyword.get([max_bytes: fields.max_bytes], :max_bytes, 10_485_760)
-    %{request | max_bytes: request_max_bytes}
+    # V3+ carries max_bytes at the request level (the total response cap) in
+    # addition to the per-partition partition_max_bytes set in build_topics/2.
+    # KafkaEx fetches a single partition per request, so the request-level cap
+    # mirrors the caller's :max_bytes (the same value used for the partition).
+    #
+    # (#269: this previously read from a synthetic one-element keyword list —
+    # `Keyword.get([max_bytes: fields.max_bytes], :max_bytes, 10_485_760)` — which
+    # always returned fields.max_bytes and left the 10 MiB default as dead code.)
+    %{request | max_bytes: fields.max_bytes}
   end
 
   def add_max_bytes(request, _fields, _api_version), do: request


### PR DESCRIPTION
## Simplify fetch request-level `max_bytes` — remove dead code (#269)

`RequestHelpers.add_max_bytes/3` set the V3+ request-level `max_bytes` via:

```elixir
request_max_bytes = Keyword.get([max_bytes: fields.max_bytes], :max_bytes, 10_485_760)
```

It looks up `:max_bytes` from a **synthetic one-element keyword list** that always contains it, so it can only ever return `fields.max_bytes` — the `10_485_760` (10 MiB) default is **unreachable dead code**. This replaces it with the direct expression:

```elixir
%{request | max_bytes: fields.max_bytes}
```

**No behavior change.** The request-level cap still mirrors the caller's `:max_bytes` (KafkaEx issues one partition per fetch, so the total-response cap equals the per-partition cap — which is exactly what the existing `request_test.exs` "allows custom max_bytes" tests assert). This PR only removes the misleading construct and dead default.

### Scope note
The original #269 symptom — a consumer stuck on a single message set larger than `max_bytes` — is mitigated by the broker since **KIP-74 (Fetch V3+, Kafka 0.10.1+)**, which guarantees returning at least the first record of a batch even when it exceeds `max_bytes`. KafkaEx uses Fetch V3–V11 and requires Kafka ≥ 0.11.0, so that liveness scenario cannot occur on a supported broker. The residual was purely this dead-code/clarity issue.

### Gates
`mix format` · `mix compile --warnings-as-errors` · `mix credo --strict` (no issues) · `mix dialyzer` (0) · `mix test.unit` (2993/0) · fetch request tests 81/0 — all green (behavior unchanged, existing tests are the regression guard).
