### PR TITLE
Allow consumers to fetch from closest replica (KIP-392 a.k.a. "rack-awareness")

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -300,3 +300,61 @@ jobs:
       - name: Retry failed tests (2nd retry)
         if: steps.retry-1.outcome == 'failure'
         run: mix test --only auth --failed
+
+  rack-awareness-tests:
+    name: Rack Awareness Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      MIX_ENV: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir & Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18"
+          otp-version: "27.2"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-27.2-1.18-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-27.2-1.18-
+
+      - name: Install dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix deps.compile
+
+      - name: Check Docker availability
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Docker-compose up
+        run: ./scripts/docker_up.sh
+
+      - name: Run Rack Awareness Tests
+        id: test-run
+        continue-on-error: true
+        run: mix test --only rack_awareness
+
+      - name: Retry failed tests (1st retry)
+        id: retry-1
+        if: steps.test-run.outcome == 'failure'
+        continue-on-error: true
+        run: mix test --only rack_awareness --failed
+
+      - name: Retry failed tests (2nd retry)
+        if: steps.retry-1.outcome == 'failure'
+        run: mix test --only rack_awareness --failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@
 
 ### Added
 
+* **Rack-aware fetching (KIP-392).** Consumers can now route fetches to the
+  closest in-rack replica, eliminating cross-AZ traffic on multi-AZ Kafka
+  deployments (most notably AWS MSK, where cross-AZ data transfer is billed).
+
+  New `:client_rack` option on `KafkaEx.Consumer.GenConsumer.start_link/5`
+  (also accepted by `KafkaEx.Consumer.ConsumerGroup.start_link/4`):
+
+  ```elixir
+  KafkaEx.Consumer.ConsumerGroup.start_link(MyConsumer, "my-group", ["my-topic"],
+    client_rack: System.get_env("AZ_ID")  # e.g. "use1-az2"
+  )
+  ```
+
+  Under the hood, each Fetch v11+ request includes the consumer's rack id;
+  the broker's `RackAwareReplicaSelector` responds with `preferred_read_replica`
+  pointing at a same-rack replica; the client caches that hint per
+  topic-partition in `KafkaEx.Cluster.ClusterMetadata` and routes
+  subsequent fetches to the preferred broker. Requires Kafka 2.4+ brokers
+  with `replica.selector.class=org.apache.kafka.common.replica.RackAwareReplicaSelector`
+  configured.
 * **Static consumer-group membership (KIP-345).** New `:group_instance_id` option on
   `KafkaEx.Consumer.ConsumerGroup` (resolved `opts > app-env > nil`, default off). When set, the
   member presents a stable instance id on JoinGroup/SyncGroup/Heartbeat and **does not send

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ KafkaEx v1.0 is the Kayrock-based release. Scope:
 - ✅ Compression (gzip, snappy, lz4, zstd)
 - ✅ Automatic API version negotiation with per-request / per-app overrides
 - ✅ First-class telemetry (27+ events)
