### PR TITLE
feat: align consumer-group defaults with Kafka 3.0 (session 45s, heartbeat 3s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@
   KafkaEx 2.0. It remains honored as an alias; setting it without `:request_timeout` logs a
   one-time deprecation warning at client boot. See UPGRADING.md.
 
+### Changed
+
+* **Consumer-group defaults aligned with the Apache Kafka 3.0+ consumer.**
+  `session_timeout` default is now `45_000` ms (was `30_000`; matches KIP-735, which raised
+  `session.timeout.ms` to cut spurious rebalances) and `heartbeat_interval` is now `3_000` ms
+  (was `5_000`; the canonical Kafka pairing, ≈ 1/15 of the session). The derived
+  `rebalance_timeout` default (`session_timeout × 3`) is therefore `135_000` ms. **Behavior
+  change:** a dead member is now detected after ~45 s of missed heartbeats instead of ~30 s
+  (fewer spurious rebalances on transient hiccups), and heartbeats are sent more frequently.
+  Override `:session_timeout` / `:heartbeat_interval` to restore the old values. See UPGRADING.md.
+
 ## 1.0.1 (2026-06-26)
 
 ### Breaking Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -161,6 +161,32 @@ default 3s). Two consequences for that window:
     members, KIP-345, intentionally skip LeaveGroup anyway). Raise the group's
     child `shutdown:` if graceful mid-rebalance leave matters for your deploys.
 
+## Consumer-group defaults aligned with Kafka 3.0
+
+Two consumer-group defaults now match the Apache Kafka 3.0+ consumer:
+
+| Option | Old default | New default | Why |
+|---|---|---|---|
+| `session_timeout` | `30_000` | `45_000` | KIP-735 — fewer spurious rebalances |
+| `heartbeat_interval` | `5_000` | `3_000` | Kafka's canonical pairing (≈ session / 15) |
+
+The derived `rebalance_timeout` default (`session_timeout × 3`) is therefore
+`135_000` ms.
+
+**Behavior change.** A dead/partitioned member is now declared dead after ~45 s
+of missed heartbeats instead of ~30 s — a transient hiccup is less likely to
+trigger a rebalance, at the cost of slightly slower detection of a genuinely
+gone member. Heartbeats are also sent more often (every 3 s). To keep the old
+behavior, set them explicitly:
+
+```elixir
+KafkaEx.Consumer.ConsumerGroup.start_link(
+  MyConsumer, "my-group", ["topic"],
+  session_timeout: 30_000,
+  heartbeat_interval: 5_000
+)
+```
+
 ---
 
 # Upgrading to KafkaEx 1.0

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -145,8 +145,11 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
           }
   end
 
-  @heartbeat_interval 5_000
-  @session_timeout 30_000
+  # Defaults aligned with the Apache Kafka 3.0+ consumer (KIP-735 raised
+  # session.timeout.ms 10s→45s to cut spurious rebalances; heartbeat.interval.ms
+  # stays 3s, ≈ 1/15 of the session and well within the ≤ 1/3 requirement).
+  @heartbeat_interval 3_000
+  @session_timeout 45_000
   @session_timeout_padding 10_000
   # Default rebalance_timeout multiplier (relative to session_timeout)
   # In Java client, rebalance_timeout = max.poll.interval.ms (default 5 min)


### PR DESCRIPTION
## What

Aligns two consumer-group defaults with the Apache Kafka 3.0+ consumer:

| Option | Old | New | Why |
|---|---|---|---|
| `session_timeout` | `30_000` | `45_000` | KIP-735 — raised to cut spurious rebalances |
| `heartbeat_interval` | `5_000` | `3_000` | Kafka's canonical pairing (≈ session / 15) |

The derived `rebalance_timeout` default (`session_timeout × 3`) becomes `135_000` ms.

## Behavior change

A dead/partitioned member is now declared dead after ~45 s of missed heartbeats
instead of ~30 s (fewer spurious rebalances on a transient hiccup, at the cost of
slightly slower detection of a genuinely gone member); heartbeats are sent more
often (every 3 s). Set `:session_timeout` / `:heartbeat_interval` explicitly to
keep the old values. See `UPGRADING.md`.

## Notes

- **Stacked on #566** (the JoinGroup/SyncGroup timeout fix), which this shares
  `manager.ex` / `UPGRADING.md` with. Base will retarget to `master` once #566
  merges.
- Verified: `mix format` · `compile --warnings-as-errors` · `credo --strict` ·
  `dialyzer` (0 errors) · `mix test.unit` (all green).
