### PR TITLE
fix: consumer-group JoinGroup/SyncGroup cold-start timeout + :request_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@
   KafkaEx 2.0. It remains honored as an alias; setting it without `:request_timeout` logs a
   one-time deprecation warning at client boot. See UPGRADING.md.
 
+### Changed
+
+* **Consumer-group defaults aligned with the Apache Kafka 3.0+ consumer.**
+  `session_timeout` default is now `45_000` ms (was `30_000`; matches KIP-735, which raised
+  `session.timeout.ms` to cut spurious rebalances) and `heartbeat_interval` is now `3_000` ms
+  (was `5_000`; the canonical Kafka pairing, ≈ 1/15 of the session). The derived
+  `rebalance_timeout` default (`session_timeout × 3`) is therefore `135_000` ms. **Behavior
+  change:** a dead member is now detected after ~45 s of missed heartbeats instead of ~30 s
+  (fewer spurious rebalances on transient hiccups), and heartbeats are sent more frequently.
+  Override `:session_timeout` / `:heartbeat_interval` to restore the old values. See UPGRADING.md.
+
 ## 1.0.1 (2026-06-26)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,27 @@
   logs a warning and the consumer runs dynamically. A duplicate id is fenced
   (`:fenced_instance_id` → terminal stop, `member_terminated{terminal_class: :fenced}`).
 
+* **Per-attempt request timeout is now configurable via `:request_timeout`** (default
+  `15_000` ms) — the `Socket.recv` deadline for a single synchronous broker request attempt
+  (metadata, offset commit/fetch, heartbeat, produce ack, …). Consumer-group JoinGroup/SyncGroup
+  derive their own, longer per-attempt deadlines from the group's rebalance/session timeouts.
+
+* **Retry backoff now applies ±20% jitter (KIP-580)** in `KafkaEx.Support.Retry.with_retry/2`,
+  decorrelating retries across many consumer-group members after a shared coordinator/broker blip.
+
 ### Fixed
+
+* **Consumer-group cold start no longer times out (JoinGroup/SyncGroup socket timeouts).**
+  JoinGroup/SyncGroup previously fell back to the `1000` ms generic socket-recv timeout, while the
+  broker legitimately holds a JoinGroup response for up to `group.initial.rebalance.delay.ms`
+  (default 3 s) on a cold/empty group — so the first member reliably timed out and never joined.
+  (The library's own `config.exs` value never propagated to consumers, so the effective default
+  was the `1000` ms code fallback.) JoinGroup's per-attempt deadline is now `rebalance_timeout +
+  5000` and SyncGroup's is derived from the session window; both are sent **send-once** at the
+  client, with `ConsumerGroup.Manager` owning rejoin — matching the Java/kafka-python/librdkafka
+  model. The outer `GenServer.call` budget is derived from the per-attempt deadline so the two can
+  no longer mismatch (the #357 class of bug). A socket recv-timeout is no longer retried inside the
+  synchronous client loop; protocol errors keep their retry + metadata/coordinator refresh.
 
 * **The abnormal heartbeat-crash rejoin loop is now bounded (#560).** When a
   consumer-group member's heartbeat process dies abnormally — an uncatchable
@@ -32,6 +52,12 @@
   `member_terminated` metadata gains a low-cardinality `terminal_class` atom
   (`:fenced | :auth | :crash_loop | :crashed | :error | :client_died | :other`)
   for alert routing.
+
+### Deprecated
+
+* **`:sync_timeout` is deprecated in favour of `:request_timeout`** and will be removed in
+  KafkaEx 2.0. It remains honored as an alias; setting it without `:request_timeout` logs a
+  one-time deprecation warning at client boot. See UPGRADING.md.
 
 ## 1.0.1 (2026-06-26)
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ config :kafka_ex,
   # Default consumer group
   default_consumer_group: "my-consumer-group",
 
-  # Request timeout (milliseconds)
-  sync_timeout: 10_000
+  # Per-attempt request timeout, in milliseconds (default 15_000).
+  # Was `:sync_timeout` (now a deprecated alias, removed in 2.0).
+  request_timeout: 10_000
 ```
 
 ### SSL/TLS Configuration

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -161,6 +161,32 @@ default 3s). Two consequences for that window:
     members, KIP-345, intentionally skip LeaveGroup anyway). Raise the group's
     child `shutdown:` if graceful mid-rebalance leave matters for your deploys.
 
+## Consumer-group defaults aligned with Kafka 3.0
+
+Two consumer-group defaults now match the Apache Kafka 3.0+ consumer:
+
+| Option | Old default | New default | Why |
+|---|---|---|---|
+| `session_timeout` | `30_000` | `45_000` | KIP-735 — fewer spurious rebalances |
+| `heartbeat_interval` | `5_000` | `3_000` | Kafka's canonical pairing (≈ session / 15) |
+
+The derived `rebalance_timeout` default (`session_timeout × 3`) is therefore
+`135_000` ms.
+
+**Behavior change.** A dead/partitioned member is now declared dead after ~45 s
+of missed heartbeats instead of ~30 s — a transient hiccup is less likely to
+trigger a rebalance, at the cost of slightly slower detection of a genuinely
+gone member. Heartbeats are also sent more often (every 3 s). To keep the old
+behavior, set them explicitly:
+
+```elixir
+KafkaEx.Consumer.ConsumerGroup.start_link(
+  MyConsumer, "my-group", ["topic"],
+  session_timeout: 30_000,
+  heartbeat_interval: 5_000
+)
+```
+
 ---
 
 # Upgrading to KafkaEx 1.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -89,6 +89,42 @@ KafkaEx.Consumer.ConsumerGroup.start_link(
 Requires Kafka >= 2.3. A too-old broker logs a warning and the consumer runs
 with dynamic membership (no error, no crash).
 
+## Consumer-group JoinGroup/SyncGroup timeouts and the new `:request_timeout`
+
+**What changed.** JoinGroup and SyncGroup used to fall back to the generic
+socket-recv timeout — effectively `1000` ms for apps that did not set
+`:sync_timeout`. Because the broker legitimately holds a JoinGroup response for
+up to `group.initial.rebalance.delay.ms` (default 3 s) on a cold/empty group,
+the first consumer to join reliably timed out and never joined. These requests
+now derive their own, longer per-attempt deadlines (JoinGroup =
+`rebalance_timeout + 5000`; SyncGroup from the session window) and are sent
+send-once, with the consumer-group manager owning rejoin.
+
+**`:sync_timeout` → `:request_timeout`.** The generic per-attempt request timeout
+is now configured with `:request_timeout` (default `15_000` ms). `:sync_timeout`
+is deprecated but still honored as an alias; it will be removed in 2.0. Setting
+`:sync_timeout` without `:request_timeout` logs a one-time warning at client boot.
+
+```elixir
+# Before
+config :kafka_ex, sync_timeout: 3_000
+
+# After
+config :kafka_ex, request_timeout: 15_000
+```
+
+**If you raised `:sync_timeout` as a workaround for consumer-group join
+timeouts** (e.g. `60_000`), you can remove it — JoinGroup/SyncGroup no longer
+use it. A large `:request_timeout` now only widens the window before a
+silently-unresponsive broker is detected on other requests.
+
+**Behavior note.** A socket recv-timeout is no longer retried inside the
+(synchronous) client `GenServer`; it is surfaced to the higher-level loops
+(consumer-group manager, `GenConsumer` commit, stream), which re-issue with
+±20% jittered backoff (KIP-580). Protocol errors (e.g.
+`not_leader_for_partition`, `not_coordinator`) keep their in-client retry with
+metadata/coordinator refresh.
+
 ---
 
 # Upgrading to KafkaEx 1.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -125,6 +125,42 @@ silently-unresponsive broker is detected on other requests.
 `not_leader_for_partition`, `not_coordinator`) keep their in-client retry with
 metadata/coordinator refresh.
 
+**Data-plane failure latency.** Because the generic per-attempt timeout default
+rose (effectively ~1 s → `:request_timeout` = 15 s) and a socket timeout is now
+send-once, a request to a **silently unresponsive** broker (accepted TCP, no
+reply) now returns `{:error, :timeout}` after ~15 s instead of ~1–3 s. A healthy
+broker is unaffected (it replies in ms). Latency-sensitive callers (e.g. a
+produce on a request path) that relied on the old fast-fail should set a lower
+`:request_timeout`, or pass an explicit `:timeout`/`:max_wait_time` per call.
+
+**Heartbeat.** A consumer-group heartbeat now uses a short per-attempt deadline
+(the configured `heartbeat_interval`), not the generic `:request_timeout`, so a
+stalled heartbeat is detected well inside `session_timeout`. A single heartbeat
+whose recv times out is **not** retried in-client (previously up to 3×); it
+escalates to a rejoin, which under a persistent coordinator stall means a
+rebalance — matching the Java/librdkafka "mark coordinator dead, rejoin" model.
+Keep `heartbeat_interval` well below `session_timeout / 3`: the outer heartbeat
+budget is `heartbeat_interval × 3`, so an over-large interval could let a
+retrying heartbeat span the whole session.
+
+**Consumer-group manager responsiveness during a rebalance.** JoinGroup/SyncGroup
+now wait for the broker for as long as it legitimately holds the response (up to
+`rebalance_timeout + 5s` for join). The `ConsumerGroup.Manager` performs the join
+synchronously, so while a *rebalance* is in progress it is busy for that window
+(a cold-start join on an empty group still returns in ~`group.initial.rebalance.delay.ms`,
+default 3s). Two consequences for that window:
+
+  * The `KafkaEx.Consumer.ConsumerGroup` introspection calls
+    (`generation_id/1`, `member_id/1`, `assignments/1`, `active?/1`, …) use a
+    5s `GenServer.call`; during a long rebalance they may exit with a call
+    timeout. Wrap them or pass a longer timeout if you poll them during
+    rebalances.
+  * If your supervisor stops the group mid-rebalance, the default 5s child
+    shutdown may cut off `terminate/2` before it sends `LeaveGroup`; a dynamic
+    member's partitions then wait `session_timeout` to redistribute (static
+    members, KIP-345, intentionally skip LeaveGroup anyway). Raise the group's
+    child `shutdown:` if graceful mid-rebalance leave matters for your deploys.
+
 ---
 
 # Upgrading to KafkaEx 1.0

