### PR TITLE
refactor: extract pure GenServer.call budget arithmetic into RequestBudget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Effective version per request = **per-request opts > application config (`:api_v
 ## Conventions & gotchas
 
 - `mix compile --warnings-as-errors` is enforced — keep the build warning-free.
-- The client retry budget is split across two modules: `@retry_count` in `client/client.ex` and `@fetch_max_retries` in `api.ex` must stay equal, and are kept in sync **by hand** (see #357). Change both together.
+- The client retry budget lives in `@retry_count` (`client/client.ex`, exposed via `Client.retry_count/0`); `KafkaEx.API` derives `@fetch_max_retries` from it at compile time (#562), so the two can no longer drift — change `@retry_count` only.
 - Test mocking uses **Mimic** (recently migrated off Hammox). Test support lives in `test/support` (compiled only in `:test`).
 - The protocol layer favors keeping Kafka business logic *out* of the `Client` GenServer and *in* the per-version protocol impls, so the client stays stable as the wire protocol evolves.
 

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -92,22 +92,16 @@ defmodule KafkaEx.API do
   @type member_id :: binary
   @type generation_id :: non_neg_integer
 
-  # Timeout model (canonical note; call sites point here). Each request derives a
-  # per-attempt Socket.recv deadline (network_timeout) and an outer GenServer.call
-  # budget from it (via KafkaEx.Client.RequestBudget), so the two can't mismatch
-  # (#357). Per-attempt deadline by op: fetch = max_wait_time + grace; join =
-  # rebalance_timeout + lapse (broker holds it that long); sync = session window;
-  # create/delete = broker op timeout + grace; everything else = :request_timeout.
-  # @fetch_max_retries comes from Client.retry_count/0 (single source of truth;
-  # makes API compile-depend on Client — acyclic, keep it so). @default_max_wait_time
-  # MUST match the fetch builder's :max_wait_time default.
+  # Per-attempt Socket.recv deadline per op; the outer GenServer.call budget is
+  # derived from it via RequestBudget so the two can't mismatch (#357):
+  #   fetch = max_wait_time + grace · join = rebalance_timeout + lapse
+  #   sync = session window · create/delete = broker op timeout + grace · else = :request_timeout
+  # @default_max_wait_time MUST match the fetch builder's :max_wait_time default.
   @default_max_wait_time 10_000
-  # Per-attempt socket-recv grace over a broker-held duration (fetch long-poll,
-  # create/delete op timeout). The outer-call buffer lives in RequestBudget.
   @network_timeout_buffer 5_000
+  # Retry budget's single source of truth (API compile-depends on Client for it; acyclic).
   @fetch_max_retries KafkaEx.Client.retry_count()
 
-  # JoinGroup grace over rebalance_timeout (mirrors Java's JOIN_GROUP_TIMEOUT_LAPSE).
   @join_group_timeout_lapse 5_000
   @join_default_rebalance_timeout 60_000
   @sync_default_timeout 35_000
@@ -683,11 +677,9 @@ defmodule KafkaEx.API do
   @spec leave_group(client, consumer_group_name, member_id, opts) ::
           {:ok, :no_error | LeaveGroup.t()} | {:error, error_atom}
   def leave_group(client, consumer_group, member_id, opts \\ []) do
-    case GenServer.call(client, {:leave_group, consumer_group, member_id, opts}, generic_call_budget()) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call({:leave_group, consumer_group, member_id, opts}, generic_call_budget())
+    |> normalize_reply()
   end
 
   @doc """
@@ -711,15 +703,12 @@ defmodule KafkaEx.API do
     network_timeout = Keyword.get(opts, :network_timeout, Config.request_timeout())
     opts = Keyword.put(opts, :network_timeout, network_timeout)
 
-    case GenServer.call(
-           client,
-           {:heartbeat, consumer_group, member_id, generation_id, opts},
-           call_budget(network_timeout)
-         ) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call(
+      {:heartbeat, consumer_group, member_id, generation_id, opts},
+      RequestBudget.call_budget(network_timeout, @fetch_max_retries)
+    )
+    |> normalize_reply()
   end
 
   @doc """
@@ -746,11 +735,9 @@ defmodule KafkaEx.API do
   @spec find_coordinator(client, consumer_group_name) :: {:ok, FindCoordinator.t()} | {:error, error_atom}
   @spec find_coordinator(client, consumer_group_name, opts) :: {:ok, FindCoordinator.t()} | {:error, error_atom}
   def find_coordinator(client, group_id, opts \\ []) do
-    case GenServer.call(client, {:find_coordinator, group_id, opts}, generic_call_budget()) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call({:find_coordinator, group_id, opts}, generic_call_budget())
+    |> normalize_reply()
   end
 
   # ---------------------------------------------------------------------------
@@ -867,11 +854,9 @@ defmodule KafkaEx.API do
   end
 
   def produce(client, topic, partition, messages, opts) when is_integer(partition) do
-    case GenServer.call(client, {:produce, topic, partition, messages, opts}, generic_call_budget()) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call({:produce, topic, partition, messages, opts}, generic_call_budget())
+    |> normalize_reply()
   end
 
   @doc """
@@ -967,42 +952,35 @@ defmodule KafkaEx.API do
   def fetch(client, topic, partition, offset, opts \\ []) do
     {call_timeout, opts_with_timeout} = derive_fetch_timeouts(opts)
 
-    case GenServer.call(client, {:fetch, topic, partition, offset, opts_with_timeout}, call_timeout) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call({:fetch, topic, partition, offset, opts_with_timeout}, call_timeout)
+    |> normalize_reply()
   end
 
   defp derive_fetch_timeouts(opts) do
     max_wait_time = Keyword.get(opts, :max_wait_time, @default_max_wait_time)
     network_timeout = Keyword.get(opts, :network_timeout, max_wait_time + @network_timeout_buffer)
-    {call_budget(network_timeout), Keyword.put_new(opts, :network_timeout, network_timeout)}
+    call_timeout = RequestBudget.call_budget(network_timeout, @fetch_max_retries)
+    {call_timeout, Keyword.put_new(opts, :network_timeout, network_timeout)}
   end
 
-  # Outer GenServer.call budget for a retried request (fetch + generic data-plane):
-  # per-attempt deadline × the client retry budget, via RequestBudget.
-  defp call_budget(per_attempt), do: RequestBudget.retrying(per_attempt, @fetch_max_retries)
+  # Derived, never the implicit 5000 GenServer.call default: a >5000 :request_timeout
+  # would otherwise exit the caller before the client replies (#357).
+  defp generic_call_budget, do: RequestBudget.call_budget(Config.request_timeout(), @fetch_max_retries)
 
-  # Outer budget for requests whose per-attempt recv is the generic :request_timeout.
-  # Derived (not the implicit 5000 default) so a >5000 :request_timeout can't exceed
-  # the outer call and exit the caller mid-flight (#357).
-  defp generic_call_budget, do: call_budget(Config.request_timeout())
-
-  # Shared plumbing for the send-once coordinator calls (join/sync): inject the
-  # derived per-attempt `network_timeout` as a control opt, size the outer budget
-  # from it (no × retries — send-once), and normalize the reply. Only the message
-  # tuple and the `network_timeout` derivation differ between join and sync.
+  # join/sync share this: inject the per-attempt network_timeout as a control opt,
+  # size the send-once outer budget from it, normalize the reply.
   defp coordinator_call(client, opts, network_timeout, msg_fun) do
-    call_timeout = RequestBudget.send_once(network_timeout)
+    call_timeout = RequestBudget.call_budget(network_timeout)
     call_opts = opts |> Keyword.delete(:timeout) |> Keyword.put(:network_timeout, network_timeout)
 
-    case GenServer.call(client, msg_fun.(call_opts), call_timeout) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client |> GenServer.call(msg_fun.(call_opts), call_timeout) |> normalize_reply()
   end
+
+  # Collapse the client's reply into the public {:ok, _} | {:error, atom} contract.
+  defp normalize_reply({:ok, result}), do: {:ok, result}
+  defp normalize_reply({:error, %{error: error_atom}}), do: {:error, error_atom}
+  defp normalize_reply({:error, error_atom}), do: {:error, error_atom}
 
   @doc """
   Fetch all available records from a topic partition.
@@ -1085,11 +1063,12 @@ defmodule KafkaEx.API do
     network_timeout = timeout + @network_timeout_buffer
     opts = Keyword.put_new(opts, :network_timeout, network_timeout)
 
-    case GenServer.call(client, {:create_topics, topics, timeout, opts}, call_budget(network_timeout)) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call(
+      {:create_topics, topics, timeout, opts},
+      RequestBudget.call_budget(network_timeout, @fetch_max_retries)
+    )
+    |> normalize_reply()
   end
 
   @doc """
@@ -1168,11 +1147,12 @@ defmodule KafkaEx.API do
     network_timeout = timeout + @network_timeout_buffer
     opts = Keyword.put_new(opts, :network_timeout, network_timeout)
 
-    case GenServer.call(client, {:delete_topics, topics, timeout, opts}, call_budget(network_timeout)) do
-      {:ok, result} -> {:ok, result}
-      {:error, %{error: error_atom}} -> {:error, error_atom}
-      {:error, error_atom} -> {:error, error_atom}
-    end
+    client
+    |> GenServer.call(
+      {:delete_topics, topics, timeout, opts},
+      RequestBudget.call_budget(network_timeout, @fetch_max_retries)
+    )
+    |> normalize_reply()
   end
 
   @doc """

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -56,6 +56,7 @@ defmodule KafkaEx.API do
   """
 
   alias KafkaEx.Client
+  alias KafkaEx.Client.RequestBudget
   alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Cluster.Topic
   alias KafkaEx.Config
@@ -93,23 +94,23 @@ defmodule KafkaEx.API do
 
   # Timeout model (canonical note; call sites point here). Each request derives a
   # per-attempt Socket.recv deadline (network_timeout) and an outer GenServer.call
-  # budget from it, so the two can't mismatch (#357). Per-attempt deadline by op:
-  # fetch = max_wait_time + buffer; join = rebalance_timeout + lapse (broker holds
-  # it that long); sync = session window; everything else = :request_timeout.
+  # budget from it (via KafkaEx.Client.RequestBudget), so the two can't mismatch
+  # (#357). Per-attempt deadline by op: fetch = max_wait_time + grace; join =
+  # rebalance_timeout + lapse (broker holds it that long); sync = session window;
+  # create/delete = broker op timeout + grace; everything else = :request_timeout.
   # @fetch_max_retries comes from Client.retry_count/0 (single source of truth;
   # makes API compile-depend on Client — acyclic, keep it so). @default_max_wait_time
   # MUST match the fetch builder's :max_wait_time default.
   @default_max_wait_time 10_000
-  @fetch_network_timeout_buffer 5_000
-  @fetch_call_timeout_buffer 5_000
+  # Per-attempt socket-recv grace over a broker-held duration (fetch long-poll,
+  # create/delete op timeout). The outer-call buffer lives in RequestBudget.
+  @network_timeout_buffer 5_000
   @fetch_max_retries KafkaEx.Client.retry_count()
 
   # JoinGroup grace over rebalance_timeout (mirrors Java's JOIN_GROUP_TIMEOUT_LAPSE).
   @join_group_timeout_lapse 5_000
   @join_default_rebalance_timeout 60_000
   @sync_default_timeout 35_000
-  # Outer-call buffer over the per-attempt deadline (join/sync send-once: no ×retries).
-  @coordinator_call_timeout_buffer 5_000
 
   # ---------------------------------------------------------------------------
   # __using__ macro for mixin pattern
@@ -975,15 +976,13 @@ defmodule KafkaEx.API do
 
   defp derive_fetch_timeouts(opts) do
     max_wait_time = Keyword.get(opts, :max_wait_time, @default_max_wait_time)
-    network_timeout = Keyword.get(opts, :network_timeout, max_wait_time + @fetch_network_timeout_buffer)
+    network_timeout = Keyword.get(opts, :network_timeout, max_wait_time + @network_timeout_buffer)
     {call_budget(network_timeout), Keyword.put_new(opts, :network_timeout, network_timeout)}
   end
 
-  # Outer GenServer.call budget for a per-attempt socket-recv deadline: covers the
-  # full client-level retry loop (`per_attempt × retries + buffer`). Single source
-  # for the shape shared by fetch (`derive_fetch_timeouts/1`) and the generic
-  # data-plane wrappers (`generic_call_budget/0`).
-  defp call_budget(per_attempt), do: per_attempt * @fetch_max_retries + @fetch_call_timeout_buffer
+  # Outer GenServer.call budget for a retried request (fetch + generic data-plane):
+  # per-attempt deadline × the client retry budget, via RequestBudget.
+  defp call_budget(per_attempt), do: RequestBudget.retrying(per_attempt, @fetch_max_retries)
 
   # Outer budget for requests whose per-attempt recv is the generic :request_timeout.
   # Derived (not the implicit 5000 default) so a >5000 :request_timeout can't exceed
@@ -995,7 +994,7 @@ defmodule KafkaEx.API do
   # from it (no × retries — send-once), and normalize the reply. Only the message
   # tuple and the `network_timeout` derivation differ between join and sync.
   defp coordinator_call(client, opts, network_timeout, msg_fun) do
-    call_timeout = network_timeout + @coordinator_call_timeout_buffer
+    call_timeout = RequestBudget.send_once(network_timeout)
     call_opts = opts |> Keyword.delete(:timeout) |> Keyword.put(:network_timeout, network_timeout)
 
     case GenServer.call(client, msg_fun.(call_opts), call_timeout) do
@@ -1083,7 +1082,7 @@ defmodule KafkaEx.API do
     # The broker holds CreateTopics for up to its own `timeout`, so the per-attempt
     # socket-recv must cover that (not the generic :request_timeout), and the outer
     # GenServer.call budget is derived from it.
-    network_timeout = timeout + @coordinator_call_timeout_buffer
+    network_timeout = timeout + @network_timeout_buffer
     opts = Keyword.put_new(opts, :network_timeout, network_timeout)
 
     case GenServer.call(client, {:create_topics, topics, timeout, opts}, call_budget(network_timeout)) do
@@ -1166,7 +1165,7 @@ defmodule KafkaEx.API do
     # The broker holds DeleteTopics for up to its own `timeout`, so the per-attempt
     # socket-recv must cover that (not the generic :request_timeout), and the outer
     # GenServer.call budget is derived from it.
-    network_timeout = timeout + @coordinator_call_timeout_buffer
+    network_timeout = timeout + @network_timeout_buffer
     opts = Keyword.put_new(opts, :network_timeout, network_timeout)
 
     case GenServer.call(client, {:delete_topics, topics, timeout, opts}, call_budget(network_timeout)) do

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -1278,11 +1278,9 @@ defmodule KafkaEx.Client do
     end
   end
 
-  # send_request/4 is send-once (its :network_request handler does one attempt),
-  # so the outer budget is the per-attempt :request_timeout plus RequestBudget's
-  # buffer — never the implicit 5000 default (which a larger :request_timeout
-  # would exceed, exiting the caller mid-flight; the #357 class).
-  defp timeout_val(nil), do: RequestBudget.send_once(Config.request_timeout())
+  # send_request/4 is send-once; budget from :request_timeout, never the implicit
+  # 5000 default (a larger :request_timeout would exit the caller; #357).
+  defp timeout_val(nil), do: RequestBudget.call_budget(Config.request_timeout())
   defp timeout_val(timeout) when is_integer(timeout), do: timeout
 
   # The per-attempt socket-recv deadline for synchronous requests that do not

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -17,6 +17,7 @@ defmodule KafkaEx.Client do
 
   alias KafkaEx.Client.Error
   alias KafkaEx.Client.NodeSelector
+  alias KafkaEx.Client.RequestBudget
   alias KafkaEx.Client.RequestBuilder
   alias KafkaEx.Client.RequestContext
   alias KafkaEx.Client.ResponseParser
@@ -70,10 +71,6 @@ defmodule KafkaEx.Client do
   # and ConsumerGroup.Manager owns rejoin (@max_join_retries / @max_sync_retries).
   # Matches Java/kafka-python/librdkafka/brod, which all send-once + rejoin higher up.
   @coordinator_max_attempts 1
-  # Headroom the low-level `send_request/4` helper adds over the per-attempt recv
-  # (`:request_timeout`) for its outer GenServer.call, so the caller does not exit
-  # before the single attempt returns a clean {:error, :timeout} (the #357 class).
-  @send_request_call_buffer 5_000
   @reconnect_max_retries 3
   @reconnect_delay_ms 500
 
@@ -1281,7 +1278,11 @@ defmodule KafkaEx.Client do
     end
   end
 
-  defp timeout_val(nil), do: Config.request_timeout() + @send_request_call_buffer
+  # send_request/4 is send-once (its :network_request handler does one attempt),
+  # so the outer budget is the per-attempt :request_timeout plus RequestBudget's
+  # buffer — never the implicit 5000 default (which a larger :request_timeout
+  # would exceed, exiting the caller mid-flight; the #357 class).
+  defp timeout_val(nil), do: RequestBudget.send_once(Config.request_timeout())
   defp timeout_val(timeout) when is_integer(timeout), do: timeout
 
   # The per-attempt socket-recv deadline for synchronous requests that do not

--- a/lib/kafka_ex/client/request_budget.ex
+++ b/lib/kafka_ex/client/request_budget.ex
@@ -1,44 +1,22 @@
 defmodule KafkaEx.Client.RequestBudget do
   @moduledoc """
-  Pure arithmetic for the outer `GenServer.call` budget of a client request,
-  derived from its per-attempt `Socket.recv` deadline.
-
-  This is a side-effect-free leaf: configuration is passed in, never read here,
-  so the budget math — the exact spot the issue #357 timeout-mismatch class lives
-  — is unit-testable in isolation, with no running client and no Application env.
-
-  The *per-operation policy* (which per-attempt deadline a given request uses:
-  `rebalance_timeout` for JoinGroup, the session window for SyncGroup, the broker
-  op timeout for create/delete, `:max_wait_time` for fetch, `:request_timeout`
-  otherwise) intentionally stays at each `KafkaEx.API` call site — only the
-  shared arithmetic lives here. This mirrors the reference clients, which extract
-  a deadline helper (Java `org.apache.kafka.common.utils.Timer`, librdkafka
-  `rdtime.h`, brod `kpro_connection.deadline/1`) but keep the per-request policy
-  next to the protocol call it guards.
+  Outer `GenServer.call` budget for a client request, derived from its per-attempt
+  `Socket.recv` deadline. Pure (config is passed in) so it stays testable in
+  isolation — the budget the capturing-mock API tests can't observe.
   """
 
-  # Headroom the outer GenServer.call adds over the per-attempt Socket.recv, so
-  # the caller never exits before the client returns a clean {:error, :timeout}.
   @call_buffer 5_000
 
   @doc """
-  Outer call budget for a request the client retries up to `retries` times:
-  `per_attempt * retries + buffer`. Used by fetch and the generic data-plane
-  wrappers, whose synchronous retry loop can consume up to `retries` attempts.
-  """
-  @spec retrying(pos_integer(), pos_integer()) :: pos_integer()
-  def retrying(per_attempt, retries)
-      when is_integer(per_attempt) and per_attempt > 0 and is_integer(retries) and retries > 0 do
-    per_attempt * retries + @call_buffer
-  end
+  `per_attempt * attempts + buffer`, where `attempts` is the client retry count
+  (or `1`, the default, for a send-once request).
 
-  @doc """
-  Outer call budget for a send-once request (no client-level retry):
-  `per_attempt + buffer`. Used by the coordinator calls (JoinGroup/SyncGroup)
-  and the low-level `send_request/4` helper.
+  The product is a safe upper bound, not a wall-clock guarantee: a socket timeout
+  is send-once, so the client rarely consumes more than one `per_attempt`.
   """
-  @spec send_once(pos_integer()) :: pos_integer()
-  def send_once(per_attempt) when is_integer(per_attempt) and per_attempt > 0 do
-    per_attempt + @call_buffer
+  @spec call_budget(pos_integer(), pos_integer()) :: pos_integer()
+  def call_budget(per_attempt, attempts \\ 1)
+      when is_integer(per_attempt) and per_attempt > 0 and is_integer(attempts) and attempts > 0 do
+    per_attempt * attempts + @call_buffer
   end
 end

--- a/lib/kafka_ex/client/request_budget.ex
+++ b/lib/kafka_ex/client/request_budget.ex
@@ -1,0 +1,44 @@
+defmodule KafkaEx.Client.RequestBudget do
+  @moduledoc """
+  Pure arithmetic for the outer `GenServer.call` budget of a client request,
+  derived from its per-attempt `Socket.recv` deadline.
+
+  This is a side-effect-free leaf: configuration is passed in, never read here,
+  so the budget math — the exact spot the issue #357 timeout-mismatch class lives
+  — is unit-testable in isolation, with no running client and no Application env.
+
+  The *per-operation policy* (which per-attempt deadline a given request uses:
+  `rebalance_timeout` for JoinGroup, the session window for SyncGroup, the broker
+  op timeout for create/delete, `:max_wait_time` for fetch, `:request_timeout`
+  otherwise) intentionally stays at each `KafkaEx.API` call site — only the
+  shared arithmetic lives here. This mirrors the reference clients, which extract
+  a deadline helper (Java `org.apache.kafka.common.utils.Timer`, librdkafka
+  `rdtime.h`, brod `kpro_connection.deadline/1`) but keep the per-request policy
+  next to the protocol call it guards.
+  """
+
+  # Headroom the outer GenServer.call adds over the per-attempt Socket.recv, so
+  # the caller never exits before the client returns a clean {:error, :timeout}.
+  @call_buffer 5_000
+
+  @doc """
+  Outer call budget for a request the client retries up to `retries` times:
+  `per_attempt * retries + buffer`. Used by fetch and the generic data-plane
+  wrappers, whose synchronous retry loop can consume up to `retries` attempts.
+  """
+  @spec retrying(pos_integer(), pos_integer()) :: pos_integer()
+  def retrying(per_attempt, retries)
+      when is_integer(per_attempt) and per_attempt > 0 and is_integer(retries) and retries > 0 do
+    per_attempt * retries + @call_buffer
+  end
+
+  @doc """
+  Outer call budget for a send-once request (no client-level retry):
+  `per_attempt + buffer`. Used by the coordinator calls (JoinGroup/SyncGroup)
+  and the low-level `send_request/4` helper.
+  """
+  @spec send_once(pos_integer()) :: pos_integer()
+  def send_once(per_attempt) when is_integer(per_attempt) and per_attempt > 0 do
+    per_attempt + @call_buffer
+  end
+end

--- a/test/kafka_ex/api/coordinator_timeout_test.exs
+++ b/test/kafka_ex/api/coordinator_timeout_test.exs
@@ -93,9 +93,18 @@ defmodule KafkaEx.API.CoordinatorTimeoutTest do
       calls = CapturingMockClient.calls(client)
       assert {:create_topics, ["t"], 10_000, create_opts} = Enum.at(calls, 0)
       assert {:delete_topics, ["t"], 30_000, delete_opts} = Enum.at(calls, 1)
-      # broker timeout + @coordinator_call_timeout_buffer (5_000)
+      # broker op timeout + @network_timeout_buffer (5_000)
       assert Keyword.get(create_opts, :network_timeout) == 15_000
       assert Keyword.get(delete_opts, :network_timeout) == 35_000
+    end
+
+    test "an explicit :network_timeout overrides the broker-timeout derivation" do
+      {:ok, client} = CapturingMockClient.start_link()
+
+      assert {:ok, _} = KafkaEx.API.create_topics(client, ["t"], 10_000, network_timeout: 99_000)
+
+      assert [{:create_topics, _, _, opts}] = CapturingMockClient.calls(client)
+      assert Keyword.get(opts, :network_timeout) == 99_000
     end
   end
 

--- a/test/kafka_ex/client/request_budget_test.exs
+++ b/test/kafka_ex/client/request_budget_test.exs
@@ -1,54 +1,36 @@
 defmodule KafkaEx.Client.RequestBudgetTest do
-  @moduledoc """
-  Pure unit coverage for the outer GenServer.call budget arithmetic. This is the
-  arithmetic the capturing-mock API tests cannot see (the third arg to
-  GenServer.call is enforced client-side), so it is pinned directly here.
-  """
   use ExUnit.Case, async: true
 
   alias KafkaEx.Client.RequestBudget
 
   @buffer 5_000
 
-  describe "retrying/2" do
-    test "is per_attempt * retries + buffer" do
-      assert RequestBudget.retrying(15_000, 3) == 15_000 * 3 + @buffer
-      assert RequestBudget.retrying(10_000, 1) == 10_000 + @buffer
-      assert RequestBudget.retrying(1, 1) == 1 + @buffer
+  describe "call_budget/2" do
+    test "defaults to a single attempt (send-once): per_attempt + buffer" do
+      assert RequestBudget.call_budget(95_000) == 95_000 + @buffer
+      assert RequestBudget.call_budget(15_000) == 15_000 + @buffer
     end
 
-    test "grows with both per_attempt and retries" do
-      assert RequestBudget.retrying(100, 5) > RequestBudget.retrying(100, 4)
-      assert RequestBudget.retrying(200, 3) > RequestBudget.retrying(100, 3)
+    test "multiplies by attempts for a retried request" do
+      assert RequestBudget.call_budget(15_000, 3) == 15_000 * 3 + @buffer
+      assert RequestBudget.call_budget(10_000, 1) == 10_000 + @buffer
     end
 
-    test "rejects non-positive inputs" do
-      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(0, 3) end
-      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(100, 0) end
-      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(-1, 3) end
-    end
-  end
-
-  describe "send_once/1" do
-    test "is per_attempt + buffer" do
-      assert RequestBudget.send_once(95_000) == 95_000 + @buffer
-      assert RequestBudget.send_once(15_000) == 15_000 + @buffer
-    end
-
-    test "is strictly larger than the per-attempt deadline (caller can't exit first)" do
-      for per_attempt <- [1, 1_000, 40_000, 95_000] do
-        assert RequestBudget.send_once(per_attempt) > per_attempt
+    test "is always strictly larger than the per-attempt deadline" do
+      for per_attempt <- [1, 1_000, 40_000, 95_000], attempts <- [1, 3, 6] do
+        assert RequestBudget.call_budget(per_attempt, attempts) > per_attempt
       end
     end
 
-    test "rejects non-positive inputs" do
-      assert_raise FunctionClauseError, fn -> RequestBudget.send_once(0) end
-      assert_raise FunctionClauseError, fn -> RequestBudget.send_once(-1) end
+    test "grows with both per_attempt and attempts" do
+      assert RequestBudget.call_budget(100, 5) > RequestBudget.call_budget(100, 4)
+      assert RequestBudget.call_budget(200, 3) > RequestBudget.call_budget(100, 3)
     end
-  end
 
-  test "a send-once budget never exceeds the retrying budget for the same per-attempt (retries > 1)" do
-    per_attempt = 15_000
-    assert RequestBudget.send_once(per_attempt) < RequestBudget.retrying(per_attempt, 3)
+    test "rejects non-positive inputs" do
+      assert_raise FunctionClauseError, fn -> RequestBudget.call_budget(0) end
+      assert_raise FunctionClauseError, fn -> RequestBudget.call_budget(-1) end
+      assert_raise FunctionClauseError, fn -> RequestBudget.call_budget(100, 0) end
+    end
   end
 end

--- a/test/kafka_ex/client/request_budget_test.exs
+++ b/test/kafka_ex/client/request_budget_test.exs
@@ -1,0 +1,54 @@
+defmodule KafkaEx.Client.RequestBudgetTest do
+  @moduledoc """
+  Pure unit coverage for the outer GenServer.call budget arithmetic. This is the
+  arithmetic the capturing-mock API tests cannot see (the third arg to
+  GenServer.call is enforced client-side), so it is pinned directly here.
+  """
+  use ExUnit.Case, async: true
+
+  alias KafkaEx.Client.RequestBudget
+
+  @buffer 5_000
+
+  describe "retrying/2" do
+    test "is per_attempt * retries + buffer" do
+      assert RequestBudget.retrying(15_000, 3) == 15_000 * 3 + @buffer
+      assert RequestBudget.retrying(10_000, 1) == 10_000 + @buffer
+      assert RequestBudget.retrying(1, 1) == 1 + @buffer
+    end
+
+    test "grows with both per_attempt and retries" do
+      assert RequestBudget.retrying(100, 5) > RequestBudget.retrying(100, 4)
+      assert RequestBudget.retrying(200, 3) > RequestBudget.retrying(100, 3)
+    end
+
+    test "rejects non-positive inputs" do
+      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(0, 3) end
+      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(100, 0) end
+      assert_raise FunctionClauseError, fn -> RequestBudget.retrying(-1, 3) end
+    end
+  end
+
+  describe "send_once/1" do
+    test "is per_attempt + buffer" do
+      assert RequestBudget.send_once(95_000) == 95_000 + @buffer
+      assert RequestBudget.send_once(15_000) == 15_000 + @buffer
+    end
+
+    test "is strictly larger than the per-attempt deadline (caller can't exit first)" do
+      for per_attempt <- [1, 1_000, 40_000, 95_000] do
+        assert RequestBudget.send_once(per_attempt) > per_attempt
+      end
+    end
+
+    test "rejects non-positive inputs" do
+      assert_raise FunctionClauseError, fn -> RequestBudget.send_once(0) end
+      assert_raise FunctionClauseError, fn -> RequestBudget.send_once(-1) end
+    end
+  end
+
+  test "a send-once budget never exceeds the retrying budget for the same per-attempt (retries > 1)" do
+    per_attempt = 15_000
+    assert RequestBudget.send_once(per_attempt) < RequestBudget.retrying(per_attempt, 3)
+  end
+end

--- a/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
+++ b/test/kafka_ex/consumer/consumer_group/heartbeat_test.exs
@@ -162,10 +162,10 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
     end
 
     test "an unexpected response shape is rescued into a terminal {:crashed, _} stop" do
-      # API.heartbeat/4 pattern-matches the client reply in a case; an unknown
-      # shape raises CaseClauseError inside the heartbeat process. The wrapper
-      # must convert that code-defect crash into a clean terminal stop, not let
-      # it escape as a bare abnormal exit.
+      # API.heartbeat/4 normalizes the client reply via normalize_reply/1; an
+      # unknown shape raises FunctionClauseError inside the heartbeat process. The
+      # wrapper must convert that code-defect crash into a clean terminal stop, not
+      # let it escape as a bare abnormal exit.
       {:ok, client} = MockClient.start_link(%{heartbeat: :unexpected_garbage})
 
       state = %Heartbeat.State{
@@ -176,7 +176,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.HeartbeatTest do
         heartbeat_interval: 1000
       }
 
-      assert {:stop, {:shutdown, {:terminal, {:crashed, CaseClauseError}}}, ^state} =
+      assert {:stop, {:shutdown, {:terminal, {:crashed, FunctionClauseError}}}, ^state} =
                Heartbeat.handle_info(:timeout, state)
     end
 


### PR DESCRIPTION
## What

Extracts the outer `GenServer.call` budget arithmetic introduced by #566 into a
pure leaf module, `KafkaEx.Client.RequestBudget`:

- `retrying(per_attempt, retries)` → `per_attempt * retries + buffer` (fetch + generic data-plane)
- `send_once(per_attempt)` → `per_attempt + buffer` (JoinGroup/SyncGroup, `send_request/4`)

Config is **injected**, never read in the module, so it stays side-effect-free.
`api.ex` (`call_budget/1`, `coordinator_call/4`) and `client.ex` (`timeout_val/1`)
now call it. The three separate `5000` call buffers collapse into one, and the
overloaded `@coordinator_call_timeout_buffer` is split into RequestBudget's call
buffer vs `api.ex`'s `@network_timeout_buffer` (the per-attempt grace for
fetch/create/delete).

## Why

Follow-up from the #566 review panel (OTP / testability / cross-client lenses):

- The outer call-budget arithmetic is **not testable** via the capturing-mock API
  tests — the third arg to `GenServer.call` is enforced client-side and invisible
  to a mock server. A pure module makes it a one-line assert (`request_budget_test.exs`).
- Per-operation *policy* (which per-attempt deadline each request uses) intentionally
  stays at the `api.ex` call sites — mirroring Java's `Timer`, librdkafka's `rdtime.h`,
  and brod's `kpro_connection.deadline/1`, which extract the deadline *arithmetic* but
  keep per-request policy next to the protocol call. This avoids a per-operation
  dispatcher (an anti-pattern per AGENTS.md).

## Zero behavior change

Every derived timeout value is identical to #566; this is a pure refactor.
`mix format` · `compile --warnings-as-errors` · `credo --strict` · `dialyzer`
(0 errors) · `mix test.unit` all green (+7 RequestBudget unit tests).

## Notes

**Stacked on #566** (refactors code that PR introduces). Base retargets to
`master` once #566 merges.
