### PR TITLE
refactor: make Support.Retry the single home for error classification

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -916,8 +916,8 @@ defmodule KafkaEx.Client do
   #
   # The `retryable?` field on the `%RequestContext{}` lets callers specify which
   # errors should trigger a retry. This is important for produce requests where
-  # blind retries can cause duplicate messages. By default (the struct's
-  # `always_retryable/1`), all errors are retried (backwards compatible behavior).
+  # blind retries can cause duplicate messages. By default
+  # (`Retry.data_plane_retryable?/1`), all errors are retried.
   #
   # For produce requests, the context sets `&Retry.produce_retryable?/1` to only retry leadership errors.
   # ----------------------------------------------------------------------------------------------------
@@ -985,25 +985,16 @@ defmodule KafkaEx.Client do
   defp extract_error_atom(error) when is_atom(error), do: error
   defp extract_error_atom(_), do: :unknown
 
-  # Errors that indicate the client has stale metadata and should refresh before retrying.
-  defp requires_metadata_refresh?(:not_leader_for_partition), do: true
-  defp requires_metadata_refresh?(:leader_not_available), do: true
-  defp requires_metadata_refresh?(:unknown_topic_or_partition), do: true
-  defp requires_metadata_refresh?(:not_leader_or_follower), do: true
-  defp requires_metadata_refresh?(:fenced_leader_epoch), do: true
-  defp requires_metadata_refresh?(_), do: false
-
-  defp requires_coordinator_refresh?(:not_coordinator), do: true
-  defp requires_coordinator_refresh?(:coordinator_not_available), do: true
-  defp requires_coordinator_refresh?(_), do: false
-
+  # Error classification (which errors need a refresh) lives in Support.Retry; the
+  # refresh action stays here. A leadership error means stale metadata; a
+  # coordinator_refresh error means the group coordinator moved.
   defp refresh_for_error(error_atom, ctx, state) do
     cond do
-      requires_metadata_refresh?(error_atom) ->
+      Retry.leadership_error?(error_atom) ->
         Logger.info("Refreshing metadata due to #{inspect(error_atom)} error")
         update_metadata(state)
 
-      coordinator_request?(ctx.node_selector) and requires_coordinator_refresh?(error_atom) ->
+      coordinator_request?(ctx.node_selector) and Retry.coordinator_refresh_error?(error_atom) ->
         Logger.info("Re-discovering group coordinator due to #{inspect(error_atom)} error")
         refresh_coordinator(state, ctx.node_selector.consumer_group_name)
 

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -985,9 +985,6 @@ defmodule KafkaEx.Client do
   defp extract_error_atom(error) when is_atom(error), do: error
   defp extract_error_atom(_), do: :unknown
 
-  # Error classification (which errors need a refresh) lives in Support.Retry; the
-  # refresh action stays here. A leadership error means stale metadata; a
-  # coordinator_refresh error means the group coordinator moved.
   defp refresh_for_error(error_atom, ctx, state) do
     cond do
       Retry.leadership_error?(error_atom) ->

--- a/lib/kafka_ex/client/request_context.ex
+++ b/lib/kafka_ex/client/request_context.ex
@@ -40,13 +40,14 @@ defmodule KafkaEx.Client.RequestContext do
   """
 
   alias KafkaEx.Client.NodeSelector
+  alias KafkaEx.Support.Retry
 
   @enforce_keys [:request, :parser_fn, :node_selector]
   defstruct [
     :request,
     :parser_fn,
     :node_selector,
-    retryable?: &__MODULE__.always_retryable/1,
+    retryable?: &Retry.data_plane_retryable?/1,
     network_timeout: nil
   ]
 
@@ -63,7 +64,4 @@ defmodule KafkaEx.Client.RequestContext do
           retryable?: retryable_fn(),
           network_timeout: non_neg_integer() | nil
         }
-
-  @doc false
-  def always_retryable(_error), do: true
 end

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -5,14 +5,9 @@ defmodule KafkaEx.Support.Retry do
   This module provides:
   - Exponential backoff calculation with optional cap
   - Generic retry wrapper function
-  - **The single home for Kafka error classification.** Both retry loops (the
-    synchronous `KafkaEx.Client` loop and this `with_retry/2`) classify here:
-    retriability per operation (`data_plane_retryable?`, `produce_retryable?`,
-    `commit_retryable?`, `sync_group_retryable?`, `heartbeat_retryable?`,
-    `join_group_retryable?`); transport (`transport_timeout?`); refresh-need
-    (`leadership_error?` → metadata, `coordinator_refresh_error?` → coordinator);
-    primitives (`transient_error?`, `coordinator_error?`, `leadership_error?`);
-    terminal/fatal (`commit_terminal_error?`, `commit_fatal_error?`).
+  - **The single home for Kafka error classification** — both retry loops (the
+    synchronous `KafkaEx.Client` loop and `with_retry/2`) read their retriability,
+    transport, and refresh-need decisions from the classifiers below.
 
   ## Usage
 
@@ -236,10 +231,9 @@ defmodule KafkaEx.Support.Retry do
   def data_plane_retryable?(_error), do: true
 
   @doc """