--- a/config/config.exs
+++ b/config/config.exs
@@ -41,11 +41,11 @@ config :kafka_ex,
   # i.e., if you want to start your own set of named workers
   disable_default_worker: false,
   # Timeout value, in msec, for synchronous operations (e.g., network calls).
-  # If this value is greater than GenServer's default timeout of 5000, it will also
-  # be used as the timeout for work dispatched via KafkaEx.Server.call (e.g., KafkaEx.metadata).
-  # In those cases, it should be considered a 'total timeout', encompassing both network calls and
-  # wait time for the genservers.
-  sync_timeout: 3000,
+  # Per-attempt request socket-recv timeout (ms) for synchronous requests that do
+  # not derive their own (metadata, offset, heartbeat, produce ack, …). Consumer-group
+  # JoinGroup/SyncGroup derive their own, longer deadlines from the group's
+  # rebalance/session timeouts. Was `:sync_timeout` (now a deprecated alias, removed in 2.0).
+  request_timeout: 15000,
   # Supervision max_restarts - the maximum amount of restarts allowed in a time frame
   max_restarts: 10,
   # Supervision max_seconds -  the time frame in which :max_restarts applies

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,7 @@ config :kafka_ex,
 
 config :kayrock, snappy_module: :snappyer
 
-config :kafka_ex, sync_timeout: 60_000
+config :kafka_ex, request_timeout: 60_000
 
 # Help debug tests that are tricky to understand
 config :logger, :console,

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -107,6 +107,18 @@ defmodule KafkaEx.API do
   @fetch_call_timeout_buffer 5_000
   @fetch_max_retries KafkaEx.Client.retry_count()
 
+  # JoinGroup's per-attempt socket-recv deadline is derived from rebalance_timeout
+  # plus a fixed grace, mirroring the Java client's JOIN_GROUP_TIMEOUT_LAPSE = 5000.
+  # The broker legitimately holds a JoinGroup response for up to the rebalance
+  # window (>= group.initial.rebalance.delay.ms on a cold group), so a generic
+  # short timeout would fail every cold-start join.
+  @join_group_timeout_lapse 5_000
+  @join_default_rebalance_timeout 60_000
+  @sync_default_timeout 35_000
+  # Outer GenServer.call budget = per-attempt network_timeout + this buffer.
+  # join/sync are send-once at the client, so there is no × retries factor.
+  @coordinator_call_timeout_buffer 5_000
+
   # ---------------------------------------------------------------------------
   # __using__ macro for mixin pattern
   # ---------------------------------------------------------------------------
@@ -585,10 +597,23 @@ defmodule KafkaEx.API do
   @spec join_group(client, consumer_group_name, member_id) :: {:ok, JoinGroup.t()} | {:error, error_atom}
   @spec join_group(client, consumer_group_name, member_id, opts) :: {:ok, JoinGroup.t()} | {:error, error_atom}
   def join_group(client, consumer_group, member_id, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, Keyword.get(opts, :rebalance_timeout, 60_000) + 10_000)
-    call_opts = Keyword.delete(opts, :timeout)
+    # JoinGroup is held by the broker for up to the rebalance window, so its
+    # per-attempt socket-recv deadline is rebalance_timeout + a fixed grace
+    # (Java's JOIN_GROUP_TIMEOUT_LAPSE = 5000). Sent send-once at the client;
+    # ConsumerGroup.Manager owns rejoin. The outer GenServer.call budget must
+    # cover that per-attempt deadline, so it is derived from it (not a fixed 40s),
+    # otherwise the caller would time out while the broker is still holding a
+    # legitimate rebalance response (the #357 class of mismatch).
+    rebalance_timeout = Keyword.get(opts, :rebalance_timeout, @join_default_rebalance_timeout)
+    network_timeout = Keyword.get(opts, :network_timeout, rebalance_timeout + @join_group_timeout_lapse)
+    call_timeout = network_timeout + @coordinator_call_timeout_buffer
 
-    case GenServer.call(client, {:join_group, consumer_group, member_id, call_opts}, timeout) do
+    call_opts =
+      opts
+      |> Keyword.delete(:timeout)
+      |> Keyword.put(:network_timeout, network_timeout)
+
+    case GenServer.call(client, {:join_group, consumer_group, member_id, call_opts}, call_timeout) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -611,11 +636,20 @@ defmodule KafkaEx.API do
   @spec sync_group(client, consumer_group_name, generation_id, member_id, opts) ::
           {:ok, SyncGroup.t()} | {:error, error_atom}
   def sync_group(client, consumer_group, generation_id, member_id, opts \\ []) do
-    # SyncGroup can block until all members sync or session_timeout
-    timeout = Keyword.get(opts, :timeout, 35_000)
-    call_opts = Keyword.delete(opts, :timeout)
+    # SyncGroup can be held by the broker until the leader distributes assignments
+    # (bounded by the session window). Per-attempt socket-recv = the caller-supplied
+    # :timeout (ConsumerGroup.Manager passes session_timeout + padding) or a default;
+    # sent send-once at the client. The outer GenServer.call budget is derived from
+    # that per-attempt deadline so the two cannot mismatch (#357).
+    network_timeout = Keyword.get(opts, :network_timeout, Keyword.get(opts, :timeout, @sync_default_timeout))
+    call_timeout = network_timeout + @coordinator_call_timeout_buffer
 
-    case GenServer.call(client, {:sync_group, consumer_group, generation_id, member_id, call_opts}, timeout) do
+    call_opts =
+      opts
+      |> Keyword.delete(:timeout)
+      |> Keyword.put(:network_timeout, network_timeout)
+
+    case GenServer.call(client, {:sync_group, consumer_group, generation_id, member_id, call_opts}, call_timeout) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -105,6 +105,9 @@ defmodule KafkaEx.API do
   @default_max_wait_time 10_000
   @fetch_network_timeout_buffer 5_000
   @fetch_call_timeout_buffer 5_000
+  # Single source of truth for the retry budget (kills the #357 hand-sync drift).
+  # NB: this makes KafkaEx.API compile-depend on KafkaEx.Client — safe today (no
+  # cycle, Client does not reference API at module scope); keep it that way.
   @fetch_max_retries KafkaEx.Client.retry_count()
 
   # JoinGroup's per-attempt socket-recv deadline is derived from rebalance_timeout
@@ -417,7 +420,7 @@ defmodule KafkaEx.API do
   @spec list_offsets(client, [{topic_name, [partition_offset_request]}], opts) ::
           {:ok, list(Offset.t())} | {:error, any}
   def list_offsets(client, [{topic, [partition_request]}], opts \\ []) do
-    case GenServer.call(client, {:list_offsets, [{topic, [partition_request]}], opts}) do
+    case GenServer.call(client, {:list_offsets, [{topic, [partition_request]}], opts}, generic_call_budget()) do
       {:ok, offsets} -> {:ok, offsets}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -442,7 +445,7 @@ defmodule KafkaEx.API do
   """
   @spec topics_metadata(client, [topic_name], boolean) :: {:ok, [Topic.t()]} | {:error, error_atom}
   def topics_metadata(client, topics, allow_topic_creation \\ false) do
-    GenServer.call(client, {:topic_metadata, topics, allow_topic_creation})
+    GenServer.call(client, {:topic_metadata, topics, allow_topic_creation}, generic_call_budget())
   end
 
   @doc """
@@ -458,7 +461,7 @@ defmodule KafkaEx.API do
   """
   @spec cluster_metadata(client) :: {:ok, ClusterMetadata.t()}
   def cluster_metadata(client) do
-    GenServer.call(client, :cluster_metadata)
+    GenServer.call(client, :cluster_metadata, generic_call_budget())
   end
 
   @doc """
@@ -480,7 +483,7 @@ defmodule KafkaEx.API do
   def metadata(client, opts \\ []) do
     api_version = Keyword.get(opts, :api_version, 1)
 
-    case GenServer.call(client, {:metadata, nil, opts, api_version}) do
+    case GenServer.call(client, {:metadata, nil, opts, api_version}, generic_call_budget()) do
       {:ok, cluster_metadata} -> {:ok, cluster_metadata}
       {:error, error} -> {:error, error}
     end
@@ -502,7 +505,7 @@ defmodule KafkaEx.API do
     api_version = Keyword.get(opts, :api_version, 1)
     request_opts = Keyword.put(opts, :topics, topics)
 
-    case GenServer.call(client, {:metadata, topics, request_opts, api_version}) do
+    case GenServer.call(client, {:metadata, topics, request_opts, api_version}, generic_call_budget()) do
       {:ok, cluster_metadata} -> {:ok, cluster_metadata}
       {:error, error} -> {:error, error}
     end
@@ -532,7 +535,7 @@ defmodule KafkaEx.API do
   @spec api_versions(client) :: {:ok, ApiVersions.t()} | {:error, error_atom}
   @spec api_versions(client, opts) :: {:ok, ApiVersions.t()} | {:error, error_atom}
   def api_versions(client, opts \\ []) do
-    case GenServer.call(client, {:api_versions, opts}) do
+    case GenServer.call(client, {:api_versions, opts}, generic_call_budget()) do
       {:ok, versions} -> {:ok, versions}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -567,7 +570,7 @@ defmodule KafkaEx.API do
   @spec describe_group(client, consumer_group_name) :: {:ok, ConsumerGroupDescription.t()} | {:error, any}
   @spec describe_group(client, consumer_group_name, opts) :: {:ok, ConsumerGroupDescription.t()} | {:error, any}
   def describe_group(client, consumer_group_name, opts \\ []) do
-    case GenServer.call(client, {:describe_groups, [consumer_group_name], opts}) do
+    case GenServer.call(client, {:describe_groups, [consumer_group_name], opts}, generic_call_budget()) do
       {:ok, [group]} -> {:ok, group}
       {:error, error} -> {:error, error}
     end
@@ -606,18 +609,7 @@ defmodule KafkaEx.API do
     # legitimate rebalance response (the #357 class of mismatch).
     rebalance_timeout = Keyword.get(opts, :rebalance_timeout, @join_default_rebalance_timeout)
     network_timeout = Keyword.get(opts, :network_timeout, rebalance_timeout + @join_group_timeout_lapse)