+- ✅ KIP-392 Rack-awareness for consumers
 - ❌ Idempotent / transactional producer (planned, post-1.0)
 - ❌ KIP-848 new rebalance protocol (planned, post-1.0)
 - ❌ KIP-368 proactive SASL re-authentication on token expiry (see [AUTH.md § Token expiry behaviour](./AUTH.md#token-expiry-behaviour) for the current reconnect-driven behaviour)

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -26,6 +26,7 @@ services:
       - "9392:9392"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "1"
+      KAFKA_BROKER_RACK: "az-a"
 
       KAFKA_LISTENERS: "INTERNAL://:29092,NOAUTH://:9092,PLAIN://:9192,SCRAM://:9292,OAUTH://:9392"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-1:29092,NOAUTH://localhost:9092,PLAIN://localhost:9192,SCRAM://localhost:9292,OAUTH://localhost:9392"
@@ -50,6 +51,7 @@ services:
       - "9393:9393"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "2"
+      KAFKA_BROKER_RACK: "az-b"
 
       KAFKA_LISTENERS: "INTERNAL://:29093,NOAUTH://:9093,PLAIN://:9193,SCRAM://:9293,OAUTH://:9393"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-2:29093,NOAUTH://localhost:9093,PLAIN://localhost:9193,SCRAM://localhost:9293,OAUTH://localhost:9393"
@@ -74,6 +76,7 @@ services:
       - "9394:9394"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "3"
+      KAFKA_BROKER_RACK: "az-c"
 
       KAFKA_LISTENERS: "INTERNAL://:29094,NOAUTH://:9094,PLAIN://:9194,SCRAM://:9294,OAUTH://:9394"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-3:29094,NOAUTH://localhost:9094,PLAIN://localhost:9194,SCRAM://localhost:9294,OAUTH://localhost:9394"
@@ -112,5 +115,6 @@ services:
         set -euo pipefail
         kafka-topics --bootstrap-server kafka-1:29092 --create --if-not-exists --partitions 4 --replication-factor 2 --topic consumer_group_implementation_test
         kafka-topics --bootstrap-server kafka-1:29092 --create --if-not-exists --partitions 4 --replication-factor 2 --topic test0p8p0
+        kafka-topics --bootstrap-server kafka-1:29092 --create --if-not-exists --partitions 3 --replication-factor 3 --topic rack_aware_test
         kafka-topics --bootstrap-server kafka-1:29092 --list
       '

--- a/docker-compose-kafka.env
+++ b/docker-compose-kafka.env
@@ -58,3 +58,8 @@ KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR=1
 KAFKA_LOG_RETENTION_HOURS=1
 # KAFKA_LOG_SEGMENT_BYTES=1073741824
 # KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=300000
+
+######## KIP-392 rack-aware fetch
+# Each broker also sets its own KAFKA_BROKER_RACK inline in docker-compose.yml.
+# The selector class is shared cluster-wide and lives here.
+KAFKA_REPLICA_SELECTOR_CLASS=org.apache.kafka.common.replica.RackAwareReplicaSelector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - "9392:9392"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "1"
+      KAFKA_BROKER_RACK: "az-a"
 
       KAFKA_LISTENERS: "INTERNAL://:29092,NOAUTH://:9092,PLAIN://:9192,SCRAM://:9292,OAUTH://:9392"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-1:29092,NOAUTH://localhost:9092,PLAIN://localhost:9192,SCRAM://localhost:9292,OAUTH://localhost:9392"
@@ -50,6 +51,7 @@ services:
       - "9393:9393"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "2"
+      KAFKA_BROKER_RACK: "az-b"
 
       KAFKA_LISTENERS: "INTERNAL://:29093,NOAUTH://:9093,PLAIN://:9193,SCRAM://:9293,OAUTH://:9393"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-2:29093,NOAUTH://localhost:9093,PLAIN://localhost:9193,SCRAM://localhost:9293,OAUTH://localhost:9393"
@@ -74,6 +76,7 @@ services:
       - "9394:9394"   # OAUTH
     environment:
       KAFKA_BROKER_ID: "3"
+      KAFKA_BROKER_RACK: "az-c"
 
       KAFKA_LISTENERS: "INTERNAL://:29094,NOAUTH://:9094,PLAIN://:9194,SCRAM://:9294,OAUTH://:9394"
       KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka-3:29094,NOAUTH://localhost:9094,PLAIN://localhost:9194,SCRAM://localhost:9294,OAUTH://localhost:9394"
@@ -112,5 +115,6 @@ services:
         set -euo pipefail
         kafka-topics --zookeeper zookeeper:32181 --create --if-not-exists --partitions 4 --replication-factor 2 --topic consumer_group_implementation_test
         kafka-topics --zookeeper zookeeper:32181 --create --if-not-exists --partitions 4 --replication-factor 2 --topic test0p8p0
+        kafka-topics --zookeeper zookeeper:32181 --create --if-not-exists --partitions 3 --replication-factor 3 --topic rack_aware_test
         kafka-topics --zookeeper zookeeper:32181 --list
       '

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -682,12 +682,30 @@ defmodule KafkaEx.Client do
       filtered_result = Fetch.filter_from_offset(result, offset)
       message_count = length(Map.get(filtered_result, :records, []))
       stop_metadata = Map.put(metadata, :message_count, message_count)
+      updated_state = cache_preferred_replica(updated_state, topic, partition, filtered_result)
       {{{:ok, filtered_result}, updated_state}, stop_metadata}
     else
       {:error, error} -> {{:error, error}, metadata}
       error_result -> {error_result, metadata}
     end
   end
+
+  # `-1` means "stay where you are" (Java client semantics). Clearing the
+  # cache here would ping-pong subsequent fetches back to the leader.
+  defp cache_preferred_replica(state, _topic, _partition, %Fetch{preferred_read_replica: node_id})
+       when node_id in [nil, -1] do
+    state
+  end
+
+  defp cache_preferred_replica(state, topic, partition, %Fetch{preferred_read_replica: node_id})
+       when is_integer(node_id) do
+    %{
+      state
+      | cluster_metadata: ClusterMetadata.put_preferred_replica(state.cluster_metadata, topic, partition, node_id)
+    }
+  end
+
+  defp cache_preferred_replica(state, _topic, _partition, _other), do: state
 
   defp find_coordinator_request(group_id, opts, state) do
     # FindCoordinator can be sent to any broker
@@ -1482,7 +1500,10 @@ defmodule KafkaEx.Client do
   end
 
   defp broker_to_telemetry_info(nil), do: %{}
-  defp broker_to_telemetry_info(broker), do: %{node_id: broker.node_id, host: broker.host, port: broker.port}
+
+  defp broker_to_telemetry_info(%Broker{} = broker) do
+    %{node_id: broker.node_id, host: broker.host, port: broker.port, rack: broker.rack}
+  end
 
   defp deserialize(data, request) do
     {resp, _} = @protocol.response_deserializer(request).(data)

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -672,7 +672,7 @@ defmodule KafkaEx.Client do
   end
 
   defp do_fetch_request(topic, partition, offset, opts, state, metadata) do
-    node_selector = NodeSelector.topic_partition(topic, partition)
+    node_selector = NodeSelector.topic_partition_replica(topic, partition)
     {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
     req_data = [{:topic, topic}, {:partition, partition}, {:offset, offset} | req_opts]
 
@@ -1226,9 +1226,8 @@ defmodule KafkaEx.Client do
     end
   end
 
-  defp broker_for_partition_with_update(state, topic, partition) do
-    node = NodeSelector.topic_partition(topic, partition)
-    select_broker_with_update(state, node, &update_metadata(&1, [topic]))
+  defp broker_for_partition_with_update(state, %NodeSelector{topic: topic} = selector) do
+    select_broker_with_update(state, selector, &update_metadata(&1, [topic]))
   end
 
   defp broker_for_consumer_group_with_update(state, consumer_group) do
@@ -1435,12 +1434,13 @@ defmodule KafkaEx.Client do
   end
 
   defp get_send_request_function(
-         %NodeSelector{strategy: :topic_partition, topic: topic, partition: partition},
+         %NodeSelector{strategy: strategy} = selector,
          state,
          network_timeout,
          synchronous
-       ) do
-    {broker, updated_state} = broker_for_partition_with_update(state, topic, partition)
+       )
+       when strategy in [:topic_partition, :topic_partition_replica] do
+    {broker, updated_state} = broker_for_partition_with_update(state, selector)
 
     if broker do
       if synchronous do

--- a/lib/kafka_ex/client/node_selector.ex
+++ b/lib/kafka_ex/client/node_selector.ex
@@ -17,6 +17,7 @@ defmodule KafkaEx.Client.NodeSelector do
           | :first_available
           | :controller
           | :topic_partition
+          | :topic_partition_replica
           | :consumer_group
   @type t :: %__MODULE__{
           strategy: valid_strategy,
@@ -61,6 +62,24 @@ defmodule KafkaEx.Client.NodeSelector do
       when is_binary(topic) and is_integer(partition) do
     %__MODULE__{
       strategy: :topic_partition,
+      topic: topic,
+      partition: partition
+    }
+  end
+
+  @doc """
+  Select the node to read the given topic and partition from, including "preferred replicas" previously returned by the
+  broker. Falls back to partition leader if no preferred replica is known.
+
+  Use this only for reads (Fetch). Writes and offset lookups must use `topic_partition/2`, which always resolves to the
+  leader.
+  """
+  @spec topic_partition_replica(KafkaExAPI.topic_name(), KafkaExAPI.partition_id()) ::
+          __MODULE__.t()
+  def topic_partition_replica(topic, partition)
+      when is_binary(topic) and is_integer(partition) do
+    %__MODULE__{
+      strategy: :topic_partition_replica,
       topic: topic,
       partition: partition
     }

--- a/lib/kafka_ex/cluster/cluster_metadata.ex
+++ b/lib/kafka_ex/cluster/cluster_metadata.ex
@@ -11,13 +11,20 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   alias KafkaEx.Cluster.Broker
   alias KafkaEx.Cluster.Topic
 
-  defstruct brokers: %{}, controller_id: nil, topics: %{}, consumer_group_coordinators: %{}
+  defstruct brokers: %{},
+            controller_id: nil,
+            topics: %{},
+            consumer_group_coordinators: %{},
+            preferred_replicas: %{}
+
+  @type partition_key :: {KafkaExAPI.topic_name(), KafkaExAPI.partition_id()}
 
   @type t :: %__MODULE__{
           brokers: %{KafkaExAPI.node_id() => Broker.t()},
           controller_id: KafkaExAPI.node_id() | nil,
           topics: %{KafkaExAPI.topic_name() => Topic.t()},
-          consumer_group_coordinators: %{KafkaExAPI.consumer_group_name() => KafkaExAPI.node_id()}
+          consumer_group_coordinators: %{KafkaExAPI.consumer_group_name() => KafkaExAPI.node_id()},
+          preferred_replicas: %{partition_key() => KafkaExAPI.node_id()}
         }
 
   @typedoc """
@@ -78,7 +85,7 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
       {:ok, %Topic{partition_leaders: partition_leaders}} ->
         case Map.fetch(partition_leaders, partition) do
           :error -> {:error, :no_such_partition}
-          {:ok, node_id} -> {:ok, node_id}
+          {:ok, leader_node_id} -> {:ok, pick_preferred_or_leader(cluster_metadata, topic, partition, leader_node_id)}
         end
     end
   end
@@ -152,6 +159,29 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   end
 
   @doc """
+  Get the cached preferred read replica for `{topic, partition}`, or `nil` if none is cached.
+  """
+  @spec preferred_replica(t, KafkaExAPI.topic_name(), KafkaExAPI.partition_id()) :: KafkaExAPI.node_id() | nil
+  def preferred_replica(%__MODULE__{preferred_replicas: prefs}, topic, partition) do
+    Map.get(prefs, {topic, partition})
+  end
+
+  @doc """
+  Cache (or clear) the preferred read replica for `{topic, partition}`. Passing `nil` or `-1` (the Kafka wire value for
+  "no preference") clears the entry.
+  """
+  @spec put_preferred_replica(t, KafkaExAPI.topic_name(), KafkaExAPI.partition_id(), KafkaExAPI.node_id() | nil) :: t
+  def put_preferred_replica(%__MODULE__{preferred_replicas: prefs} = cluster_metadata, topic, partition, node_id)
+      when node_id in [nil, -1] do
+    %{cluster_metadata | preferred_replicas: Map.delete(prefs, {topic, partition})}
+  end
+
+  def put_preferred_replica(%__MODULE__{preferred_replicas: prefs} = cluster_metadata, topic, partition, node_id)
+      when is_integer(node_id) do
+    %{cluster_metadata | preferred_replicas: Map.put(prefs, {topic, partition}, node_id)}
+  end
+
+  @doc """
   update a consumer group coordinator node id
   """
   @spec put_consumer_group_coordinator(t, KafkaExAPI.consumer_group_name(), KafkaExAPI.node_id()) :: t
@@ -189,5 +219,12 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   @spec remove_topics(t, [KafkaExAPI.topic_name()]) :: t
   def remove_topics(%__MODULE__{topics: topics} = cluster_metadata, topics_to_remove) do
     %{cluster_metadata | topics: Map.drop(topics, topics_to_remove)}
+  end
+
+  defp pick_preferred_or_leader(%__MODULE__{brokers: brokers} = cluster_metadata, topic, partition, leader_node_id) do
+    case preferred_replica(cluster_metadata, topic, partition) do
+      nil -> leader_node_id
+      node_id -> if Map.has_key?(brokers, node_id), do: node_id, else: leader_node_id
+    end
   end
 end

--- a/lib/kafka_ex/cluster/cluster_metadata.ex
+++ b/lib/kafka_ex/cluster/cluster_metadata.ex
@@ -35,7 +35,7 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   @doc """
   List names of topics known by the cluster metadata
 
-  Tthis is a subset of the topics in the cluster - it will only contain topics for which we have fetched metadata
+  This is a subset of the topics in the cluster - it will only contain topics for which we have fetched metadata
   """
   @spec known_topics(t) :: [KafkaExAPI.topic_name()]
   def known_topics(%__MODULE__{topics: topics}), do: Map.keys(topics)
@@ -78,15 +78,16 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
         topic: topic,
         partition: partition
       }) do
-    case Map.fetch(cluster_metadata.topics, topic) do
-      :error ->
-        {:error, :no_such_topic}
+    partition_leader(cluster_metadata, topic, partition)
+  end
 
-      {:ok, %Topic{partition_leaders: partition_leaders}} ->
-        case Map.fetch(partition_leaders, partition) do
-          :error -> {:error, :no_such_partition}
-          {:ok, leader_node_id} -> {:ok, pick_preferred_or_leader(cluster_metadata, topic, partition, leader_node_id)}
-        end
+  def select_node(%__MODULE__{} = cluster_metadata, %NodeSelector{
+        strategy: :topic_partition_replica,
+        topic: topic,
+        partition: partition
+      }) do
+    with {:ok, leader_node_id} <- partition_leader(cluster_metadata, topic, partition) do
+      {:ok, pick_preferred_or_leader(cluster_metadata, topic, partition, leader_node_id)}
     end
   end
 
@@ -219,6 +220,19 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   @spec remove_topics(t, [KafkaExAPI.topic_name()]) :: t
   def remove_topics(%__MODULE__{topics: topics} = cluster_metadata, topics_to_remove) do
     %{cluster_metadata | topics: Map.drop(topics, topics_to_remove)}
+  end
+
+  defp partition_leader(%__MODULE__{} = cluster_metadata, topic, partition) do
+    case Map.fetch(cluster_metadata.topics, topic) do
+      :error ->
+        {:error, :no_such_topic}
+
+      {:ok, %Topic{partition_leaders: partition_leaders}} ->
+        case Map.fetch(partition_leaders, partition) do
+          :error -> {:error, :no_such_partition}
+          {:ok, leader_node_id} -> {:ok, leader_node_id}
+        end
+    end
   end
 
   defp pick_preferred_or_leader(%__MODULE__{brokers: brokers} = cluster_metadata, topic, partition, leader_node_id) do

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -246,6 +246,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
           | {:api_versions, map()}
           | {:shutdown, timeout()}
           | {:extra_consumer_args, map()}
+          | {:client_rack, String.t()}
 
   @typedoc """
   Options used when starting a `KafkaEx.Consumer.GenConsumer`.
@@ -509,6 +510,14 @@ defmodule KafkaEx.Consumer.GenConsumer do
   * `:fetch_options` - Optional keyword list that is passed along to the
     fetch operation.
 
+  * `:client_rack` - The consumer's rack identifier (KIP-392). When set, the
+    Fetch v11+ `rack_id` field is populated on every fetch this consumer
+    issues; the broker can then hint at a same-rack replica via the response's
+    `preferred_read_replica`, and the client will route subsequent fetches for
+    that `(topic, partition)` to the hinted broker — reducing cross-AZ traffic
+    in multi-AZ Kafka deployments. An explicit `fetch_options[:rack_id]` wins
+    over `:client_rack` if both are set.
+
   * `:shutdown` - Optional amount of time in milliseconds that the supervisor
     will wait for a `GenConsumer` to terminate after emitting a
     `Process.exit(child, :shutdown)` signal. Defaults to `5_000`.
@@ -640,13 +649,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
       {:ok, consumer_state} ->
         {client, owns_client} = resolve_client(opts, group_name, topic)
 
-        default_fetch_options = [
-          auto_commit: false
-        ]
-
-        given_fetch_options = Keyword.get(opts, :fetch_options, [])
-
-        fetch_options = Keyword.merge(default_fetch_options, given_fetch_options)
+        fetch_options = build_fetch_options(opts)
 
         state = %State{
           consumer_module: consumer_module,
@@ -672,6 +675,20 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
       {:stop, reason} ->
         {:stop, reason}
+    end
+  end
+
+  @doc false
+  # Exposed for testability. Explicit `fetch_options[:rack_id]` wins over
+  # `:client_rack` (via `Keyword.put_new`).
+  def build_fetch_options(opts) do
+    default_fetch_options = [auto_commit: false]
+    given_fetch_options = Keyword.get(opts, :fetch_options, [])
+    fetch_options = Keyword.merge(default_fetch_options, given_fetch_options)
+
+    case Keyword.get(opts, :client_rack) do
+      nil -> fetch_options
+      rack when is_binary(rack) -> Keyword.put_new(fetch_options, :rack_id, rack)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -91,9 +91,9 @@ defmodule KafkaEx.Mixfile do
   defp aliases do
     [
       "test.unit":
-        "test --exclude auth --exclude consume --exclude consumer_group --exclude chaos --exclude lifecycle --exclude produce",
+        "test --exclude auth --exclude consume --exclude consumer_group --exclude chaos --exclude lifecycle --exclude produce --exclude rack_awareness",
       "test.integration":
-        "test --include auth --include consume --include consumer_group --include lifecycle --include produce",
+        "test --include auth --include consume --include consumer_group --include lifecycle --include produce --include rack_awareness",
       "test.chaos": "test --only chaos"
     ]
   end

--- a/test/integration/rack_awareness_test.exs
+++ b/test/integration/rack_awareness_test.exs
@@ -1,0 +1,91 @@
+defmodule KafkaEx.Integration.RackAwarenessTest do
+  @moduledoc """
+  End-to-end verification of KIP-392 (rack-aware fetching) against a
+  rack-tagged cluster: the request carries `rack_id`, the response carries
+  `preferred_read_replica`, the broker picks a same-rack replica, and the
+  client caches the hint so subsequent fetches go to the preferred broker.
+
+  Cluster shape lives in `docker-compose.yml` — `KAFKA_BROKER_RACK` per
+  broker and `KAFKA_REPLICA_SELECTOR_CLASS=RackAwareReplicaSelector` in
+  `docker-compose-kafka.env`.
+  """
+  use ExUnit.Case, async: true
+  @moduletag :rack_awareness
+
+  alias KafkaEx.Client
+  alias KafkaEx.API
+  alias KafkaEx.Messages.Fetch
+
+  @topic "rack_aware_test"
+
+  @rack_to_broker_id %{"az-a" => 1, "az-b" => 2, "az-c" => 3}
+  @partition_to_leader_rack %{0 => "az-a", 1 => "az-b", 2 => "az-c"}
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, pid} = Client.start_link(args, :no_name)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    {:ok, %{client: pid}}
+  end
+
+  defp with_fresh_client(fun) do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, pid} = Client.start_link(args, :no_name)
+
+    try do
+      fun.(pid)
+    after
+      if Process.alive?(pid), do: GenServer.stop(pid)
+    end
+  end
+
+  describe "broker metadata" do
+    test "keeps track of broker-reported rack IDs", %{client: client} do
+      {:ok, cluster_metadata} = API.metadata(client, [@topic], api_version: 9)
+
+      for {expected_rack, broker_id} <- @rack_to_broker_id do
+        broker = Map.fetch!(cluster_metadata.brokers, broker_id)
+        assert broker.rack == expected_rack
+      end
+    end
+  end
+
+  describe "Fetch V11 with rack_id (KIP-392)" do
+    test "cross-rack request returns the same-rack replica as preferred" do
+      for partition <- 0..2,
+          {client_rack, expected_broker_id} <- @rack_to_broker_id,
+          @partition_to_leader_rack[partition] != client_rack do
+        with_fresh_client(fn client ->
+          assert {:ok, %Fetch{preferred_read_replica: ^expected_broker_id}} =
+                   API.fetch(client, @topic, partition, 0, rack_id: client_rack, min_bytes: 0)
+        end)
+      end
+    end
+
+    test "same-rack-as-leader request returns -1 (no redirect needed)" do
+      for partition <- 0..2,
+          {client_rack, _broker_id} <- @rack_to_broker_id,
+          @partition_to_leader_rack[partition] == client_rack do
+        with_fresh_client(fn client ->
+          assert {:ok, %Fetch{preferred_read_replica: -1}} =
+                   API.fetch(client, @topic, partition, 0, rack_id: client_rack, min_bytes: 0)
+        end)
+      end
+    end
+
+    test "missing rack_id → no preference (-1)", %{client: client} do
+      {:ok, %Fetch{} = result} = API.fetch(client, @topic, 0, 0, min_bytes: 0)
+      assert result.preferred_read_replica in [-1, nil]
+    end
+
+    test "empty rack_id (default) → no preference (-1)", %{client: client} do
+      {:ok, %Fetch{} = result} = API.fetch(client, @topic, 0, 0, rack_id: "", min_bytes: 0)
+      assert result.preferred_read_replica in [-1, nil]
+    end
+
+    test "unknown rack_id → no preference (-1)", %{client: client} do
+      {:ok, %Fetch{} = result} = API.fetch(client, @topic, 0, 0, rack_id: "az-unknown", min_bytes: 0)
+      assert result.preferred_read_replica in [-1, nil]
+    end
+  end
+end

--- a/test/integration/rack_awareness_test.exs
+++ b/test/integration/rack_awareness_test.exs
@@ -10,10 +10,13 @@ defmodule KafkaEx.Integration.RackAwarenessTest do
   `docker-compose-kafka.env`.
   """
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
   @moduletag :rack_awareness
 
   alias KafkaEx.Client
   alias KafkaEx.API
+  alias KafkaEx.Client.NodeSelector
+  alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Messages.Fetch
 
   @topic "rack_aware_test"
@@ -86,6 +89,55 @@ defmodule KafkaEx.Integration.RackAwarenessTest do
     test "unknown rack_id → no preference (-1)", %{client: client} do
       {:ok, %Fetch{} = result} = API.fetch(client, @topic, 0, 0, rack_id: "az-unknown", min_bytes: 0)
       assert result.preferred_read_replica in [-1, nil]
+    end
+  end
+
+  describe "preferred-replica cache must not leak into writes" do
+    @partition 0
+
+    setup %{client: client} do
+      {:ok, cm} = API.metadata(client, [@topic], api_version: 9)
+      leader = cm.topics |> Map.fetch!(@topic) |> Map.fetch!(:partition_leaders) |> Map.fetch!(@partition)
+      leader_rack = cm.brokers |> Map.fetch!(leader) |> Map.fetch!(:rack)
+
+      {follower, cross_rack} =
+        cm.brokers
+        |> Map.values()
+        |> Enum.find_value(fn b -> b.rack != leader_rack && {b.node_id, b.rack} end)
+
+      {:ok, leader: leader, follower: follower, cross_rack: cross_rack}
+    end
+
+    test "the topic_partition selector still resolves to the leader after a fetch cached a follower",
+         %{client: client, leader: leader, follower: follower, cross_rack: cross_rack} do
+      assert {:ok, %Fetch{preferred_read_replica: ^follower}} =
+               API.fetch(client, @topic, @partition, 0, rack_id: cross_rack, min_bytes: 0)
+
+      {:ok, cm} = API.cluster_metadata(client)
+      assert ClusterMetadata.preferred_replica(cm, @topic, @partition) == follower
+
+      # produce and list_offsets both select the node via this exact selector; it
+      # must resolve to the leader, never the cached follower.
+      assert ClusterMetadata.select_node(cm, NodeSelector.topic_partition(@topic, @partition)) ==
+               {:ok, leader}
+    end
+
+    test "producing after a cross-rack fetch is not routed to the cached follower",
+         %{client: client, follower: follower, cross_rack: cross_rack} do
+      assert {:ok, %Fetch{preferred_read_replica: ^follower}} =
+               API.fetch(client, @topic, @partition, 0, rack_id: cross_rack, min_bytes: 0)
+
+      # Produce recovers (the leadership error refreshes metadata, dropping the
+      # cache, and the retry hits the leader), so the return value is {:ok, _}.
+      # The bug is the wasted, failed first attempt against the follower —
+      # `:not_leader_for_partition` / `:not_leader_or_follower` in the log.
+      log =
+        capture_log(fn ->
+          assert {:ok, _} = API.produce(client, @topic, @partition, [%{value: "must-hit-leader"}])
+        end)
+
+      refute log =~ "not_leader",
+             "producer was routed to the cached follower instead of the leader:\n#{log}"
     end
   end
 end

--- a/test/kafka_ex/cluster/cluster_metadata_test.exs
+++ b/test/kafka_ex/cluster/cluster_metadata_test.exs
@@ -396,4 +396,95 @@ defmodule KafkaEx.Cluster.ClusterMetadataTest do
       assert ClusterMetadata.known_topics(updated_cluster) == ["topic-one"]
     end
   end
+
+  describe "preferred_replica/3 + put_preferred_replica/4" do
+    test "preferred_replica returns nil when nothing is cached" do
+      cluster = %ClusterMetadata{}
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == nil
+    end
+
+    test "put_preferred_replica stores a node_id, preferred_replica returns it" do
+      cluster = %ClusterMetadata{} |> ClusterMetadata.put_preferred_replica("t", 0, 7)
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == 7
+    end
+
+    test "put_preferred_replica updates an existing entry" do
+      cluster =
+        %ClusterMetadata{}
+        |> ClusterMetadata.put_preferred_replica("t", 0, 7)
+        |> ClusterMetadata.put_preferred_replica("t", 0, 9)
+
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == 9
+    end
+
+    test "put_preferred_replica with -1 clears the entry (Kafka wire 'no preference')" do
+      cluster =
+        %ClusterMetadata{}
+        |> ClusterMetadata.put_preferred_replica("t", 0, 7)
+        |> ClusterMetadata.put_preferred_replica("t", 0, -1)
+
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == nil
+    end
+
+    test "put_preferred_replica with nil clears the entry" do
+      cluster =
+        %ClusterMetadata{}
+        |> ClusterMetadata.put_preferred_replica("t", 0, 7)
+        |> ClusterMetadata.put_preferred_replica("t", 0, nil)
+
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == nil
+    end
+
+    test "entries for different (topic, partition) tuples are independent" do
+      cluster =
+        %ClusterMetadata{}
+        |> ClusterMetadata.put_preferred_replica("t", 0, 7)
+        |> ClusterMetadata.put_preferred_replica("t", 1, 8)
+        |> ClusterMetadata.put_preferred_replica("u", 0, 9)
+
+      assert ClusterMetadata.preferred_replica(cluster, "t", 0) == 7
+      assert ClusterMetadata.preferred_replica(cluster, "t", 1) == 8
+      assert ClusterMetadata.preferred_replica(cluster, "u", 0) == 9
+    end
+  end
+
+  describe "select_node/2 with preferred replica (KIP-392)" do
+    setup do
+      topic =
+        KafkaEx.Cluster.Topic.from_topic_metadata(%{
+          name: "t",
+          is_internal: false,
+          partitions: [
+            %{error_code: 0, partition_index: 0, leader_id: 1, replica_nodes: [], isr_nodes: []}
+          ]
+        })
+
+      cluster = %ClusterMetadata{
+        brokers: %{
+          1 => %KafkaEx.Cluster.Broker{node_id: 1},
+          2 => %KafkaEx.Cluster.Broker{node_id: 2}
+        },
+        topics: %{topic.name => topic}
+      }
+
+      {:ok, cluster: cluster, selector: KafkaEx.Client.NodeSelector.topic_partition("t", 0)}
+    end
+
+    test ":topic_partition returns the preferred replica when cached", %{cluster: cluster, selector: selector} do
+      cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 2)
+      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 2}
+    end
+
+    test ":topic_partition falls back to leader when no preference is cached", %{cluster: cluster, selector: selector} do
+      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 1}
+    end
+
+    test ":topic_partition falls back to leader when preferred broker no longer exists", %{
+      cluster: cluster,
+      selector: selector
+    } do
+      cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 99)
+      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 1}
+    end
+  end
 end

--- a/test/kafka_ex/cluster/cluster_metadata_test.exs
+++ b/test/kafka_ex/cluster/cluster_metadata_test.exs
@@ -448,7 +448,7 @@ defmodule KafkaEx.Cluster.ClusterMetadataTest do
     end
   end
 
-  describe "select_node/2 with preferred replica (KIP-392)" do
+  describe "select_node/2 preferred replica (KIP-392) is fetch-only" do
     setup do
       topic =
         KafkaEx.Cluster.Topic.from_topic_metadata(%{
@@ -467,24 +467,51 @@ defmodule KafkaEx.Cluster.ClusterMetadataTest do
         topics: %{topic.name => topic}
       }
 
-      {:ok, cluster: cluster, selector: KafkaEx.Client.NodeSelector.topic_partition("t", 0)}
+      {:ok,
+       cluster: cluster,
+       leader_selector: KafkaEx.Client.NodeSelector.topic_partition("t", 0),
+       replica_selector: KafkaEx.Client.NodeSelector.topic_partition_replica("t", 0)}
     end
 
-    test ":topic_partition returns the preferred replica when cached", %{cluster: cluster, selector: selector} do
-      cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 2)
-      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 2}
-    end
-
-    test ":topic_partition falls back to leader when no preference is cached", %{cluster: cluster, selector: selector} do
-      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 1}
-    end
-
-    test ":topic_partition falls back to leader when preferred broker no longer exists", %{
+    test ":topic_partition ignores the cache — writes always go to the leader", %{
       cluster: cluster,
-      selector: selector
+      leader_selector: leader_selector
+    } do
+      cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 2)
+      assert ClusterMetadata.select_node(cluster, leader_selector) == {:ok, 1}
+    end
+
+    test ":topic_partition_replica returns the preferred replica when cached", %{
+      cluster: cluster,
+      replica_selector: replica_selector
+    } do
+      cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 2)
+      assert ClusterMetadata.select_node(cluster, replica_selector) == {:ok, 2}
+    end
+
+    test ":topic_partition_replica falls back to leader when no preference is cached", %{
+      cluster: cluster,
+      replica_selector: replica_selector
+    } do
+      assert ClusterMetadata.select_node(cluster, replica_selector) == {:ok, 1}
+    end
+
+    test ":topic_partition_replica falls back to leader when the preferred broker no longer exists", %{
+      cluster: cluster,
+      replica_selector: replica_selector
     } do
       cluster = ClusterMetadata.put_preferred_replica(cluster, "t", 0, 99)
-      assert ClusterMetadata.select_node(cluster, selector) == {:ok, 1}
+      assert ClusterMetadata.select_node(cluster, replica_selector) == {:ok, 1}
+    end
+
+    test ":topic_partition_replica reports :no_such_topic / :no_such_partition like :topic_partition", %{
+      cluster: cluster
+    } do
+      assert ClusterMetadata.select_node(cluster, KafkaEx.Client.NodeSelector.topic_partition_replica("nope", 0)) ==
+               {:error, :no_such_topic}
+
+      assert ClusterMetadata.select_node(cluster, KafkaEx.Client.NodeSelector.topic_partition_replica("t", 9)) ==
+               {:error, :no_such_partition}
     end
   end
 end

--- a/test/kafka_ex/consumer/gen_consumer_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_test.exs
@@ -23,4 +23,33 @@ defmodule KafkaEx.Consumer.GenConsumerTest do
              TestConsumer.handle_info(nil, nil)
            end) =~ "unexpected message in handle_info"
   end
+
+  describe "build_fetch_options/1 (used at init to fold :client_rack into fetch_options)" do
+    alias KafkaEx.Consumer.GenConsumer
+
+    test "preserves the default auto_commit: false" do
+      assert GenConsumer.build_fetch_options([])[:auto_commit] == false
+    end
+
+    test ":client_rack is folded in as :rack_id" do
+      opts = [client_rack: "az-a"]
+      assert GenConsumer.build_fetch_options(opts)[:rack_id] == "az-a"
+    end
+
+    test "no :rack_id is set when :client_rack is absent" do
+      refute Keyword.has_key?(GenConsumer.build_fetch_options([]), :rack_id)
+    end
+
+    test "explicit fetch_options[:rack_id] wins over :client_rack" do
+      opts = [client_rack: "az-a", fetch_options: [rack_id: "az-explicit"]]
+      assert GenConsumer.build_fetch_options(opts)[:rack_id] == "az-explicit"
+    end
+
+    test "user-supplied fetch_options are merged with defaults" do
+      opts = [fetch_options: [max_bytes: 1024]]
+      result = GenConsumer.build_fetch_options(opts)
+      assert result[:auto_commit] == false
+      assert result[:max_bytes] == 1024
+    end
+  end
 end


### PR DESCRIPTION
[KIP-392](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/95653762/KIP-392+Allow+consumers+to+fetch+from+closest+replica) allows follower fetching.
Consumers can fetch from a node that is not the _leader_ for a given partition, but holds a replica.
This is important as it allows to consume from brokers within the same availability zone / data center, saving transfer costs.

For this to work, a consumer must:
* advertise its `rack_id` to the brokers, and
* follow hints from brokers as to where to fetch a given topic/partition from (`preferred_read_replica`)

This PR does exactly this:
* forward `client_rack` option for GenConsumer to brokers on fetch
    * building on top of existing `rack_id` support for fetch requests
    * building on top of existing `preferred_read_replica` support for fetch responses
* keep track of preferred read replicas in cluster metadata, and use them to pick brokers for fetch requests
* add brokers' rack IDs to telemetry metadata - this should allow users to monitor what racks KafkaEx is consuming from