-  Coordinator errors that mean the client should re-discover the group coordinator
-  before retrying. A subset of `coordinator_error?/1`: it excludes the transient
-  `:coordinator_load_in_progress`, where re-discovery would find the same (loading)
-  coordinator. `leadership_error?/1` is the metadata-refresh counterpart.
+  Coordinator errors that warrant re-discovering the coordinator before retrying.
+  Subset of `coordinator_error?/1` — excludes transient `:coordinator_load_in_progress`
+  (re-discovery would just find the same loading coordinator).
   """
   @spec coordinator_refresh_error?(error()) :: boolean()
   def coordinator_refresh_error?(:not_coordinator), do: true

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -5,7 +5,14 @@ defmodule KafkaEx.Support.Retry do
   This module provides:
   - Exponential backoff calculation with optional cap
   - Generic retry wrapper function
-  - Error classifiers for common Kafka error patterns
+  - **The single home for Kafka error classification.** Both retry loops (the
+    synchronous `KafkaEx.Client` loop and this `with_retry/2`) classify here:
+    retriability per operation (`data_plane_retryable?`, `produce_retryable?`,
+    `commit_retryable?`, `sync_group_retryable?`, `heartbeat_retryable?`,
+    `join_group_retryable?`); transport (`transport_timeout?`); refresh-need
+    (`leadership_error?` → metadata, `coordinator_refresh_error?` → coordinator);
+    primitives (`transient_error?`, `coordinator_error?`, `leadership_error?`);
+    terminal/fatal (`commit_terminal_error?`, `commit_fatal_error?`).
 
   ## Usage
 
@@ -223,6 +230,21 @@ defmodule KafkaEx.Support.Retry do
   @spec transport_timeout?(error()) :: boolean()
   def transport_timeout?(:timeout), do: true
   def transport_timeout?(_), do: false
+
+  @doc "Permissive retriability default for data-plane requests (metadata, offset, produce, fetch, admin); tightening it is a follow-up."
+  @spec data_plane_retryable?(error()) :: boolean()
+  def data_plane_retryable?(_error), do: true
+
+  @doc """
+  Coordinator errors that mean the client should re-discover the group coordinator
+  before retrying. A subset of `coordinator_error?/1`: it excludes the transient
+  `:coordinator_load_in_progress`, where re-discovery would find the same (loading)
+  coordinator. `leadership_error?/1` is the metadata-refresh counterpart.
+  """
+  @spec coordinator_refresh_error?(error()) :: boolean()
+  def coordinator_refresh_error?(:not_coordinator), do: true
+  def coordinator_refresh_error?(:coordinator_not_available), do: true
+  def coordinator_refresh_error?(_), do: false
 
   @doc """
   Check if error is a leadership-related error requiring metadata refresh.

--- a/test/kafka_ex/client/coordinator_refresh_test.exs
+++ b/test/kafka_ex/client/coordinator_refresh_test.exs
@@ -4,10 +4,11 @@ defmodule KafkaEx.Client.CoordinatorRefreshTest do
   response on a consumer-group request must invalidate the cached coordinator and
   re-run FindCoordinator before retrying — not blind-retry the stale broker.
 
-  Pre-fix, `requires_metadata_refresh?/1` only knew leadership errors, so
+  Pre-fix, the metadata-refresh classifier only knew leadership errors, so
   `:not_coordinator` retried the same cached coordinator and FindCoordinator was
-  never re-issued (the rolling-deploy hang). Driven through the real `handle_call`
-  path; no private function is exposed.
+  never re-issued (the rolling-deploy hang). Coordinator-refresh classification now
+  lives in `Retry.coordinator_refresh_error?/1`. Driven through the real
+  `handle_call` path; no private function is exposed.
 
   The `:not_coordinator` is injected via the network seam (PR-2 now surfaces the
   real atom into the retry loop); the observable is that a FindCoordinator request

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -453,4 +453,29 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.heartbeat_retryable?(:coordinator_not_available)
     end
   end
+
+  describe "data_plane_retryable?/1" do
+    test "is permissive — retries any error" do
+      assert Retry.data_plane_retryable?(:not_leader_for_partition)
+      assert Retry.data_plane_retryable?(:request_timed_out)
+      assert Retry.data_plane_retryable?(:topic_authorization_failed)
+      assert Retry.data_plane_retryable?(:anything)
+    end
+  end
+
+  describe "coordinator_refresh_error?/1" do
+    test "true only for the coordinator-moved errors" do
+      assert Retry.coordinator_refresh_error?(:not_coordinator)
+      assert Retry.coordinator_refresh_error?(:coordinator_not_available)
+    end
+
+    test "false for the transient loading state (re-discovery would find the same coordinator)" do
+      refute Retry.coordinator_refresh_error?(:coordinator_load_in_progress)
+    end
+
+    test "false for unrelated errors" do
+      refute Retry.coordinator_refresh_error?(:not_leader_for_partition)
+      refute Retry.coordinator_refresh_error?(:timeout)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up from the #566 holistic review. Every error-classification decision now lives in `Support.Retry`; both retry loops (the synchronous `KafkaEx.Client` loop and `Support.Retry.with_retry`) read from it. **Zero behavior change.**

- Move the client's refresh classification out of `client.ex`: metadata refresh keys on `Retry.leadership_error?/1` (identical error set) and coordinator refresh on the new `Retry.coordinator_refresh_error?/1` (subset of `coordinator_error?/1` — excludes the transient `:coordinator_load_in_progress`, where re-discovery is pointless). Deletes `client.ex`'s private `requires_metadata_refresh?/1` + `requires_coordinator_refresh?/1`.
- Give the data-plane default a named home: `Retry.data_plane_retryable?/1` (permissive — identical to the removed inline `RequestContext.always_retryable/1`). Tightening it is a separate follow-up.
- `Support.Retry` moduledoc is now the canonical classification map.

The two loops stay separate (Client sync/immediate/no-sleep; `with_retry` async/backoff) — only classification is unified. +6 classifier unit tests; all existing tests unchanged (behavior identical). credo/dialyzer/format clean.