-    call_timeout = network_timeout + @coordinator_call_timeout_buffer
-
-    call_opts =
-      opts
-      |> Keyword.delete(:timeout)
-      |> Keyword.put(:network_timeout, network_timeout)
-
-    case GenServer.call(client, {:join_group, consumer_group, member_id, call_opts}, call_timeout) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    coordinator_call(client, opts, network_timeout, &{:join_group, consumer_group, member_id, &1})
   end
 
   @doc """
@@ -642,18 +634,7 @@ defmodule KafkaEx.API do
     # sent send-once at the client. The outer GenServer.call budget is derived from
     # that per-attempt deadline so the two cannot mismatch (#357).
     network_timeout = Keyword.get(opts, :network_timeout, Keyword.get(opts, :timeout, @sync_default_timeout))
-    call_timeout = network_timeout + @coordinator_call_timeout_buffer
-
-    call_opts =
-      opts
-      |> Keyword.delete(:timeout)
-      |> Keyword.put(:network_timeout, network_timeout)
-
-    case GenServer.call(client, {:sync_group, consumer_group, generation_id, member_id, call_opts}, call_timeout) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    coordinator_call(client, opts, network_timeout, &{:sync_group, consumer_group, generation_id, member_id, &1})
   end
 
   @doc """
@@ -671,7 +652,7 @@ defmodule KafkaEx.API do
   @spec leave_group(client, consumer_group_name, member_id, opts) ::
           {:ok, :no_error | LeaveGroup.t()} | {:error, error_atom}
   def leave_group(client, consumer_group, member_id, opts \\ []) do
-    case GenServer.call(client, {:leave_group, consumer_group, member_id, opts}) do
+    case GenServer.call(client, {:leave_group, consumer_group, member_id, opts}, generic_call_budget()) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -693,7 +674,18 @@ defmodule KafkaEx.API do
   @spec heartbeat(client, consumer_group_name, member_id, generation_id, opts) ::
           {:ok, Heartbeat.t()} | {:error, error_atom}
   def heartbeat(client, consumer_group, member_id, generation_id, opts \\ []) do
-    case GenServer.call(client, {:heartbeat, consumer_group, member_id, generation_id, opts}) do
+    # Heartbeat is answered promptly (never broker-held), so it uses a short
+    # per-attempt deadline — the caller passes `:network_timeout` (heartbeat_interval)
+    # — instead of the generic :request_timeout, so a stalled heartbeat is detected
+    # well inside session_timeout. Falls back to the generic budget for direct callers.
+    network_timeout = Keyword.get(opts, :network_timeout, Config.request_timeout())
+    opts = Keyword.put(opts, :network_timeout, network_timeout)
+
+    case GenServer.call(
+           client,
+           {:heartbeat, consumer_group, member_id, generation_id, opts},
+           call_budget(network_timeout)
+         ) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -724,7 +716,7 @@ defmodule KafkaEx.API do
   @spec find_coordinator(client, consumer_group_name) :: {:ok, FindCoordinator.t()} | {:error, error_atom}
   @spec find_coordinator(client, consumer_group_name, opts) :: {:ok, FindCoordinator.t()} | {:error, error_atom}
   def find_coordinator(client, group_id, opts \\ []) do
-    case GenServer.call(client, {:find_coordinator, group_id, opts}) do
+    case GenServer.call(client, {:find_coordinator, group_id, opts}, generic_call_budget()) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -752,7 +744,7 @@ defmodule KafkaEx.API do
   @spec fetch_committed_offset(client, consumer_group_name, topic_name, [partition_id_request], opts) ::
           {:ok, [Offset.t()]} | {:error, error_atom}
   def fetch_committed_offset(client, consumer_group, topic, partitions, opts \\ []) do
-    case GenServer.call(client, {:offset_fetch, consumer_group, [{topic, partitions}], opts}) do
+    case GenServer.call(client, {:offset_fetch, consumer_group, [{topic, partitions}], opts}, generic_call_budget()) do
       {:ok, offsets} -> {:ok, offsets}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -776,7 +768,7 @@ defmodule KafkaEx.API do
   @spec commit_offset(client, consumer_group_name, topic_name, [partition_offset_commit_request], opts) ::
           {:ok, [Offset.t()]} | {:error, error_atom}
   def commit_offset(client, consumer_group, topic, partitions, opts \\ []) do
-    case GenServer.call(client, {:offset_commit, consumer_group, [{topic, partitions}], opts}) do
+    case GenServer.call(client, {:offset_commit, consumer_group, [{topic, partitions}], opts}, generic_call_budget()) do
       {:ok, offsets} -> {:ok, offsets}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -845,7 +837,7 @@ defmodule KafkaEx.API do
   end
 
   def produce(client, topic, partition, messages, opts) when is_integer(partition) do
-    case GenServer.call(client, {:produce, topic, partition, messages, opts}) do
+    case GenServer.call(client, {:produce, topic, partition, messages, opts}, generic_call_budget()) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -955,8 +947,38 @@ defmodule KafkaEx.API do
   defp derive_fetch_timeouts(opts) do
     max_wait_time = Keyword.get(opts, :max_wait_time, @default_max_wait_time)
     network_timeout = Keyword.get(opts, :network_timeout, max_wait_time + @fetch_network_timeout_buffer)
