### PR TITLE
feat: cluster-wide ListGroups admin API (#90)

### DIFF
--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -61,6 +61,7 @@ defmodule KafkaEx.API do
   alias KafkaEx.Config
   alias KafkaEx.Messages.ApiVersions
   alias KafkaEx.Messages.ConsumerGroupDescription
+  alias KafkaEx.Messages.ConsumerGroupListing
   alias KafkaEx.Messages.CreateTopics
   alias KafkaEx.Messages.DeleteTopics
   alias KafkaEx.Messages.Fetch
@@ -181,6 +182,10 @@ defmodule KafkaEx.API do
       # Consumer group functions
       def describe_group(group, opts \\ []) do
         unquote(api_module).describe_group(client(), group, opts)
+      end
+
+      def list_groups(opts \\ []) do
+        unquote(api_module).list_groups(client(), opts)
       end
 
       def join_group(group, member_id, opts \\ []) do
@@ -559,6 +564,49 @@ defmodule KafkaEx.API do
       {:ok, [group]} -> {:ok, group}
       {:error, error} -> {:error, error}
     end
+  end
+
+  @doc """
+  Lists the consumer groups known to the cluster.
+
+  ListGroups is answered per broker (each broker reports only the groups it
+  coordinates), so this fans the request out to every known broker and merges
+  the results. A consumer group is coordinated by exactly one broker, so the
+  merged list needs no de-duplication.
+
+  This is all-or-nothing: if any broker is unreachable or returns an error, the
+  call returns `{:error, {:node_error, node_id, reason}}` rather than a silently
+  partial list. Returns `{:error, :no_brokers_available}` if the client knows of
+  no brokers.
+
+  ## Examples
+
+      {:ok, groups} = KafkaEx.API.list_groups(client)
+  """
+  @spec list_groups(client) ::
+          {:ok, [ConsumerGroupListing.t()]}
+          | {:error, {:node_error, node_id, term} | :no_brokers_available}
+  @spec list_groups(client, opts) ::
+          {:ok, [ConsumerGroupListing.t()]}
+          | {:error, {:node_error, node_id, term} | :no_brokers_available}
+  def list_groups(client, opts \\ []) do
+    {:ok, %ClusterMetadata{} = cluster_metadata} = cluster_metadata(client)
+
+    case ClusterMetadata.brokers(cluster_metadata) do
+      [] -> {:error, :no_brokers_available}
+      brokers -> list_groups_across_brokers(client, brokers, opts)
+    end
+  end
+
+  defp list_groups_across_brokers(client, brokers, opts) do
+    node_ids = brokers |> Enum.map(& &1.node_id) |> Enum.sort()
+
+    Enum.reduce_while(node_ids, {:ok, []}, fn node_id, {:ok, acc} ->
+      case GenServer.call(client, {:list_groups, node_id, opts}) do
+        {:ok, listings} -> {:cont, {:ok, acc ++ listings}}
+        {:error, reason} -> {:halt, {:error, {:node_error, node_id, reason}}}
+      end
+    end)
   end
 
   @doc """

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -247,6 +247,13 @@ defmodule KafkaEx.Client do
     end
   end
 
+  def handle_call({:list_groups, node_id, opts}, _from, state) do
+    case list_groups_request(node_id, opts, state) do
+      {:error, error} -> {:reply, {:error, error}, state}
+      {result, updated_state} -> {:reply, result, updated_state}
+    end
+  end
+
   def handle_call({:offset_fetch, consumer_group, [{topic, partitions_data}], opts}, _from, state) do
     if KafkaEx.valid_consumer_group?(consumer_group) and is_binary(consumer_group) do
       case offset_fetch_request(consumer_group, {topic, partitions_data}, opts, state) do
@@ -433,6 +440,15 @@ defmodule KafkaEx.Client do
 
     case RequestBuilder.describe_groups_request(req_data, state) do
       {:ok, request} -> handle_describe_group_request(request, node_selector, state)
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp list_groups_request(node_id, opts, state) do
+    node_selector = NodeSelector.node_id(node_id)
+
+    case RequestBuilder.list_groups_request(opts, state) do
+      {:ok, request} -> handle_list_groups_request(request, node_selector, state)
       {:error, error} -> {:error, error}
     end
   end
@@ -738,6 +754,15 @@ defmodule KafkaEx.Client do
     %RequestContext{
       request: request,
       parser_fn: &ResponseParser.describe_groups_response/1,
+      node_selector: node_selector
+    }
+    |> handle_request_with_retry(state)
+  end
+
+  defp handle_list_groups_request(request, node_selector, state) do
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.list_groups_response/1,
       node_selector: node_selector
     }
     |> handle_request_with_retry(state)

--- a/lib/kafka_ex/client/request_builder.ex
+++ b/lib/kafka_ex/client/request_builder.ex
@@ -54,6 +54,21 @@ defmodule KafkaEx.Client.RequestBuilder do
   end
 
   @doc """
+  Builds request for List Groups API. ListGroups has no request fields.
+  """
+  @spec list_groups_request(Keyword.t(), State.t()) ::
+          {:ok, term} | {:error, :api_version_no_supported | :api_not_supported_by_broker}
+  def list_groups_request(request_opts, state) do
+    case get_api_version(state, :list_groups, request_opts) do
+      {:ok, api_version} ->
+        {:ok, @protocol.build_request(:list_groups, api_version, [])}
+
+      {:error, error_code} ->
+        {:error, error_code}
+    end
+  end
+
+  @doc """
   Builds request for List Offsets API
   """
   @spec lists_offset_request(Keyword.t(), State.t()) ::

--- a/lib/kafka_ex/client/response_parser.ex
+++ b/lib/kafka_ex/client/response_parser.ex
@@ -7,6 +7,7 @@ defmodule KafkaEx.Client.ResponseParser do
   alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Messages.ApiVersions
   alias KafkaEx.Messages.ConsumerGroupDescription
+  alias KafkaEx.Messages.ConsumerGroupListing
   alias KafkaEx.Messages.CreateTopics
   alias KafkaEx.Messages.DeleteTopics
   alias KafkaEx.Messages.Fetch
@@ -38,6 +39,14 @@ defmodule KafkaEx.Client.ResponseParser do
 
   @doc """
   Parses response for List Groups API
+  """
+  @spec list_groups_response(term) :: {:ok, [ConsumerGroupListing.t()]} | {:error, Error.t()}
+  def list_groups_response(response) do
+    @protocol.parse_response(:list_groups, response)
+  end
+
+  @doc """
+  Parses response for List Offsets API
   """
   @spec list_offsets_response(term) :: {:ok, [Offset.t()]} | {:error, Error.t()}
   def list_offsets_response(response) do

--- a/lib/kafka_ex/messages/consumer_group_listing.ex
+++ b/lib/kafka_ex/messages/consumer_group_listing.ex
@@ -1,0 +1,40 @@
+defmodule KafkaEx.Messages.ConsumerGroupListing do
+  @moduledoc """
+  A lightweight listing of a single consumer group in the cluster.
+
+  Java equivalent: `org.apache.kafka.clients.admin.ConsumerGroupListing`
+
+  Returned by the ListGroups API. Carries only the group id and protocol type;
+  use `KafkaEx.API.describe_group/2` for full group detail (state, members, ...).
+  """
+
+  @type t :: %__MODULE__{
+          group_id: binary,
+          protocol_type: binary
+        }
+
+  defstruct ~w(group_id protocol_type)a
+
+  @doc """
+  Builds a ConsumerGroupListing from a ListGroups API response group entry.
+  """
+  @spec from_list_groups_response(map) :: t()
+  def from_list_groups_response(group) do
+    %__MODULE__{
+      group_id: group.group_id,
+      protocol_type: group.protocol_type
+    }
+  end
+
+  @doc """
+  Returns the group ID.
+  """
+  @spec group_id(t()) :: binary
+  def group_id(%__MODULE__{group_id: group_id}), do: group_id
+
+  @doc """
+  Returns the protocol type (e.g. `"consumer"`).
+  """
+  @spec protocol_type(t()) :: binary
+  def protocol_type(%__MODULE__{protocol_type: protocol_type}), do: protocol_type
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups.ex
@@ -48,7 +48,7 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups do
 
     ## Return Values
     - Success: `{:ok, [ConsumerGroupListing.t()]}`
-    - Error: `{:error, atom}` (the top-level error code as an atom)
+    - Error: `{:error, KafkaEx.Client.Error.t()}` (the top-level error code)
 
     All known versions (V0-V3) have explicit implementations.
     The `Any` fallback handles unknown future versions.
@@ -57,7 +57,7 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups do
 
     alias KafkaEx.Messages.ConsumerGroupListing
 
-    @spec parse_response(t()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, atom}
+    @spec parse_response(t()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, KafkaEx.Client.Error.t()}
     def parse_response(response)
   end
 end

--- a/lib/kafka_ex/protocol/kayrock/list_groups.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups.ex
@@ -1,0 +1,63 @@
+defmodule KafkaEx.Protocol.Kayrock.ListGroups do
+  @moduledoc """
+  This module handles List Groups request & response parsing.
+  Request is built using the Kayrock protocol; the response is parsed to
+  native `KafkaEx.Messages.ConsumerGroupListing` structs.
+
+  ListGroups asks a single broker for the consumer groups it coordinates. A
+  cluster-wide listing (fan-out across all brokers + merge) is assembled in
+  `KafkaEx.API.list_groups/2`.
+
+  ## Supported Versions
+
+  - **V0**: Basic ListGroups
+    - Request: no fields
+    - Response: `error_code` (top-level) + `groups` (array of `group_id`, `protocol_type`)
+  - **V1**: Adds `throttle_time_ms` to response (not exposed in the domain layer)
+    - Request: same as V0
+  - **V2**: No changes vs V1 (pure version bump)
+  - **V3**: Flexible version (KIP-482)
+    - Request: `tagged_fields` only (Kayrock handles compact encoding)
+    - Response: compact encoding + `tagged_fields`; domain fields identical to V0
+
+  All known versions (V0-V3) have explicit `defimpl` implementations.
+  An `Any` fallback is retained for forward compatibility with unknown
+  future Kayrock versions.
+  """
+
+  defprotocol Request do
+    @moduledoc """
+    This protocol is used to build List Groups requests.
+
+    ListGroups carries no request fields at any version, so every
+    implementation returns the request template unchanged. The `opts`
+    argument is accepted for signature parity with other operations.
+
+    All known versions (V0-V3) have explicit implementations.
+    The `Any` fallback handles unknown future versions.
+    """
+    @fallback_to_any true
+
+    @spec build_request(t(), Keyword.t()) :: t()
+    def build_request(request, opts)
+  end
+
+  defprotocol Response do
+    @moduledoc """
+    This protocol is used to parse List Groups responses.
+
+    ## Return Values
+    - Success: `{:ok, [ConsumerGroupListing.t()]}`
+    - Error: `{:error, atom}` (the top-level error code as an atom)
+
+    All known versions (V0-V3) have explicit implementations.
+    The `Any` fallback handles unknown future versions.
+    """
+    @fallback_to_any true
+
+    alias KafkaEx.Messages.ConsumerGroupListing
+
+    @spec parse_response(t()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, atom}
+    def parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/any_request_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/any_request_impl.ex
@@ -1,0 +1,9 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Request, for: Any do
+  @moduledoc """
+  Fallback implementation of ListGroups Request for unknown future versions.
+
+  ListGroups has no request fields, so the template is returned unchanged.
+  """
+
+  def build_request(request, _opts), do: request
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/any_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/any_response_impl.ex
@@ -1,0 +1,13 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Any do
+  @moduledoc """
+  Fallback implementation of ListGroups Response for unknown future versions.
+
+  All versions share the same parsing via `ResponseHelpers.parse_response/1`.
+  """
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+
+  def parse_response(response) do
+    ResponseHelpers.parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
@@ -10,8 +10,8 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers do
   Kayrock but are not exposed in the domain layer.
   """
 
-  alias KafkaEx.Messages.ConsumerGroupListing
   alias KafkaEx.Client.Error, as: ErrorStruct
+  alias KafkaEx.Messages.ConsumerGroupListing
 
   @doc """
   Parses a ListGroups response for any version (V0-V3).

--- a/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
@@ -11,20 +11,20 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers do
   """
 
   alias KafkaEx.Messages.ConsumerGroupListing
-  alias Kayrock.ErrorCode
+  alias KafkaEx.Client.Error, as: ErrorStruct
 
   @doc """
   Parses a ListGroups response for any version (V0-V3).
 
   Returns `{:ok, [ConsumerGroupListing.t()]}` when the top-level `error_code`
-  is 0, otherwise `{:error, error_atom}`.
+  is 0, otherwise `{:error, ErrorStruct.t()}`.
   """
-  @spec parse_response(map()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, atom}
+  @spec parse_response(map()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, ErrorStruct.t()}
   def parse_response(%{error_code: 0, groups: groups}) do
     {:ok, Enum.map(groups, &ConsumerGroupListing.from_list_groups_response/1)}
   end
 
   def parse_response(%{error_code: error_code}) do
-    {:error, ErrorCode.code_to_atom(error_code)}
+    {:error, ErrorStruct.build(error_code, %{})}
   end
 end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/response_helpers.ex
@@ -1,0 +1,30 @@
+defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers do
+  @moduledoc """
+  Shared helper for parsing ListGroups responses across all versions (V0-V3).
+
+  Unlike DescribeGroups (per-group error codes), ListGroups reports a single
+  top-level `error_code`. A non-zero code means the queried broker could not
+  serve the listing.
+
+  `throttle_time_ms` (V1+) and per-group `tagged_fields` (V3) are parsed by
+  Kayrock but are not exposed in the domain layer.
+  """
+
+  alias KafkaEx.Messages.ConsumerGroupListing
+  alias Kayrock.ErrorCode
+
+  @doc """
+  Parses a ListGroups response for any version (V0-V3).
+
+  Returns `{:ok, [ConsumerGroupListing.t()]}` when the top-level `error_code`
+  is 0, otherwise `{:error, error_atom}`.
+  """
+  @spec parse_response(map()) :: {:ok, [ConsumerGroupListing.t()]} | {:error, atom}
+  def parse_response(%{error_code: 0, groups: groups}) do
+    {:ok, Enum.map(groups, &ConsumerGroupListing.from_list_groups_response/1)}
+  end
+
+  def parse_response(%{error_code: error_code}) do
+    {:error, ErrorCode.code_to_atom(error_code)}
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v0_request_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v0_request_impl.ex
@@ -1,0 +1,7 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Request, for: Kayrock.ListGroups.V0.Request do
+  @moduledoc """
+  Implementation for ListGroups v0 Request. V0 has no request fields.
+  """
+
+  def build_request(request, _opts), do: request
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v0_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v0_response_impl.ex
@@ -1,0 +1,11 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V0.Response do
+  @moduledoc """
+  Implementation for ListGroups v0 Response (no throttle_time_ms).
+  """
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+
+  def parse_response(response) do
+    ResponseHelpers.parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v1_request_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v1_request_impl.ex
@@ -1,0 +1,7 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Request, for: Kayrock.ListGroups.V1.Request do
+  @moduledoc """
+  Implementation for ListGroups v1 Request. V1 has no request fields.
+  """
+
+  def build_request(request, _opts), do: request
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v1_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v1_response_impl.ex
@@ -1,0 +1,11 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V1.Response do
+  @moduledoc """
+  Implementation for ListGroups v1 Response (adds throttle_time_ms (ignored in domain layer)).
+  """
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+
+  def parse_response(response) do
+    ResponseHelpers.parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v1_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v1_response_impl.ex
@@ -1,6 +1,6 @@
 defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V1.Response do
   @moduledoc """
-  Implementation for ListGroups v1 Response (adds throttle_time_ms (ignored in domain layer)).
+  Implementation for ListGroups v1 Response. Adds throttle_time_ms, ignored in the domain layer.
   """
 
   alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v2_request_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v2_request_impl.ex
@@ -1,0 +1,7 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Request, for: Kayrock.ListGroups.V2.Request do
+  @moduledoc """
+  Implementation for ListGroups v2 Request. V2 has no request fields.
+  """
+
+  def build_request(request, _opts), do: request
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v2_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v2_response_impl.ex
@@ -1,0 +1,11 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V2.Response do
+  @moduledoc """
+  Implementation for ListGroups v2 Response (adds throttle_time_ms (ignored in domain layer)).
+  """
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+
+  def parse_response(response) do
+    ResponseHelpers.parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v2_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v2_response_impl.ex
@@ -1,6 +1,6 @@
 defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V2.Response do
   @moduledoc """
-  Implementation for ListGroups v2 Response (adds throttle_time_ms (ignored in domain layer)).
+  Implementation for ListGroups v2 Response. Adds throttle_time_ms, ignored in the domain layer.
   """
 
   alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v3_request_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v3_request_impl.ex
@@ -1,0 +1,7 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Request, for: Kayrock.ListGroups.V3.Request do
+  @moduledoc """
+  Implementation for ListGroups v3 Request (FLEX). No request fields; tagged_fields handled by Kayrock.
+  """
+
+  def build_request(request, _opts), do: request
+end

--- a/lib/kafka_ex/protocol/kayrock/list_groups/v3_response_impl.ex
+++ b/lib/kafka_ex/protocol/kayrock/list_groups/v3_response_impl.ex
@@ -1,0 +1,11 @@
+defimpl KafkaEx.Protocol.Kayrock.ListGroups.Response, for: Kayrock.ListGroups.V3.Response do
+  @moduledoc """
+  Implementation for ListGroups v3 Response (FLEX version; tagged_fields ignored in domain layer).
+  """
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+
+  def parse_response(response) do
+    ResponseHelpers.parse_response(response)
+  end
+end

--- a/lib/kafka_ex/protocol/kayrock_protocol.ex
+++ b/lib/kafka_ex/protocol/kayrock_protocol.ex
@@ -18,6 +18,7 @@ defmodule KafkaEx.Protocol.KayrockProtocol do
   alias Kayrock.JoinGroup
   alias Kayrock.KafkaSchemaMetadata
   alias Kayrock.LeaveGroup
+  alias Kayrock.ListGroups
   alias Kayrock.ListOffsets
   alias Kayrock.Metadata
   alias Kayrock.OffsetCommit
@@ -58,6 +59,12 @@ defmodule KafkaEx.Protocol.KayrockProtocol do
     api_version
     |> DescribeGroups.get_request_struct()
     |> KayrockProtocol.DescribeGroups.Request.build_request(opts)
+  end
+
+  def build_request(:list_groups, api_version, opts) do
+    api_version
+    |> ListGroups.get_request_struct()
+    |> KayrockProtocol.ListGroups.Request.build_request(opts)
   end
 
   def build_request(:list_offsets, api_version, opts) do
@@ -144,6 +151,7 @@ defmodule KafkaEx.Protocol.KayrockProtocol do
   """
   def parse_response(:api_versions, response), do: KayrockProtocol.ApiVersions.Response.parse_response(response)
   def parse_response(:describe_groups, response), do: KayrockProtocol.DescribeGroups.Response.parse_response(response)
+  def parse_response(:list_groups, response), do: KayrockProtocol.ListGroups.Response.parse_response(response)
   def parse_response(:list_offsets, response), do: KayrockProtocol.ListOffsets.Response.parse_response(response)
   def parse_response(:offset_fetch, response), do: KayrockProtocol.OffsetFetch.Response.parse_response(response)
   def parse_response(:offset_commit, response), do: KayrockProtocol.OffsetCommit.Response.parse_response(response)

--- a/test/integration/consumer_group/list_groups_test.exs
+++ b/test/integration/consumer_group/list_groups_test.exs
@@ -1,0 +1,42 @@
+defmodule KafkaEx.Integration.ConsumerGroup.ListGroupsTest do
+  use ExUnit.Case, async: false
+  @moduletag :consumer_group
+
+  import KafkaEx.TestHelpers
+  import KafkaEx.IntegrationHelpers
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Client
+  alias KafkaEx.API
+  alias KafkaEx.Messages.ConsumerGroupListing
+  alias KafkaEx.Test.KayrockFixtures, as: Fixtures
+
+  setup do
+    {:ok, args} = KafkaEx.build_worker_options([])
+    {:ok, pid} = Client.start_link(args, :no_name)
+    on_exit(fn -> stop_safely(pid) end)
+
+    {:ok, %{client: pid}}
+  end
+
+  test "list_groups returns a joined consumer group from across the cluster", %{client: client} do
+    topic_name = generate_random_string()
+    consumer_group = generate_random_string()
+    _ = create_topic(client, topic_name)
+
+    group_protocols = [
+      %{name: "assign", metadata: Fixtures.group_protocol_metadata(topics: [topic_name])}
+    ]
+
+    opts = [session_timeout: 30_000, rebalance_timeout: 60_000, group_protocols: group_protocols]
+    {:ok, _join} = join_group_with_retry(client, consumer_group, "", opts)
+
+    assert {:ok, listings} = API.list_groups(client)
+
+    assert Enum.any?(listings, fn
+             %ConsumerGroupListing{group_id: ^consumer_group, protocol_type: "consumer"} -> true
+             _ -> false
+           end),
+           "expected #{consumer_group} (protocol_type \"consumer\") in #{inspect(listings)}"
+  end
+end

--- a/test/kafka_ex/api_test.exs
+++ b/test/kafka_ex/api_test.exs
@@ -6,6 +6,7 @@ defmodule KafkaEx.APITest do
   alias KafkaEx.Cluster.Topic
   alias KafkaEx.Messages.ApiVersions
   alias KafkaEx.Messages.ConsumerGroupDescription
+  alias KafkaEx.Messages.ConsumerGroupListing
   alias KafkaEx.Messages.CreateTopics
   alias KafkaEx.Messages.DeleteTopics
   alias KafkaEx.Messages.Fetch
@@ -471,6 +472,98 @@ defmodule KafkaEx.APITest do
       {:ok, client} = MockClient.start_link(%{describe_groups: {:error, :group_not_found}})
 
       assert {:error, :group_not_found} = KafkaEx.API.describe_group(client, "unknown-group")
+    end
+  end
+
+  describe "list_groups/2" do
+    setup do
+      cluster = %ClusterMetadata{
+        brokers: %{
+          0 => %Broker{node_id: 0, host: "localhost", port: 9092},
+          1 => %Broker{node_id: 1, host: "localhost", port: 9093},
+          2 => %Broker{node_id: 2, host: "localhost", port: 9094}
+        }
+      }
+
+      {:ok, %{cluster: cluster}}
+    end
+
+    test "merges groups across all brokers (sorted by node_id)", %{cluster: cluster} do
+      {:ok, client} =
+        MockClient.start_link(%{
+          cluster_metadata: {:ok, cluster},
+          list_groups: %{
+            0 => {:ok, [%ConsumerGroupListing{group_id: "g0", protocol_type: "consumer"}]},
+            1 => {:ok, [%ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"}]},
+            2 => {:ok, [%ConsumerGroupListing{group_id: "g2", protocol_type: "connect"}]}
+          }
+        })
+
+      assert {:ok, listings} = KafkaEx.API.list_groups(client)
+
+      assert listings == [
+               %ConsumerGroupListing{group_id: "g0", protocol_type: "consumer"},
+               %ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"},
+               %ConsumerGroupListing{group_id: "g2", protocol_type: "connect"}
+             ]
+    end
+
+    test "queries every broker exactly once", %{cluster: cluster} do
+      {:ok, client} = MockClient.start_link(%{cluster_metadata: {:ok, cluster}, list_groups: %{}})
+
+      {:ok, _} = KafkaEx.API.list_groups(client)
+
+      node_ids =
+        client
+        |> MockClient.get_calls()
+        |> Enum.filter(&match?({:list_groups, _, _}, &1))
+        |> Enum.map(fn {:list_groups, node_id, _opts} -> node_id end)
+
+      assert node_ids == [0, 1, 2]
+    end
+
+    test "is all-or-nothing: any broker error aborts with {:node_error, node_id, reason}", %{
+      cluster: cluster
+    } do
+      {:ok, client} =
+        MockClient.start_link(%{
+          cluster_metadata: {:ok, cluster},
+          list_groups: %{
+            0 => {:ok, [%ConsumerGroupListing{group_id: "g0", protocol_type: "consumer"}]},
+            1 => {:ok, []},
+            2 => {:error, :coordinator_not_available}
+          }
+        })
+
+      assert KafkaEx.API.list_groups(client) ==
+               {:error, {:node_error, 2, :coordinator_not_available}}
+    end
+
+    test "returns {:error, :no_brokers_available} when the cluster has no brokers" do
+      {:ok, client} =
+        MockClient.start_link(%{cluster_metadata: {:ok, %ClusterMetadata{brokers: %{}}}})
+
+      assert KafkaEx.API.list_groups(client) == {:error, :no_brokers_available}
+    end
+
+    test "returns {:ok, []} when brokers exist but coordinate no groups", %{cluster: cluster} do
+      {:ok, client} = MockClient.start_link(%{cluster_metadata: {:ok, cluster}, list_groups: %{}})
+
+      assert KafkaEx.API.list_groups(client) == {:ok, []}
+    end
+
+    test "passes a caller-supplied api_version straight through to each broker", %{cluster: cluster} do
+      {:ok, client} = MockClient.start_link(%{cluster_metadata: {:ok, cluster}, list_groups: %{}})
+
+      {:ok, _} = KafkaEx.API.list_groups(client, api_version: 2)
+
+      opts_seen =
+        client
+        |> MockClient.get_calls()
+        |> Enum.filter(&match?({:list_groups, _, _}, &1))
+        |> Enum.map(fn {:list_groups, _node_id, opts} -> opts end)
+
+      assert Enum.all?(opts_seen, &(&1 == [api_version: 2]))
     end
   end
 

--- a/test/kafka_ex/api_test.exs
+++ b/test/kafka_ex/api_test.exs
@@ -539,6 +539,31 @@ defmodule KafkaEx.APITest do
                {:error, {:node_error, 2, :coordinator_not_available}}
     end
 
+    test "halts the fan-out on the first broker error and skips remaining brokers", %{
+      cluster: cluster
+    } do
+      {:ok, client} =
+        MockClient.start_link(%{
+          cluster_metadata: {:ok, cluster},
+          list_groups: %{
+            0 => {:error, :coordinator_not_available},
+            1 => {:ok, [%ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"}]},
+            2 => {:ok, [%ConsumerGroupListing{group_id: "g2", protocol_type: "connect"}]}
+          }
+        })
+
+      assert KafkaEx.API.list_groups(client) ==
+               {:error, {:node_error, 0, :coordinator_not_available}}
+
+      node_ids =
+        client
+        |> MockClient.get_calls()
+        |> Enum.filter(&match?({:list_groups, _, _}, &1))
+        |> Enum.map(fn {:list_groups, node_id, _opts} -> node_id end)
+
+      assert node_ids == [0]
+    end
+
     test "returns {:error, :no_brokers_available} when the cluster has no brokers" do
       {:ok, client} =
         MockClient.start_link(%{cluster_metadata: {:ok, %ClusterMetadata{brokers: %{}}}})

--- a/test/kafka_ex/client/list_groups_dispatch_test.exs
+++ b/test/kafka_ex/client/list_groups_dispatch_test.exs
@@ -1,0 +1,72 @@
+defmodule KafkaEx.Client.ListGroupsDispatchTest do
+  @moduledoc """
+  Regression for the ListGroups final-review Critical finding: a non-zero
+  top-level `error_code` in a REAL ListGroups response must flow through
+  `handle_request_with_retry/4` as a `%KafkaEx.Client.Error{}`, not a bare
+  atom.
+
+  Pre-fix, `ResponseHelpers.parse_response/1` returned `{:error, error_atom}`
+  for a non-zero `error_code`. `handle_request_with_retry/4` only matches
+  `{:error, [error | _]}` or `{:error, %Error{} = error}`, so a bare atom hit
+  no clause and raised `CaseClauseError`, crashing the client `GenServer`.
+
+  This test drives the REAL pipeline: the network layer returns actual wire
+  bytes for a `Kayrock.ListGroups.V0.Response{error_code: 15}`, which are
+  deserialized by the real Kayrock/KayrockProtocol stack and parsed by the
+  real `ResponseHelpers.parse_response/1` before reaching the retry loop --
+  unlike the response/response_helpers unit tests, which call the parser
+  directly and would not have caught this.
+  """
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias KafkaEx.Client
+  alias KafkaEx.Client.Error
+  alias KafkaEx.Client.State
+  alias KafkaEx.Cluster.Broker
+  alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Network.NetworkClient
+  alias KafkaEx.Network.Socket
+
+  setup :set_mimic_private
+
+  setup do
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, lport} = :inet.port(listen)
+    {:ok, sock} = :gen_tcp.connect(~c"localhost", lport, [:binary, active: false])
+
+    on_exit(fn ->
+      :gen_tcp.close(sock)
+      :gen_tcp.close(listen)
+    end)
+
+    broker = %Broker{node_id: 1, host: "localhost", port: lport, socket: %Socket{socket: sock, ssl: false}}
+
+    state = %State{
+      correlation_id: 7,
+      cluster_metadata: %ClusterMetadata{brokers: %{1 => broker}}
+    }
+
+    {:ok, state: state}
+  end
+
+  test "a non-zero top-level error_code from the broker returns %Error{} without crashing", %{
+    state: state
+  } do
+    # Wire bytes for a real Kayrock.ListGroups.V0.Response: correlation_id,
+    # error_code = 15 (coordinator_not_available), empty groups array.
+    wire_response = <<state.correlation_id::32-signed, 15::16-signed, 0::32-signed>>
+
+    stub(NetworkClient, :send_sync_request, fn _broker, _wire, _timeout -> wire_response end)
+
+    # Pre-fix, ResponseHelpers.parse_response/1 returned a bare atom that hit
+    # no clause in handle_request_with_retry/4, raising a CaseClauseError
+    # right here. Calling handle_call/3 directly (as Mimic's :set_mimic_private
+    # requires) and asserting a clean {:reply, ...} -- with no exception --
+    # is exactly what proves the GenServer no longer crashes.
+    assert {:reply, result, %State{}} =
+             Client.handle_call({:list_groups, 1, [api_version: 0]}, self(), state)
+
+    assert {:error, %Error{error: :coordinator_not_available}} = result
+  end
+end

--- a/test/kafka_ex/client/request_builder_test.exs
+++ b/test/kafka_ex/client/request_builder_test.exs
@@ -347,6 +347,32 @@ defmodule KafkaEx.Client.RequestBuilderTest do
     end
   end
 
+  describe "list_groups_request/2" do
+    test "returns request for ListGroups API at negotiated max (default)" do
+      state = %KafkaEx.Client.State{api_versions: %{16 => {0, 3}}}
+
+      {:ok, request} = RequestBuilder.list_groups_request([], state)
+
+      assert Fixtures.request_type?(request, :list_groups, 3)
+    end
+
+    test "honors a caller-supplied api_version" do
+      state = %KafkaEx.Client.State{api_versions: %{16 => {0, 3}}}
+
+      {:ok, request} = RequestBuilder.list_groups_request([api_version: 0], state)
+
+      assert Fixtures.request_type?(request, :list_groups, 0)
+    end
+
+    test "returns error when requested api version exceeds broker max" do
+      state = %KafkaEx.Client.State{api_versions: %{16 => {0, 0}}}
+
+      {:error, error_value} = RequestBuilder.list_groups_request([api_version: 2], state)
+
+      assert error_value == :api_version_no_supported
+    end
+  end
+
   describe "lists_offset_request/2" do
     test "returns request for ListOffsets API (negotiated max)" do
       state = %KafkaEx.Client.State{api_versions: %{2 => {0, 2}}}

--- a/test/kafka_ex/client/response_parser_test.exs
+++ b/test/kafka_ex/client/response_parser_test.exs
@@ -843,6 +843,18 @@ defmodule KafkaEx.Client.ResponseParserTest do
     end
   end
 
+  describe "list_groups_response/1" do
+    test "delegates to the protocol and returns ConsumerGroupListing structs" do
+      response = %Kayrock.ListGroups.V0.Response{
+        error_code: 0,
+        groups: [%{group_id: "g1", protocol_type: "consumer"}]
+      }
+
+      assert {:ok, [%KafkaEx.Messages.ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"}]} =
+               KafkaEx.Client.ResponseParser.list_groups_response(response)
+    end
+  end
+
   describe "list_offsets_response/1" do
     test "parses successful ListOffsets v0 response" do
       response =

--- a/test/kafka_ex/messages/consumer_group_listing_test.exs
+++ b/test/kafka_ex/messages/consumer_group_listing_test.exs
@@ -1,0 +1,30 @@
+defmodule KafkaEx.Messages.ConsumerGroupListingTest do
+  use ExUnit.Case, async: true
+
+  alias KafkaEx.Messages.ConsumerGroupListing
+
+  describe "from_list_groups_response/1" do
+    test "builds a listing from a Kayrock group map (group_id + protocol_type)" do
+      group = %{group_id: "my-group", protocol_type: "consumer"}
+
+      assert ConsumerGroupListing.from_list_groups_response(group) ==
+               %ConsumerGroupListing{group_id: "my-group", protocol_type: "consumer"}
+    end
+
+    test "ignores extra keys such as tagged_fields (V3 entries)" do
+      group = %{group_id: "g", protocol_type: "consumer", tagged_fields: []}
+
+      assert ConsumerGroupListing.from_list_groups_response(group) ==
+               %ConsumerGroupListing{group_id: "g", protocol_type: "consumer"}
+    end
+  end
+
+  describe "accessors" do
+    test "group_id/1 and protocol_type/1 return their fields" do
+      listing = %ConsumerGroupListing{group_id: "g", protocol_type: "connect"}
+
+      assert ConsumerGroupListing.group_id(listing) == "g"
+      assert ConsumerGroupListing.protocol_type(listing) == "connect"
+    end
+  end
+end

--- a/test/kafka_ex/protocol/kayrock/list_groups/request_test.exs
+++ b/test/kafka_ex/protocol/kayrock/list_groups/request_test.exs
@@ -1,0 +1,43 @@
+defmodule KafkaEx.Protocol.Kayrock.ListGroups.RequestTest do
+  use ExUnit.Case, async: true
+
+  # ListGroups has no request fields at any version, so build_request/2 is a
+  # pass-through: it returns the template struct unchanged.
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups
+
+  describe "V0-V2 Request implementations (no request fields)" do
+    test "V0 returns the request struct unchanged" do
+      request = %Kayrock.ListGroups.V0.Request{correlation_id: 1, client_id: "c"}
+      assert ListGroups.Request.build_request(request, []) == request
+    end
+
+    test "V1 returns the request struct unchanged" do
+      request = %Kayrock.ListGroups.V1.Request{correlation_id: 2, client_id: "c"}
+      assert ListGroups.Request.build_request(request, []) == request
+    end
+
+    test "V2 returns the request struct unchanged" do
+      request = %Kayrock.ListGroups.V2.Request{correlation_id: 3, client_id: "c"}
+      assert ListGroups.Request.build_request(request, []) == request
+    end
+  end
+
+  describe "V3 Request implementation (FLEX)" do
+    test "returns the request struct unchanged and keeps tagged_fields default" do
+      request = %Kayrock.ListGroups.V3.Request{correlation_id: 4, client_id: "c"}
+
+      result = ListGroups.Request.build_request(request, [])
+
+      assert result == request
+      assert result.tagged_fields == []
+    end
+  end
+
+  describe "Any fallback Request implementation" do
+    test "returns an unknown-version template unchanged" do
+      template = %{some_field: "future"}
+      assert ListGroups.Request.build_request(template, []) == template
+    end
+  end
+end

--- a/test/kafka_ex/protocol/kayrock/list_groups/response_helpers_test.exs
+++ b/test/kafka_ex/protocol/kayrock/list_groups/response_helpers_test.exs
@@ -25,9 +25,9 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpersTest do
     assert ResponseHelpers.parse_response(%{error_code: 0, groups: []}) == {:ok, []}
   end
 
-  test "returns {:error, atom} for a non-zero top-level error_code" do
+  test "returns {:error, %KafkaEx.Client.Error{}} for a non-zero top-level error_code" do
     # 15 = coordinator_not_available
-    assert ResponseHelpers.parse_response(%{error_code: 15, groups: []}) ==
-             {:error, :coordinator_not_available}
+    assert {:error, %KafkaEx.Client.Error{error: :coordinator_not_available}} =
+             ResponseHelpers.parse_response(%{error_code: 15, groups: []})
   end
 end

--- a/test/kafka_ex/protocol/kayrock/list_groups/response_helpers_test.exs
+++ b/test/kafka_ex/protocol/kayrock/list_groups/response_helpers_test.exs
@@ -1,0 +1,33 @@
+defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups.ResponseHelpers
+  alias KafkaEx.Messages.ConsumerGroupListing
+
+  test "maps groups to ConsumerGroupListing structs when error_code is 0" do
+    response = %{
+      error_code: 0,
+      groups: [
+        %{group_id: "g1", protocol_type: "consumer"},
+        %{group_id: "g2", protocol_type: "connect"}
+      ]
+    }
+
+    assert ResponseHelpers.parse_response(response) ==
+             {:ok,
+              [
+                %ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"},
+                %ConsumerGroupListing{group_id: "g2", protocol_type: "connect"}
+              ]}
+  end
+
+  test "returns {:ok, []} when there are no groups" do
+    assert ResponseHelpers.parse_response(%{error_code: 0, groups: []}) == {:ok, []}
+  end
+
+  test "returns {:error, atom} for a non-zero top-level error_code" do
+    # 15 = coordinator_not_available
+    assert ResponseHelpers.parse_response(%{error_code: 15, groups: []}) ==
+             {:error, :coordinator_not_available}
+  end
+end

--- a/test/kafka_ex/protocol/kayrock/list_groups/response_test.exs
+++ b/test/kafka_ex/protocol/kayrock/list_groups/response_test.exs
@@ -1,0 +1,58 @@
+defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseTest do
+  use ExUnit.Case, async: true
+
+  alias KafkaEx.Protocol.Kayrock.ListGroups
+  alias KafkaEx.Messages.ConsumerGroupListing
+
+  @groups [
+    %{group_id: "succeeded", protocol_type: "consumer"}
+  ]
+
+  @expected [%ConsumerGroupListing{group_id: "succeeded", protocol_type: "consumer"}]
+
+  describe "V0 Response implementation" do
+    test "parses groups (no throttle_time_ms)" do
+      response = %Kayrock.ListGroups.V0.Response{error_code: 0, groups: @groups}
+      assert ListGroups.Response.parse_response(response) == {:ok, @expected}
+    end
+
+    test "surfaces a non-zero top-level error_code" do
+      response = %Kayrock.ListGroups.V0.Response{error_code: 15, groups: []}
+      assert ListGroups.Response.parse_response(response) == {:error, :coordinator_not_available}
+    end
+  end
+
+  describe "V1/V2 Response implementations (throttle_time_ms ignored)" do
+    test "V1 parses groups and ignores throttle_time_ms" do
+      response = %Kayrock.ListGroups.V1.Response{error_code: 0, throttle_time_ms: 5, groups: @groups}
+      assert ListGroups.Response.parse_response(response) == {:ok, @expected}
+    end
+
+    test "V2 parses groups and ignores throttle_time_ms" do
+      response = %Kayrock.ListGroups.V2.Response{error_code: 0, throttle_time_ms: 7, groups: @groups}
+      assert ListGroups.Response.parse_response(response) == {:ok, @expected}
+    end
+  end
+
+  describe "V3 Response implementation (FLEX)" do
+    test "parses groups and ignores throttle_time_ms/tagged_fields" do
+      groups = [%{group_id: "succeeded", protocol_type: "consumer", tagged_fields: []}]
+
+      response = %Kayrock.ListGroups.V3.Response{
+        error_code: 0,
+        throttle_time_ms: 0,
+        groups: groups,
+        tagged_fields: []
+      }
+
+      assert ListGroups.Response.parse_response(response) == {:ok, @expected}
+    end
+  end
+
+  describe "Any fallback Response implementation" do
+    test "parses an unknown-version response map via the shared helper" do
+      response = %{error_code: 0, groups: @groups}
+      assert ListGroups.Response.parse_response(response) == {:ok, @expected}
+    end
+  end
+end

--- a/test/kafka_ex/protocol/kayrock/list_groups/response_test.exs
+++ b/test/kafka_ex/protocol/kayrock/list_groups/response_test.exs
@@ -18,7 +18,9 @@ defmodule KafkaEx.Protocol.Kayrock.ListGroups.ResponseTest do
 
     test "surfaces a non-zero top-level error_code" do
       response = %Kayrock.ListGroups.V0.Response{error_code: 15, groups: []}
-      assert ListGroups.Response.parse_response(response) == {:error, :coordinator_not_available}
+
+      assert {:error, %KafkaEx.Client.Error{error: :coordinator_not_available}} =
+               ListGroups.Response.parse_response(response)
     end
   end
 

--- a/test/kafka_ex/protocol/kayrock_protocol_test.exs
+++ b/test/kafka_ex/protocol/kayrock_protocol_test.exs
@@ -149,6 +149,23 @@ defmodule KafkaEx.Protocol.KayrockProtocolTest do
 
       assert request != nil
     end
+
+    test "builds list_groups request" do
+      request = KayrockProtocol.build_request(:list_groups, 0, [])
+      assert %Kayrock.ListGroups.V0.Request{} = request
+    end
+  end
+
+  describe "parse_response/2" do
+    test "parses list_groups response" do
+      response = %Kayrock.ListGroups.V0.Response{
+        error_code: 0,
+        groups: [%{group_id: "g1", protocol_type: "consumer"}]
+      }
+
+      assert {:ok, [%KafkaEx.Messages.ConsumerGroupListing{group_id: "g1", protocol_type: "consumer"}]} =
+               KayrockProtocol.parse_response(:list_groups, response)
+    end
   end
 
   describe "request_info/1" do

--- a/test/support/kayrock_fixtures.ex
+++ b/test/support/kayrock_fixtures.ex
@@ -167,6 +167,7 @@ defmodule KafkaEx.Test.KayrockFixtures do
     heartbeat: Kayrock.Heartbeat,
     join_group: Kayrock.JoinGroup,
     leave_group: Kayrock.LeaveGroup,
+    list_groups: Kayrock.ListGroups,
     list_offsets: Kayrock.ListOffsets,
     metadata: Kayrock.Metadata,
     offset_commit: Kayrock.OffsetCommit,

--- a/test/support/mock_client.ex
+++ b/test/support/mock_client.ex
@@ -80,6 +80,12 @@ defmodule KafkaEx.Test.MockClient do
     {:reply, response, record_call(state, {:describe_groups, groups})}
   end
 
+  def handle_call({:list_groups, node_id, opts}, _from, state) do
+    per_node = Map.get(state.responses, :list_groups, %{})
+    response = Map.get(per_node, node_id, {:ok, []})
+    {:reply, response, record_call(state, {:list_groups, node_id, opts})}
+  end
+
   def handle_call({:join_group, group, member_id, _opts}, _from, state) do
     response = Map.get(state.responses, :join_group, {:ok, %JoinGroup{}})
     {:reply, response, record_call(state, {:join_group, group, member_id})}


### PR DESCRIPTION
## What

Adds a cluster-wide `KafkaEx.API.list_groups/2` admin API (the ListGroups protocol operation), closing #90.

`list_groups/2` (and `list_groups/1` on the `use KafkaEx.API` macro) returns the consumer groups known to the cluster:

```elixir
{:ok, groups} = KafkaEx.API.list_groups(client)
# => [%KafkaEx.Messages.ConsumerGroupListing{group_id: "my-group", protocol_type: "consumer"}, ...]
```

## Why cluster-wide

Each broker answers ListGroups with only the groups **it** coordinates, so a single-broker request returns a silently partial view. `list_groups/2` therefore fans the request out to every known broker (via `cluster_metadata` → `NodeSelector.node_id/1`) and merges. The fan-out lives in the API layer over the existing per-node request machinery — the client's `handle_call({:list_groups, node_id, opts})` is a faithful single-node mirror of the `describe_groups` dispatch.

Design choices:
- **Sequential** fan-out — every call serializes on the same client `GenServer`, so concurrency would buy nothing and would hold the client busy longer.
- **All-or-nothing:** any broker down / non-zero `error_code` → `{:error, {:node_error, node_id, reason}}`. Empty cluster → `{:error, :no_brokers_available}`. A partial list is never returned silently.
- **Concat merge, no dedup** — a group is coordinated by exactly one broker.

## Protocol layer

New `lib/kafka_ex/protocol/kayrock/list_groups/` mirrors `describe_groups/`: V0–V3 request/response `defimpl`s + `Any` fallback + `response_helpers`. Two deliberate differences from that template: ListGroups has **no request fields** (pass-through request impls, no `request_helpers`), and reports a **top-level** `error_code` (not per-group). No `KafkaSchemaMetadata` change was needed — Kayrock already knows `:list_groups` (api_key 16, version range {0,3}).

## Testing

- Protocol impl tests across V0–V3 (throttle_time_ms ignored on V1+, tagged fields on V3, `Any` fallback).
- API fan-out unit tests through the public API: merge across brokers, all-or-nothing halt (incl. an early-broker failure asserting later brokers are never queried), empty cluster, no-groups, api_version pass-through.
- A client-pipeline regression test that drives a non-zero broker `error_code` through the real deserialize → parse → `handle_request_with_retry` path (asserting a clean `{:error, %Error{}}`, not a crash).
- Live integration test (`:consumer_group`) on the 3-broker cluster: join a group, `list_groups`, assert it appears with `protocol_type "consumer"`.

Full unit suite green (3047, 1 skip), dialyzer clean, integration green, formatted, warning-free.