-    call_timeout = network_timeout * @fetch_max_retries + @fetch_call_timeout_buffer
-    {call_timeout, Keyword.put_new(opts, :network_timeout, network_timeout)}
+    {call_budget(network_timeout), Keyword.put_new(opts, :network_timeout, network_timeout)}
+  end
+
+  # Outer GenServer.call budget for a per-attempt socket-recv deadline: covers the
+  # full client-level retry loop (`per_attempt × retries + buffer`). Single source
+  # for the shape shared by fetch (`derive_fetch_timeouts/1`) and the generic
+  # data-plane wrappers (`generic_call_budget/0`).
+  defp call_budget(per_attempt), do: per_attempt * @fetch_max_retries + @fetch_call_timeout_buffer
+
+  # Outer GenServer.call budget for the requests whose per-attempt socket-recv
+  # falls back to the generic `:request_timeout` (metadata, offset, heartbeat,
+  # find_coordinator, produce, …). It MUST be derived from `:request_timeout`,
+  # never left at the implicit 5000ms GenServer.call default: a `:request_timeout`
+  # above 5000 would otherwise exceed the outer budget, so the caller's call would
+  # exit before the client returns a clean `{:error, :timeout}` (the #357 class of
+  # mismatch). Sized × the retry budget to cover the metadata refresh loop; a
+  # socket timeout is send-once, so normal completions return well inside this.
+  defp generic_call_budget, do: call_budget(Config.request_timeout())
+
+  # Shared plumbing for the send-once coordinator calls (join/sync): inject the
+  # derived per-attempt `network_timeout` as a control opt, size the outer budget
+  # from it (no × retries — send-once), and normalize the reply. Only the message
+  # tuple and the `network_timeout` derivation differ between join and sync.
+  defp coordinator_call(client, opts, network_timeout, msg_fun) do
+    call_timeout = network_timeout + @coordinator_call_timeout_buffer
+    call_opts = opts |> Keyword.delete(:timeout) |> Keyword.put(:network_timeout, network_timeout)
+
+    case GenServer.call(client, msg_fun.(call_opts), call_timeout) do
+      {:ok, result} -> {:ok, result}
+      {:error, %{error: error_atom}} -> {:error, error_atom}
+      {:error, error_atom} -> {:error, error_atom}
+    end
   end
 
   @doc """
@@ -1034,7 +1056,13 @@ defmodule KafkaEx.API do
   @spec create_topics(client, list(), non_neg_integer()) :: {:ok, CreateTopics.t()} | {:error, error_atom}
   @spec create_topics(client, list(), non_neg_integer(), opts) :: {:ok, CreateTopics.t()} | {:error, error_atom}
   def create_topics(client, topics, timeout, opts \\ []) do
-    case GenServer.call(client, {:create_topics, topics, timeout, opts}) do
+    # The broker holds CreateTopics for up to its own `timeout`, so the per-attempt
+    # socket-recv must cover that (not the generic :request_timeout), and the outer
+    # GenServer.call budget is derived from it.
+    network_timeout = timeout + @coordinator_call_timeout_buffer
+    opts = Keyword.put_new(opts, :network_timeout, network_timeout)
+
+    case GenServer.call(client, {:create_topics, topics, timeout, opts}, call_budget(network_timeout)) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}
@@ -1111,7 +1139,13 @@ defmodule KafkaEx.API do
   @spec delete_topics(client, [topic_name], timeout) :: {:ok, DeleteTopics.t()} | {:error, error_atom}
   @spec delete_topics(client, [topic_name], timeout, opts) :: {:ok, DeleteTopics.t()} | {:error, error_atom}
   def delete_topics(client, topics, timeout, opts \\ []) do
-    case GenServer.call(client, {:delete_topics, topics, timeout, opts}) do
+    # The broker holds DeleteTopics for up to its own `timeout`, so the per-attempt
+    # socket-recv must cover that (not the generic :request_timeout), and the outer
+    # GenServer.call budget is derived from it.
+    network_timeout = timeout + @coordinator_call_timeout_buffer
+    opts = Keyword.put_new(opts, :network_timeout, network_timeout)
+
+    case GenServer.call(client, {:delete_topics, topics, timeout, opts}, call_budget(network_timeout)) do
       {:ok, result} -> {:ok, result}
       {:error, %{error: error_atom}} -> {:error, error_atom}
       {:error, error_atom} -> {:error, error_atom}

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -90,36 +90,24 @@ defmodule KafkaEx.API do
   @type member_id :: binary
   @type generation_id :: non_neg_integer
 
-  # Issue #357 — fetch timeout alignment.
-  # GenServer.call and Socket.recv timeouts derived from :max_wait_time so
-  # the broker's long-poll completes before either fires.
-  #
-  # @fetch_max_retries is derived from KafkaEx.Client.retry_count/0 (its single
-  # source of truth) so the call_timeout budget always matches the client's real
-  # retry count and the two can no longer drift. See #357.
-  #
-  # One coupling is still maintained by hand:
-  #   * @default_max_wait_time MUST equal the fetch request builder's :max_wait_time
-  #     default (KafkaEx.Protocol.Kayrock.Fetch.RequestHelpers) — if the builder's
-  #     default drifts above this, network_timeout no longer covers the long-poll.
+  # Timeout model (canonical note; call sites point here). Each request derives a
+  # per-attempt Socket.recv deadline (network_timeout) and an outer GenServer.call
+  # budget from it, so the two can't mismatch (#357). Per-attempt deadline by op:
+  # fetch = max_wait_time + buffer; join = rebalance_timeout + lapse (broker holds
+  # it that long); sync = session window; everything else = :request_timeout.
+  # @fetch_max_retries comes from Client.retry_count/0 (single source of truth;
+  # makes API compile-depend on Client — acyclic, keep it so). @default_max_wait_time
+  # MUST match the fetch builder's :max_wait_time default.
   @default_max_wait_time 10_000
   @fetch_network_timeout_buffer 5_000
   @fetch_call_timeout_buffer 5_000
-  # Single source of truth for the retry budget (kills the #357 hand-sync drift).
-  # NB: this makes KafkaEx.API compile-depend on KafkaEx.Client — safe today (no
-  # cycle, Client does not reference API at module scope); keep it that way.
   @fetch_max_retries KafkaEx.Client.retry_count()
 
-  # JoinGroup's per-attempt socket-recv deadline is derived from rebalance_timeout
-  # plus a fixed grace, mirroring the Java client's JOIN_GROUP_TIMEOUT_LAPSE = 5000.
-  # The broker legitimately holds a JoinGroup response for up to the rebalance
-  # window (>= group.initial.rebalance.delay.ms on a cold group), so a generic
-  # short timeout would fail every cold-start join.
+  # JoinGroup grace over rebalance_timeout (mirrors Java's JOIN_GROUP_TIMEOUT_LAPSE).
   @join_group_timeout_lapse 5_000
   @join_default_rebalance_timeout 60_000
   @sync_default_timeout 35_000
-  # Outer GenServer.call budget = per-attempt network_timeout + this buffer.
-  # join/sync are send-once at the client, so there is no × retries factor.
+  # Outer-call buffer over the per-attempt deadline (join/sync send-once: no ×retries).
   @coordinator_call_timeout_buffer 5_000
 
   # ---------------------------------------------------------------------------
@@ -600,15 +588,11 @@ defmodule KafkaEx.API do
   @spec join_group(client, consumer_group_name, member_id) :: {:ok, JoinGroup.t()} | {:error, error_atom}
   @spec join_group(client, consumer_group_name, member_id, opts) :: {:ok, JoinGroup.t()} | {:error, error_atom}
   def join_group(client, consumer_group, member_id, opts \\ []) do
-    # JoinGroup is held by the broker for up to the rebalance window, so its
-    # per-attempt socket-recv deadline is rebalance_timeout + a fixed grace
-    # (Java's JOIN_GROUP_TIMEOUT_LAPSE = 5000). Sent send-once at the client;
-    # ConsumerGroup.Manager owns rejoin. The outer GenServer.call budget must
-    # cover that per-attempt deadline, so it is derived from it (not a fixed 40s),
-    # otherwise the caller would time out while the broker is still holding a
-    # legitimate rebalance response (the #357 class of mismatch).
+    # Per-attempt deadline defaults to rebalance_timeout + grace; an explicit
+    # :network_timeout or :timeout overrides. See the timeout notes above.
     rebalance_timeout = Keyword.get(opts, :rebalance_timeout, @join_default_rebalance_timeout)
-    network_timeout = Keyword.get(opts, :network_timeout, rebalance_timeout + @join_group_timeout_lapse)
+    default_network_timeout = rebalance_timeout + @join_group_timeout_lapse
+    network_timeout = Keyword.get(opts, :network_timeout, Keyword.get(opts, :timeout, default_network_timeout))
     coordinator_call(client, opts, network_timeout, &{:join_group, consumer_group, member_id, &1})
   end
 
@@ -628,11 +612,9 @@ defmodule KafkaEx.API do
   @spec sync_group(client, consumer_group_name, generation_id, member_id, opts) ::
           {:ok, SyncGroup.t()} | {:error, error_atom}
   def sync_group(client, consumer_group, generation_id, member_id, opts \\ []) do
-    # SyncGroup can be held by the broker until the leader distributes assignments
-    # (bounded by the session window). Per-attempt socket-recv = the caller-supplied
-    # :timeout (ConsumerGroup.Manager passes session_timeout + padding) or a default;
-    # sent send-once at the client. The outer GenServer.call budget is derived from
-    # that per-attempt deadline so the two cannot mismatch (#357).
+    # Held by the broker until the leader distributes assignments (session-bounded).
+    # Per-attempt deadline = :network_timeout | :timeout (Manager passes session +
+    # padding) | default; send-once. See the timeout notes above.
     network_timeout = Keyword.get(opts, :network_timeout, Keyword.get(opts, :timeout, @sync_default_timeout))
     coordinator_call(client, opts, network_timeout, &{:sync_group, consumer_group, generation_id, member_id, &1})
   end
@@ -674,10 +656,9 @@ defmodule KafkaEx.API do
   @spec heartbeat(client, consumer_group_name, member_id, generation_id, opts) ::
           {:ok, Heartbeat.t()} | {:error, error_atom}
   def heartbeat(client, consumer_group, member_id, generation_id, opts \\ []) do
-    # Heartbeat is answered promptly (never broker-held), so it uses a short
-    # per-attempt deadline — the caller passes `:network_timeout` (heartbeat_interval)
-    # — instead of the generic :request_timeout, so a stalled heartbeat is detected
-    # well inside session_timeout. Falls back to the generic budget for direct callers.
+    # Answered promptly (never broker-held) → short per-attempt deadline: the caller
+    # passes :network_timeout (heartbeat_interval), else the generic budget. This keeps
+    # a stalled heartbeat detected well inside session_timeout.
     network_timeout = Keyword.get(opts, :network_timeout, Config.request_timeout())
     opts = Keyword.put(opts, :network_timeout, network_timeout)
 
@@ -956,14 +937,9 @@ defmodule KafkaEx.API do
   # data-plane wrappers (`generic_call_budget/0`).
   defp call_budget(per_attempt), do: per_attempt * @fetch_max_retries + @fetch_call_timeout_buffer
 
-  # Outer GenServer.call budget for the requests whose per-attempt socket-recv
-  # falls back to the generic `:request_timeout` (metadata, offset, heartbeat,
-  # find_coordinator, produce, …). It MUST be derived from `:request_timeout`,
-  # never left at the implicit 5000ms GenServer.call default: a `:request_timeout`
-  # above 5000 would otherwise exceed the outer budget, so the caller's call would
-  # exit before the client returns a clean `{:error, :timeout}` (the #357 class of
-  # mismatch). Sized × the retry budget to cover the metadata refresh loop; a
-  # socket timeout is send-once, so normal completions return well inside this.
+  # Outer budget for requests whose per-attempt recv is the generic :request_timeout.
+  # Derived (not the implicit 5000 default) so a >5000 :request_timeout can't exceed
+  # the outer call and exit the caller mid-flight (#357).
   defp generic_call_budget, do: call_budget(Config.request_timeout())
 
   # Shared plumbing for the send-once coordinator calls (join/sync): inject the

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -70,6 +70,10 @@ defmodule KafkaEx.Client do
   # and ConsumerGroup.Manager owns rejoin (@max_join_retries / @max_sync_retries).
   # Matches Java/kafka-python/librdkafka/brod, which all send-once + rejoin higher up.
   @coordinator_max_attempts 1
+  # Headroom the low-level `send_request/4` helper adds over the per-attempt recv
+  # (`:request_timeout`) for its outer GenServer.call, so the caller does not exit
+  # before the single attempt returns a clean {:error, :timeout} (the #357 class).
+  @send_request_call_buffer 5_000
   @reconnect_max_retries 3
   @reconnect_delay_ms 500
 
@@ -496,10 +500,11 @@ defmodule KafkaEx.Client do
 
   defp do_heartbeat_request(consumer_group, member_id, generation_id, opts, state, metadata) do
     node_selector = NodeSelector.consumer_group(consumer_group)
-    req_data = [{:group_id, consumer_group}, {:member_id, member_id}, {:generation_id, generation_id} | opts]
+    {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
+    req_data = [{:group_id, consumer_group}, {:member_id, member_id}, {:generation_id, generation_id} | req_opts]
 
     with {:ok, request} <- RequestBuilder.heartbeat_request(req_data, state),
-         {result, updated_state} <- handle_heartbeat_request(request, node_selector, state) do
+         {result, updated_state} <- handle_heartbeat_request(request, node_selector, state, network_timeout) do
       {{result, updated_state}, metadata}
     else
       {:error, error} -> {{:error, error}, metadata}
@@ -680,10 +685,11 @@ defmodule KafkaEx.Client do
   defp create_topics_request(topics, timeout, opts, state) do
     # CreateTopics must be sent to the controller broker
     node_selector = NodeSelector.controller()
-    req_data = [{:topics, topics}, {:timeout, timeout} | opts]
+    {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
+    req_data = [{:topics, topics}, {:timeout, timeout} | req_opts]
 
     case RequestBuilder.create_topics_request(req_data, state) do
-      {:ok, request} -> handle_create_topics_request(request, node_selector, state)
+      {:ok, request} -> handle_create_topics_request(request, node_selector, state, network_timeout)
       {:error, error} -> {:error, error}
     end
   end
@@ -691,10 +697,11 @@ defmodule KafkaEx.Client do
   defp delete_topics_request(topics, timeout, opts, state) do
     # DeleteTopics must be sent to the controller broker
     node_selector = NodeSelector.controller()
-    req_data = [{:topics, topics}, {:timeout, timeout} | opts]
+    {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
+    req_data = [{:topics, topics}, {:timeout, timeout} | req_opts]
 
     case RequestBuilder.delete_topics_request(req_data, state) do
-      {:ok, request} -> handle_delete_topics_request(request, node_selector, state)
+      {:ok, request} -> handle_delete_topics_request(request, node_selector, state, network_timeout)
       {:error, error} -> {:error, error}
     end
   end
@@ -775,12 +782,13 @@ defmodule KafkaEx.Client do
     |> handle_request_with_retry(state)
   end
 
-  defp handle_heartbeat_request(request, node_selector, state) do
+  defp handle_heartbeat_request(request, node_selector, state, network_timeout) do
     %RequestContext{
       request: request,
       parser_fn: &ResponseParser.heartbeat_response/1,
       node_selector: node_selector,
-      retryable?: &Retry.heartbeat_retryable?/1
+      retryable?: &Retry.heartbeat_retryable?/1,
+      network_timeout: network_timeout
     }
     |> handle_request_with_retry(state)
   end
@@ -844,13 +852,23 @@ defmodule KafkaEx.Client do
     |> handle_request_with_retry(state)
   end
 
-  defp handle_create_topics_request(request, node_selector, state) do
-    %RequestContext{request: request, parser_fn: &ResponseParser.create_topics_response/1, node_selector: node_selector}
+  defp handle_create_topics_request(request, node_selector, state, network_timeout) do
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.create_topics_response/1,
+      node_selector: node_selector,
+      network_timeout: network_timeout
+    }
     |> handle_request_with_retry(state)
   end
 
-  defp handle_delete_topics_request(request, node_selector, state) do
-    %RequestContext{request: request, parser_fn: &ResponseParser.delete_topics_response/1, node_selector: node_selector}
+  defp handle_delete_topics_request(request, node_selector, state, network_timeout) do
+    %RequestContext{
+      request: request,
+      parser_fn: &ResponseParser.delete_topics_response/1,
+      node_selector: node_selector,
+      network_timeout: network_timeout
+    }
     |> handle_request_with_retry(state)
   end
 
@@ -926,7 +944,7 @@ defmodule KafkaEx.Client do
       # which back off with jitter in their own processes. Mirrors Java/kafka-python/
       # librdkafka, which treat a request timeout as connection failure rather than
       # a same-socket retry.
-      transport_timeout?(error_atom) ->
+      Retry.transport_timeout?(error_atom) ->
         Logger.info("Request #{inspect(request_name)} timed out; not retrying at the client (send-once)")
         {{:error, error}, state}
 
@@ -940,13 +958,6 @@ defmodule KafkaEx.Client do
         {{:error, error}, state}
     end
   end
-
-  # A `Socket.recv` deadline expiry (surfaced as `:timeout`) is the one error that
-  # costs a full `network_timeout` per attempt, so it is never retried in this
-  # synchronous loop. Protocol/broker error codes (including the broker-side
-  # `:request_timed_out`) come back fast and keep their normal retry behaviour.
-  defp transport_timeout?(:timeout), do: true
-  defp transport_timeout?(_), do: false
 
   defp extract_error_atom(%Error{error: error}), do: error
   defp extract_error_atom(error) when is_atom(error), do: error
@@ -1245,7 +1256,7 @@ defmodule KafkaEx.Client do
     end
   end
 
-  defp timeout_val(nil), do: Config.request_timeout()
+  defp timeout_val(nil), do: Config.request_timeout() + @send_request_call_buffer
   defp timeout_val(timeout) when is_integer(timeout), do: timeout
 
   # The per-attempt socket-recv deadline for synchronous requests that do not

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -60,13 +60,16 @@ defmodule KafkaEx.Client do
 
   require Logger
 
-  # Default from GenServer
-  @default_call_timeout 5_000
   # The request retry budget. This is the single source of truth: KafkaEx.API's
   # fetch call_timeout budget (@fetch_max_retries) is derived from it via
   # retry_count/0, so the two can no longer drift by hand. See #357.
   @retry_count 3
-  @sync_timeout 1_000
+  # JoinGroup/SyncGroup are sent send-once at the client (one attempt, no
+  # transport-level socket retry): the broker legitimately holds these responses
+  # for the rebalance/session window, so retrying the same socket is pointless,
+  # and ConsumerGroup.Manager owns rejoin (@max_join_retries / @max_sync_retries).
+  # Matches Java/kafka-python/librdkafka/brod, which all send-once + rejoin higher up.
+  @coordinator_max_attempts 1
   @reconnect_max_retries 3
   @reconnect_delay_ms 500
 
@@ -95,6 +98,9 @@ defmodule KafkaEx.Client do
     # or :snappy compression without :snappyer). Much friendlier than
     # UndefinedFunctionError at first produce/auth.
     :ok = OptionalDeps.validate!(state.auth)
+
+    # One-time deprecation notice for the legacy :sync_timeout key (→ :request_timeout).
+    :ok = Config.warn_deprecated_timeout_config()
 
     brokers =
       state.bootstrap_uris
@@ -511,10 +517,13 @@ defmodule KafkaEx.Client do
 
   defp do_join_group_request(consumer_group, member_id, opts, state, metadata) do
     node_selector = NodeSelector.consumer_group(consumer_group)
-    req_data = [{:group_id, consumer_group}, {:member_id, member_id} | opts]
+    # :network_timeout is a control opt (derived in KafkaEx.API.join_group from
+    # rebalance_timeout), not a protocol field — pop it before building req_data.
+    {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
+    req_data = [{:group_id, consumer_group}, {:member_id, member_id} | req_opts]
 
     with {:ok, request} <- RequestBuilder.join_group_request(req_data, state),
-         {{:ok, result}, updated_state} <- handle_join_group_request(request, node_selector, state) do
+         {{:ok, result}, updated_state} <- handle_join_group_request(request, node_selector, state, network_timeout) do
       stop_metadata = add_join_group_result_metadata(metadata, result)
       {{{:ok, result}, updated_state}, stop_metadata}
     else
@@ -574,10 +583,13 @@ defmodule KafkaEx.Client do
 
   defp do_sync_group_request(consumer_group, generation_id, member_id, opts, state, metadata) do
     node_selector = NodeSelector.consumer_group(consumer_group)
-    req_data = [{:group_id, consumer_group}, {:generation_id, generation_id}, {:member_id, member_id} | opts]
+    # :network_timeout is a control opt (derived in KafkaEx.API.sync_group), not a
+    # protocol field — pop it before building req_data.
+    {network_timeout, req_opts} = Keyword.pop(opts, :network_timeout)
+    req_data = [{:group_id, consumer_group}, {:generation_id, generation_id}, {:member_id, member_id} | req_opts]
 
     with {:ok, request} <- RequestBuilder.sync_group_request(req_data, state),
-         {{:ok, result}, updated_state} <- handle_sync_group_request(request, node_selector, state) do
+         {{:ok, result}, updated_state} <- handle_sync_group_request(request, node_selector, state, network_timeout) do
       assigned_partitions = count_assigned_partitions(result.partition_assignments)
       stop_metadata = Map.put(metadata, :assigned_partitions, assigned_partitions)
       {{{:ok, result}, updated_state}, stop_metadata}
@@ -773,14 +785,15 @@ defmodule KafkaEx.Client do
     |> handle_request_with_retry(state)
   end
 
-  defp handle_join_group_request(request, node_selector, state) do
+  defp handle_join_group_request(request, node_selector, state, network_timeout) do
     %RequestContext{
       request: request,
       parser_fn: &ResponseParser.join_group_response/1,
       node_selector: node_selector,
-      retryable?: &Retry.join_group_retryable?/1
+      retryable?: &Retry.join_group_retryable?/1,
+      network_timeout: network_timeout
     }
-    |> handle_request_with_retry(state)
+    |> handle_request_with_retry(state, @coordinator_max_attempts)
   end
 
   defp handle_leave_group_request(request, node_selector, state) do
@@ -788,14 +801,15 @@ defmodule KafkaEx.Client do
     |> handle_request_with_retry(state)
   end
 
-  defp handle_sync_group_request(request, node_selector, state) do
+  defp handle_sync_group_request(request, node_selector, state, network_timeout) do
     %RequestContext{
       request: request,
       parser_fn: &ResponseParser.sync_group_response/1,
       node_selector: node_selector,
-      retryable?: &Retry.sync_group_retryable?/1
+      retryable?: &Retry.sync_group_retryable?/1,
+      network_timeout: network_timeout
     }
-    |> handle_request_with_retry(state)
+    |> handle_request_with_retry(state, @coordinator_max_attempts)
   end
 
   defp handle_produce_request(request, node_selector, state) do
@@ -904,15 +918,35 @@ defmodule KafkaEx.Client do
     error_atom = extract_error_atom(error)
     Logger.warning("Request #{inspect(request_name)} failed with error #{inspect(error_atom)}")
 
-    if ctx.retryable?.(error_atom) do
-      updated_state = refresh_for_error(error_atom, ctx, state)
-      handle_request_with_retry(ctx, updated_state, retry_count - 1, error)
-    else
-      # Non-retryable error - fail immediately
-      Logger.info("Error #{inspect(error_atom)} is not retryable for #{inspect(request_name)}, failing immediately")
-      {{:error, error}, state}
+    cond do
+      # A socket recv-timeout is sent send-once: this loop runs synchronously
+      # inside the Client GenServer, so retrying the same attempt would block the
+      # whole client for another full network_timeout. Re-issue is delegated to
+      # the higher-level loops (ConsumerGroup.Manager, GenConsumer commit, Stream),
+      # which back off with jitter in their own processes. Mirrors Java/kafka-python/
+      # librdkafka, which treat a request timeout as connection failure rather than
+      # a same-socket retry.
+      transport_timeout?(error_atom) ->
+        Logger.info("Request #{inspect(request_name)} timed out; not retrying at the client (send-once)")
+        {{:error, error}, state}
+
+      ctx.retryable?.(error_atom) ->
+        updated_state = refresh_for_error(error_atom, ctx, state)
+        handle_request_with_retry(ctx, updated_state, retry_count - 1, error)
+
+      true ->
+        # Non-retryable error - fail immediately
+        Logger.info("Error #{inspect(error_atom)} is not retryable for #{inspect(request_name)}, failing immediately")
+        {{:error, error}, state}
     end
   end
+
+  # A `Socket.recv` deadline expiry (surfaced as `:timeout`) is the one error that
+  # costs a full `network_timeout` per attempt, so it is never retried in this
+  # synchronous loop. Protocol/broker error codes (including the broker-side
+  # `:request_timed_out`) come back fast and keep their normal retry behaviour.
+  defp transport_timeout?(:timeout), do: true
+  defp transport_timeout?(_), do: false
 
   defp extract_error_atom(%Error{error: error}), do: error
   defp extract_error_atom(error) when is_atom(error), do: error
@@ -1211,11 +1245,15 @@ defmodule KafkaEx.Client do
     end
   end
 
-  defp timeout_val(nil), do: Application.get_env(:kafka_ex, :sync_timeout, @default_call_timeout)
+  defp timeout_val(nil), do: Config.request_timeout()
   defp timeout_val(timeout) when is_integer(timeout), do: timeout
 
+  # The per-attempt socket-recv deadline for synchronous requests that do not
+  # set their own `network_timeout` (metadata, offset, heartbeat, produce ack,
+  # …). Resolves via `Config.request_timeout/0` (`:request_timeout` > deprecated
+  # `:sync_timeout` > default). JoinGroup/SyncGroup pass an explicit timeout.
   defp config_sync_timeout(timeout \\ nil) do
-    timeout || Application.get_env(:kafka_ex, :sync_timeout, @sync_timeout)
+    timeout || Config.request_timeout()
   end
 
   defp get_api_versions(state) do

--- a/lib/kafka_ex/client/request_context.ex
+++ b/lib/kafka_ex/client/request_context.ex
@@ -24,12 +24,14 @@ defmodule KafkaEx.Client.RequestContext do
       classification for the separate `with_retry` loop (stream/consumer);
       converging the two is deferred follow-up.
 
-    * `network_timeout` is the **per-attempt** `Socket.recv` deadline, set only
-      by fetch (derived from `:max_wait_time` in `KafkaEx.API.fetch/5`, which
-      also widens the matching `GenServer.call` budget). Leave `nil` for every
-      other request so it falls back to `:sync_timeout`. Setting it on a
-      non-fetch request without widening that caller's `GenServer.call` timeout
-      would reintroduce the issue #357 mismatch. It is per-attempt, NOT the
+    * `network_timeout` is the **per-attempt** `Socket.recv` deadline. It is set
+      explicitly by the requests the broker legitimately holds — fetch (derived
+      from `:max_wait_time`), JoinGroup (`rebalance_timeout + 5000`) and SyncGroup
+      (session window) — each of which widens its matching `GenServer.call` budget
+      in `KafkaEx.API` so the two cannot mismatch (issue #357). Leave `nil` for
+      every other request so it falls back to the generic `:request_timeout`
+      (`KafkaEx.Config.request_timeout/0`); those callers derive their outer
+      `GenServer.call` budget from the same value. It is per-attempt, NOT the
       total budget.
 
     * Backoff/jitter between attempts is intentionally absent — the client loop

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -17,7 +17,7 @@ defmodule KafkaEx.Config do
 
         # Client settings
         client_id: "kafka_ex",
-        sync_timeout: 3000,
+        request_timeout: 15000,  # per-attempt request socket-recv timeout (was :sync_timeout, now deprecated)
 
         # Consumer group (used for offset storage)
         default_consumer_group: "kafka_ex",
@@ -166,6 +166,45 @@ defmodule KafkaEx.Config do
   """
   @spec connect_timeout() :: timeout()
   def connect_timeout, do: Application.get_env(:kafka_ex, :connect_timeout, 10_000)
+
+  @default_request_timeout 15_000
+
+  @doc """
+  Per-attempt request timeout (ms): the `Socket.recv` deadline for a single
+  synchronous broker request attempt (metadata, offset commit/fetch, heartbeat,
+  produce ack, find-coordinator, …).
+
+  Consumer-group JoinGroup/SyncGroup do **not** use this — they derive their own,
+  longer per-attempt deadlines from the group's rebalance/session timeouts,
+  because the broker legitimately holds those responses for the rebalance window.
+
+  Resolution: `:request_timeout` > deprecated `:sync_timeout` > #{@default_request_timeout}.
+  """
+  @spec request_timeout() :: pos_integer()
+  def request_timeout do
+    Application.get_env(:kafka_ex, :request_timeout) ||
+      Application.get_env(:kafka_ex, :sync_timeout) ||
+      @default_request_timeout
+  end
+
+  @doc """
+  Emits a one-time deprecation warning at client boot when the legacy
+  `:sync_timeout` key is set without the new `:request_timeout`.
+
+  Kept out of `request_timeout/0` so it does not log on every request.
+  """
+  @spec warn_deprecated_timeout_config() :: :ok
+  def warn_deprecated_timeout_config do
+    if is_nil(Application.get_env(:kafka_ex, :request_timeout)) and
+         not is_nil(Application.get_env(:kafka_ex, :sync_timeout)) do
+      Logger.warning(
+        ":sync_timeout is deprecated and will be removed in KafkaEx 2.0. " <>
+          "Use :request_timeout instead (the per-attempt request socket-recv timeout)."
+      )
+    end
+
+    :ok
+  end
 
   @doc """
   Returns SSL options for connections.

--- a/lib/kafka_ex/consumer/consumer_group.ex
+++ b/lib/kafka_ex/consumer/consumer_group.ex
@@ -140,6 +140,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
 
   @type options :: [option]
 
+  # Default timeout for the introspection calls into the Manager (generation_id/1,
+  # member_id/1, assignments/1, …). Raised above the old 5000 because the Manager
+  # performs JoinGroup/SyncGroup synchronously in its callback, so during a
+  # rebalance it can be busy for the join/sync window; a 5s query would exit with
+  # a call timeout. Callers can still pass an explicit timeout. (The deeper fix —
+  # a non-blocking Manager — is tracked as a follow-up; see UPGRADING.)
+  @manager_query_timeout 30_000
+
   @doc """
   Starts a consumer group process tree process linked to the current process.
 
@@ -202,7 +210,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   queried before the initial sync has completed.
   """
   @spec generation_id(Supervisor.supervisor(), timeout) :: integer | nil
-  def generation_id(supervisor_pid, timeout \\ 5000) do
+  def generation_id(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :generation_id, timeout)
   end
 
@@ -213,7 +221,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   initial sync has completed.
   """
   @spec member_id(Supervisor.supervisor(), timeout) :: binary | nil
-  def member_id(supervisor_pid, timeout \\ 5000) do
+  def member_id(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :member_id, timeout)
   end
 
@@ -224,7 +232,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   initial sync has completed
   """
   @spec leader_id(Supervisor.supervisor(), timeout) :: binary | nil
-  def leader_id(supervisor_pid, timeout \\ 5000) do
+  def leader_id(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :leader_id, timeout)
   end
 
@@ -235,7 +243,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   partitions.  Returns false if queried before the initial sync has completed.
   """
   @spec leader?(Supervisor.supervisor(), timeout) :: boolean
-  def leader?(supervisor_pid, timeout \\ 5000) do
+  def leader?(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :am_leader, timeout)
   end
 
@@ -248,7 +256,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   @spec assignments(Supervisor.supervisor(), timeout) :: [
           {topic :: binary, partition_id :: non_neg_integer}
         ]
-  def assignments(supervisor_pid, timeout \\ 5000) do
+  def assignments(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :assignments, timeout)
   end
 
@@ -259,7 +267,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   Returns `nil` if called before the initial sync.
   """
   @spec consumer_supervisor_pid(Supervisor.supervisor(), timeout) :: nil | pid
-  def consumer_supervisor_pid(supervisor_pid, timeout \\ 5000) do
+  def consumer_supervisor_pid(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :consumer_supervisor_pid, timeout)
   end
 
@@ -280,7 +288,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   Returns the name of the consumer group
   """
   @spec group_name(Supervisor.supervisor(), timeout) :: binary
-  def group_name(supervisor_pid, timeout \\ 5000) do
+  def group_name(supervisor_pid, timeout \\ @manager_query_timeout) do
     call_manager(supervisor_pid, :group_name, timeout)
   end
 
@@ -302,7 +310,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
   Returns true if at least one child consumer process is alive
   """
   @spec active?(Supervisor.supervisor(), timeout) :: boolean
-  def active?(supervisor_pid, timeout \\ 5000) do
+  def active?(supervisor_pid, timeout \\ @manager_query_timeout) do
     consumer_supervisor = consumer_supervisor_pid(supervisor_pid, timeout)
 
     consumer_supervisor &&
@@ -381,7 +389,14 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
     opts = Keyword.put(opts, :supervisor_pid, self())
 
     children = [
-      {KafkaEx.Consumer.ConsumerGroup.Manager, {{gen_consumer_module, consumer_module}, group_name, topics, opts}}
+      # Give the Manager more than the default 5s shutdown so terminate/2 can send
+      # LeaveGroup on a graceful stop (LeaveGroup's per-attempt recv is up to
+      # :request_timeout). A stop that lands mid-rebalance can still exceed this —
+      # the full fix (non-blocking join) is a tracked follow-up; see UPGRADING.
+      Supervisor.child_spec(
+        {KafkaEx.Consumer.ConsumerGroup.Manager, {{gen_consumer_module, consumer_module}, group_name, topics, opts}},
+        shutdown: 25_000
+      )
     ]
 
     Supervisor.init(children,

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -84,7 +84,13 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
           group_instance_id: group_instance_id
         } = state
       ) do
-    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id, group_instance_id: group_instance_id) do
+    # Heartbeat is answered promptly by the coordinator (never held), so bound its
+    # per-attempt socket-recv to heartbeat_interval rather than the generic
+    # :request_timeout — a stalled heartbeat is then detected well inside
+    # session_timeout, leaving the manager time to rejoin before eviction.
+    heartbeat_opts = [group_instance_id: group_instance_id, network_timeout: heartbeat_interval]
+
+    case KafkaExAPI.heartbeat(client, group_name, member_id, generation_id, heartbeat_opts) do
       {:ok, %KafkaEx.Messages.Heartbeat{}} ->
         {:noreply, state, heartbeat_interval}
 

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -145,8 +145,11 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           }
   end
 
-  @heartbeat_interval 5_000
-  @session_timeout 30_000
+  # Defaults aligned with the Apache Kafka 3.0+ consumer (KIP-735 raised
+  # session.timeout.ms 10s→45s to cut spurious rebalances; heartbeat.interval.ms
+  # stays 3s, ≈ 1/15 of the session and well within the ≤ 1/3 requirement).
+  @heartbeat_interval 3_000
+  @session_timeout 45_000
   @session_timeout_padding 10_000
   # Default rebalance_timeout multiplier (relative to session_timeout)
   # In Java client, rebalance_timeout = max.poll.interval.ms (default 5 min)

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -619,7 +619,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
          %State{
            client: client,
            session_timeout: session_timeout,
-           session_timeout_padding: session_timeout_padding,
            rebalance_timeout: rebalance_timeout,
            group_name: group_name,
            topics: topics,
@@ -628,11 +627,13 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
          } = state,
          attempt_number
        ) do
+    # No `:timeout` here: KafkaEx.API.join_group derives both the per-attempt
+    # socket-recv deadline and the outer GenServer.call budget from
+    # rebalance_timeout (JoinGroup is held by the broker for the rebalance window).
     opts = [
       topics: topics,
       session_timeout: session_timeout,
       rebalance_timeout: rebalance_timeout,
-      timeout: session_timeout + session_timeout_padding,
       group_instance_id: group_instance_id
     ]
 

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -92,9 +92,17 @@ defmodule KafkaEx.Support.Retry do
   @spec backoff_delay_jittered(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
           non_neg_integer()
   def backoff_delay_jittered(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
-    attempt
-    |> backoff_delay(base_ms, max_ms)
-    |> apply_jitter()
+    jittered =
+      attempt
+      |> backoff_delay(base_ms, max_ms)
+      |> apply_jitter()
+
+    # Keep the result within the cap — jitter is applied after the exponential
+    # cap, so clamp so a delay never exceeds max_ms (KIP-580 jitters within bound).
+    case max_ms do
+      :infinity -> jittered
+      cap when is_integer(cap) -> min(jittered, cap)
+    end
   end
 
   defp apply_jitter(0), do: 0
@@ -205,6 +213,18 @@ defmodule KafkaEx.Support.Retry do
   def transient_error?(error), do: coordinator_error?(error)
 
   @doc """
+  Check if an error is a socket `Socket.recv` deadline expiry (`:timeout`).
+
+  Distinct from the broker error code `:request_timed_out` (Kafka error 7), which
+  comes back fast. A recv-timeout is the one error that costs a full per-attempt
+  `network_timeout`, so `KafkaEx.Client` sends it **once** rather than retrying it
+  inside its synchronous request loop; higher-level loops re-issue with backoff.
+  """
+  @spec transport_timeout?(error()) :: boolean()
+  def transport_timeout?(:timeout), do: true
+  def transport_timeout?(_), do: false
+
+  @doc """
   Check if error is a leadership-related error requiring metadata refresh.
 
   These errors indicate the client has stale partition leadership information.
@@ -309,9 +329,16 @@ defmodule KafkaEx.Support.Retry do
 
   The heartbeat process stops on any error and lets the manager react
   (`Heartbeat.handle_info/2`), so the only retry is here at the client. Its
-  value is absorbing a transient blip (timeout / coordinator hiccup) so a
-  single failed heartbeat does not escalate into a full rejoin + group-wide
-  rebalance — hence default-retry for unclassified errors.
+  value is absorbing a transient *coordinator hiccup* so a single failed
+  heartbeat does not escalate into a full rejoin + group-wide rebalance — hence
+  default-retry for unclassified errors.
+
+  Note: a socket recv-**timeout** is NOT absorbed here. `KafkaEx.Client` treats a
+  transport `:timeout` as send-once (it would otherwise block the synchronous
+  client for another full `:request_timeout`), so a heartbeat whose recv times
+  out escalates to a rejoin rather than being retried by this classifier. This
+  matches the reference clients, and by then the coordinator is unresponsive for
+  a large fraction of the session window anyway.
 
   The broker's "rejoin now" / identity signals — `:rebalance_in_progress`,
   `:unknown_member_id` and `:illegal_generation` — are mapped by the heartbeat

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -42,6 +42,11 @@ defmodule KafkaEx.Support.Retry do
   @default_max_attempts 3
   @default_base_delay_ms 100
   @default_max_delay_ms :infinity
+  # ±20% uniform jitter on each backoff, matching Kafka's KIP-580
+  # (retry.backoff.ms grows exponentially up to retry.backoff.max.ms with ±20%
+  # jitter). Jitter decorrelates retries across many members so they do not
+  # thundering-herd the coordinator/broker after a shared failure.
+  @jitter_fraction 0.2
 
   @doc """
   Calculate exponential backoff delay.
@@ -73,6 +78,35 @@ defmodule KafkaEx.Support.Retry do
     case max_ms do
       :infinity -> delay
       cap when is_integer(cap) -> min(delay, cap)
+    end
+  end
+
+  @doc """
+  Exponential backoff (`backoff_delay/3`) with ±20% uniform jitter (KIP-580).
+
+  Returns a delay drawn uniformly from `[0.8 × base, 1.2 × base]`, where `base`
+  is the capped exponential value. Used by `with_retry/2` so concurrent retriers
+  (e.g. all members of a consumer group after a coordinator blip) spread their
+  re-attempts instead of retrying in lockstep. A zero base stays zero.
+  """
+  @spec backoff_delay_jittered(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
+          non_neg_integer()
+  def backoff_delay_jittered(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
+    attempt
+    |> backoff_delay(base_ms, max_ms)
+    |> apply_jitter()
+  end
+
+  defp apply_jitter(0), do: 0
+
+  defp apply_jitter(delay) do
+    spread = trunc(delay * @jitter_fraction)
+
+    if spread <= 0 do
+      delay
+    else
+      # uniform in [delay - spread, delay + spread]
+      delay - spread + (:rand.uniform(2 * spread + 1) - 1)
     end
   end
 
@@ -129,7 +163,7 @@ defmodule KafkaEx.Support.Retry do
 
   defp maybe_retry(fun, attempt, max, base, max_delay, retryable?, on_retry, error) do
     if attempt < max - 1 and retryable?.(error) do
-      delay = backoff_delay(attempt, base, max_delay)
+      delay = backoff_delay_jittered(attempt, base, max_delay)
       invoke_on_retry(on_retry, error, attempt + 1, delay)
       Process.sleep(delay)
       do_retry(fun, attempt + 1, max, base, max_delay, retryable?, on_retry, error)

--- a/test/kafka_ex/api/coordinator_timeout_test.exs
+++ b/test/kafka_ex/api/coordinator_timeout_test.exs
@@ -1,0 +1,59 @@
+defmodule KafkaEx.API.CoordinatorTimeoutTest do
+  @moduledoc """
+  JoinGroup/SyncGroup derive a per-attempt `:network_timeout` (the socket-recv
+  deadline) sized to how long the broker legitimately holds the response, and
+  thread it through as a control opt (popped by the client before building the
+  protocol request). Regression coverage for the consumer-group cold-start bug:
+  the old code let these fall back to the 1000ms generic timeout while the broker
+  held JoinGroup for >= group.initial.rebalance.delay.ms.
+  """
+  use ExUnit.Case, async: true
+
+  alias KafkaEx.Test.CapturingMockClient
+
+  describe "join_group/4" do
+    test "derives network_timeout = rebalance_timeout + 5000 and drops :timeout" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} =
+               KafkaEx.API.join_group(client, "g", "",
+                 rebalance_timeout: 90_000,
+                 timeout: 40_000
+               )
+
+      assert [{:join_group, "g", "", opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 95_000
+      refute Keyword.has_key?(opts, :timeout)
+    end
+
+    test "uses the default rebalance_timeout when unset" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.join_group(client, "g", "")
+
+      assert [{:join_group, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 65_000
+    end
+  end
+
+  describe "sync_group/5" do
+    test "derives network_timeout from the caller :timeout (session + padding) and drops :timeout" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.sync_group(client, "g", 1, "m", timeout: 40_000)
+
+      assert [{:sync_group, "g", 1, "m", opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 40_000
+      refute Keyword.has_key?(opts, :timeout)
+    end
+
+    test "falls back to the default when no timeout is supplied" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.sync_group(client, "g", 1, "m")
+
+      assert [{:sync_group, _, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 35_000
+    end
+  end
+end

--- a/test/kafka_ex/api/coordinator_timeout_test.exs
+++ b/test/kafka_ex/api/coordinator_timeout_test.exs
@@ -56,4 +56,24 @@ defmodule KafkaEx.API.CoordinatorTimeoutTest do
       assert Keyword.get(opts, :network_timeout) == 35_000
     end
   end
+
+  describe "heartbeat/5" do
+    test "uses the caller-supplied short network_timeout (heartbeat_interval), not the generic default" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.heartbeat(client, "g", "m", 1, network_timeout: 5_000)
+
+      assert [{:heartbeat, "g", "m", 1, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 5_000
+    end
+
+    test "falls back to the generic :request_timeout when no network_timeout is supplied" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.heartbeat(client, "g", "m", 1)
+
+      assert [{:heartbeat, _, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == KafkaEx.Config.request_timeout()
+    end
+  end
 end

--- a/test/kafka_ex/api/coordinator_timeout_test.exs
+++ b/test/kafka_ex/api/coordinator_timeout_test.exs
@@ -12,14 +12,10 @@ defmodule KafkaEx.API.CoordinatorTimeoutTest do
   alias KafkaEx.Test.CapturingMockClient
 
   describe "join_group/4" do
-    test "derives network_timeout = rebalance_timeout + 5000 and drops :timeout" do
+    test "derives network_timeout = rebalance_timeout + 5000 (no explicit timeout)" do
       {:ok, client} = CapturingMockClient.start_link()
 
-      assert {:ok, _} =
-               KafkaEx.API.join_group(client, "g", "",
-                 rebalance_timeout: 90_000,
-                 timeout: 40_000
-               )
+      assert {:ok, _} = KafkaEx.API.join_group(client, "g", "", rebalance_timeout: 90_000)
 
       assert [{:join_group, "g", "", opts}] = CapturingMockClient.calls(client)
       assert Keyword.get(opts, :network_timeout) == 95_000
@@ -33,6 +29,27 @@ defmodule KafkaEx.API.CoordinatorTimeoutTest do
 
       assert [{:join_group, _, _, opts}] = CapturingMockClient.calls(client)
       assert Keyword.get(opts, :network_timeout) == 65_000
+    end
+
+    # Backward-compat: pre-1.1 callers passed :timeout to bound the join. It is
+    # now honored as the per-attempt deadline override (rather than silently dropped).
+    test "honors an explicit :timeout override" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.join_group(client, "g", "", timeout: 12_345)
+
+      assert [{:join_group, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 12_345
+      refute Keyword.has_key?(opts, :timeout)
+    end
+
+    test ":network_timeout wins over :timeout" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.join_group(client, "g", "", network_timeout: 111, timeout: 222)
+
+      assert [{:join_group, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 111
     end
   end
 
@@ -54,6 +71,31 @@ defmodule KafkaEx.API.CoordinatorTimeoutTest do
 
       assert [{:sync_group, _, _, _, opts}] = CapturingMockClient.calls(client)
       assert Keyword.get(opts, :network_timeout) == 35_000
+    end
+
+    test ":network_timeout wins over :timeout" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.sync_group(client, "g", 1, "m", network_timeout: 111, timeout: 222)
+
+      assert [{:sync_group, _, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 111
+    end
+  end
+
+  describe "create_topics/4 and delete_topics/4" do
+    test "size the per-attempt socket-recv to the broker op timeout (timeout + buffer)" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.create_topics(client, ["t"], 10_000)
+      assert {:ok, _} = KafkaEx.API.delete_topics(client, ["t"], 30_000)
+
+      calls = CapturingMockClient.calls(client)
+      assert {:create_topics, ["t"], 10_000, create_opts} = Enum.at(calls, 0)
+      assert {:delete_topics, ["t"], 30_000, delete_opts} = Enum.at(calls, 1)
+      # broker timeout + @coordinator_call_timeout_buffer (5_000)
+      assert Keyword.get(create_opts, :network_timeout) == 15_000
+      assert Keyword.get(delete_opts, :network_timeout) == 35_000
     end
   end
 

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -19,6 +19,64 @@ defmodule KafkaEx.ConfigTest do
     :ok
   end
 
+  describe "request_timeout/0" do
+    setup do
+      on_exit(fn ->
+        Application.delete_env(:kafka_ex, :sync_timeout)
+      end)
+
+      :ok
+    end
+
+    test "defaults to 15_000 when neither :request_timeout nor :sync_timeout is set" do
+      Application.delete_env(:kafka_ex, :request_timeout)
+      Application.delete_env(:kafka_ex, :sync_timeout)
+      assert Config.request_timeout() == 15_000
+    end
+
+    test "uses :request_timeout when set" do
+      Application.put_env(:kafka_ex, :request_timeout, 20_000)
+      assert Config.request_timeout() == 20_000
+    end
+
+    test "falls back to the deprecated :sync_timeout alias" do
+      Application.delete_env(:kafka_ex, :request_timeout)
+      Application.put_env(:kafka_ex, :sync_timeout, 42_000)
+      assert Config.request_timeout() == 42_000
+    end
+
+    test ":request_timeout wins over :sync_timeout" do
+      Application.put_env(:kafka_ex, :request_timeout, 7_000)
+      Application.put_env(:kafka_ex, :sync_timeout, 42_000)
+      assert Config.request_timeout() == 7_000
+    end
+  end
+
+  describe "warn_deprecated_timeout_config/0" do
+    import ExUnit.CaptureLog
+
+    setup do
+      on_exit(fn -> Application.delete_env(:kafka_ex, :sync_timeout) end)
+      :ok
+    end
+
+    test "warns when only the deprecated :sync_timeout is set" do
+      Application.delete_env(:kafka_ex, :request_timeout)
+      Application.put_env(:kafka_ex, :sync_timeout, 30_000)
+
+      log = capture_log(fn -> assert Config.warn_deprecated_timeout_config() == :ok end)
+      assert log =~ ":sync_timeout is deprecated"
+    end
+
+    test "does not warn when :request_timeout is set" do
+      Application.put_env(:kafka_ex, :request_timeout, 15_000)
+      Application.put_env(:kafka_ex, :sync_timeout, 30_000)
+
+      log = capture_log(fn -> assert Config.warn_deprecated_timeout_config() == :ok end)
+      refute log =~ "deprecated"
+    end
+  end
+
   test "ssl_options returns the correct value when configured properly" do
     Application.put_env(:kafka_ex, :use_ssl, true)
     ssl_options = Application.get_env(:kafka_ex, :ssl_options)

--- a/test/kafka_ex/config_test.exs
+++ b/test/kafka_ex/config_test.exs
@@ -50,6 +50,20 @@ defmodule KafkaEx.ConfigTest do
       Application.put_env(:kafka_ex, :sync_timeout, 42_000)
       assert Config.request_timeout() == 7_000
     end
+
+    # End-to-end backward-compat: the deprecated alias must reach a *derived
+    # operation timeout*, not just Config. (This test module is async: false, so
+    # mutating the global :kafka_ex env is safe.)
+    test "the deprecated :sync_timeout alias flows end-to-end into a derived operation timeout" do
+      Application.delete_env(:kafka_ex, :request_timeout)
+      Application.put_env(:kafka_ex, :sync_timeout, 22_222)
+
+      {:ok, client} = KafkaEx.Test.CapturingMockClient.start_link()
+      assert {:ok, _} = KafkaEx.API.heartbeat(client, "g", "m", 1)
+
+      assert [{:heartbeat, _, _, _, opts}] = KafkaEx.Test.CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 22_222
+    end
   end
 
   describe "warn_deprecated_timeout_config/0" do

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -42,6 +42,36 @@ defmodule KafkaEx.Support.RetryTest do
     end
   end
 
+  describe "backoff_delay_jittered/3" do
+    test "stays within ±20% of the exponential base for every attempt" do
+      for attempt <- 0..5 do
+        base = Retry.backoff_delay(attempt, 100)
+        lower = trunc(base * 0.8)
+        upper = base + trunc(base * 0.2)
+
+        for _ <- 1..200 do
+          delay = Retry.backoff_delay_jittered(attempt, 100)
+          assert delay >= lower and delay <= upper
+        end
+      end
+    end
+
+    test "jitters around the max_ms cap, not the uncapped value" do
+      base = 5000
+      lower = trunc(base * 0.8)
+      upper = base + trunc(base * 0.2)
+
+      for _ <- 1..200 do
+        delay = Retry.backoff_delay_jittered(10, 100, 5000)
+        assert delay >= lower and delay <= upper
+      end
+    end
+
+    test "a zero base yields zero" do
+      assert Retry.backoff_delay_jittered(0, 0) == 0
+    end
+  end
+
   describe "with_retry/2" do
     test "returns success immediately on first try" do
       result = Retry.with_retry(fn -> {:ok, :success} end)

--- a/test/support/capturing_mock_client.ex
+++ b/test/support/capturing_mock_client.ex
@@ -57,6 +57,14 @@ defmodule KafkaEx.Test.CapturingMockClient do
     {:reply, {:ok, %KafkaEx.Messages.LeaveGroup{}}, {[{:leave_group, group, member_id, opts} | calls], watcher}}
   end
 
+  def handle_call({:create_topics, topics, timeout, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %{}}, {[{:create_topics, topics, timeout, opts} | calls], watcher}}
+  end
+
+  def handle_call({:delete_topics, topics, timeout, opts}, _from, {calls, watcher}) do
+    {:reply, {:ok, %{}}, {[{:delete_topics, topics, timeout, opts} | calls], watcher}}
+  end
+
   @impl true
   def terminate(_reason, {calls, watcher}) when is_pid(watcher) do
     send(watcher, {:captured_calls, Enum.reverse(calls)})


### PR DESCRIPTION
## Problem

Consumer-group **cold start reliably times out**. JoinGroup/SyncGroup fell back to
the generic ~1000 ms socket-recv timeout while the broker legitimately holds a
JoinGroup response for up to `group.initial.rebalance.delay.ms` (default 3 s) on a
new/empty group — so the first member timed out before the broker replied and
never joined. (The library's own `config.exs` value does not propagate to
consuming apps, so the effective downstream default was the code fallback.)
Downstream users worked around it with `sync_timeout: 60_000`.

## Fix

Adopt the reference-client model (Java / kafka-python / librdkafka: **send-once +
higher-level rejoin**), generalizing the #357 fetch-timeout derivation to all
requests:

- **JoinGroup** per-attempt socket-recv = `rebalance_timeout + 5000` (mirrors the
  Java `JOIN_GROUP_TIMEOUT_LAPSE`); **SyncGroup** = session window; both sent
  send-once at the client, with `ConsumerGroup.Manager` owning rejoin.
- Outer `GenServer.call` budgets are **derived** from the per-attempt deadline, so
  the two can no longer mismatch (the #357 class), across every request type
  (data-plane wrappers, coordinator calls, admin ops).
- A socket recv `:timeout` is **send-once** in the synchronous client loop;
  protocol errors keep their retry + metadata/coordinator refresh.
- New **`:request_timeout`** config (default `15000`) as the generic per-attempt
  socket-recv; **`:sync_timeout` is a deprecated, still-honored alias** (removed
  in 2.0), with a one-time boot warning.
- Heartbeat uses a short per-attempt deadline (`heartbeat_interval`), not the
  generic timeout, so a stalled heartbeat is caught well inside `session_timeout`.
- **±20% retry jitter** (KIP-580) added to `KafkaEx.Support.Retry`.

## Review

Reviewed through three expert lenses (kafka-python, Java client, Elixir/OTP). The
OTP review flagged that the `Manager` performs join/sync synchronously in its
callback, so during a rebalance it is briefly unresponsive; addressed here with
minimal hardening (introspection-call timeout and Manager child `shutdown:`
raised), with a fully non-blocking Manager tracked as a follow-up.

## Compatibility / behavior changes

See `UPGRADING.md`:
- `:sync_timeout` → `:request_timeout` (deprecation; a join-timeout workaround can
  be removed).
- Data-plane failure latency for a silently-unresponsive broker rises (~1–3 s →
  ~15 s per attempt); a healthy broker is unaffected.
- A single heartbeat recv-timeout now escalates to a rejoin (was retried in-client).

## Scope

P0 correctness fix. The **P2 default alignment** (`session_timeout` 45000 /
`heartbeat_interval` 3000, Kafka 3.0 / KIP-735) follows as a **separate PR**.

## Verification

`mix format` · `mix compile --warnings-as-errors` · `mix credo --strict` ·
`mix dialyzer` (0 errors) · `mix test.unit` (all green, +new coordinator/heartbeat
timeout and retry-jitter tests). Real cold-start integration coverage runs under
`mix test.integration` (Docker cluster).
