### PR TITLE
refactor: move ConsumerGroup.Manager error classifiers into Support.Retry

### DIFF
--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -81,6 +81,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   alias KafkaEx.Consumer.ConsumerGroup.Heartbeat
   alias KafkaEx.Consumer.ConsumerGroup.PartitionAssignment
   alias KafkaEx.Messages.ApiVersions
+  alias KafkaEx.Support.Retry
   alias KafkaEx.Telemetry
   require Logger
 
@@ -470,7 +471,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   # the current heartbeat_timer keeps a stale heartbeat's error EXIT from
   # triggering a spurious rebalance — it falls through to the stale-timer clause.
   def handle_info({:EXIT, timer, {:shutdown, {:error, reason}}}, %State{heartbeat_timer: timer} = state) do
-    if recoverable_error?(reason) do
+    if Retry.consumer_group_recoverable?(reason) do
       Logger.warning("Heartbeat failed with #{inspect(reason)}, attempting to rejoin group")
       {:ok, new_state} = rebalance(state, {:heartbeat_error, reason})
       {:noreply, new_state}
@@ -660,7 +661,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
       reason == :unknown_member_id ->
         handle_recoverable_join_error(reset_generation(state, :unknown_member_id), group_name, reason, attempt_number)
 
-      recoverable_error?(reason) ->
+      Retry.consumer_group_recoverable?(reason) ->
         handle_recoverable_join_error(state, group_name, reason, attempt_number)
 
       true ->
@@ -782,7 +783,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   defp handle_sync_error(%State{} = state, group_name, reason) do
     cond do
-      not sync_rejoinable?(reason) ->
+      not Retry.sync_rejoinable?(reason) ->
         raise KafkaEx.SyncGroupError, group_name: group_name, reason: reason
 
       state.sync_failures >= @max_sync_retries ->
@@ -804,10 +805,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
         rebalance(%State{state | sync_failures: attempt}, {:sync_error, reason})
     end
   end
-
-  defp sync_rejoinable?(:illegal_generation), do: true
-  defp sync_rejoinable?(:unknown_member_id), do: true
-  defp sync_rejoinable?(reason), do: recoverable_error?(reason)
 
   # Convert assignments from Manager format to protocol-agnostic format for sync_group request
   # Input: [{member_id, [{topic, [partition_ids]}]}]
@@ -1049,20 +1046,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   end
 
   ### Error Classification
-
-  # Determines if an error is recoverable via retry/rejoin.
-  # Following Java client pattern (KAFKA-6829): UNKNOWN_TOPIC_OR_PARTITION is
-  # treated like COORDINATOR_LOAD_IN_PROGRESS - both trigger retry behavior.
-  defp recoverable_error?(:coordinator_not_available), do: true
-  defp recoverable_error?(:not_coordinator), do: true
-  defp recoverable_error?(:coordinator_load_in_progress), do: true
-  defp recoverable_error?(:unknown_topic_or_partition), do: true
-  defp recoverable_error?(:no_broker), do: true
-  defp recoverable_error?(:timeout), do: true
-  defp recoverable_error?(:closed), do: true
-  defp recoverable_error?(:not_connected), do: true
-  defp recoverable_error?(:unknown), do: true
-  defp recoverable_error?(_), do: false
 
   defp maybe_warn_static_membership_unsupported(_client, nil), do: :ok
 

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -341,6 +341,36 @@ defmodule KafkaEx.Support.Retry do
   def sync_group_retryable?(_), do: true
 
   @doc """
+  Manager-layer: errors on which `ConsumerGroup.Manager` retries a join / rejoins the
+  group rather than escalating. Distinct from the client-layer
+  `consumer_group_retryable?/1` — this drives the Manager's join-retry and
+  heartbeat-error routing, and includes bare transport states (`:not_connected`,
+  `:unknown`) the client layer doesn't.
+  """
+  @spec consumer_group_recoverable?(error()) :: boolean()
+  def consumer_group_recoverable?(:coordinator_not_available), do: true
+  def consumer_group_recoverable?(:not_coordinator), do: true
+  def consumer_group_recoverable?(:coordinator_load_in_progress), do: true
+  def consumer_group_recoverable?(:unknown_topic_or_partition), do: true
+  def consumer_group_recoverable?(:no_broker), do: true
+  def consumer_group_recoverable?(:timeout), do: true
+  def consumer_group_recoverable?(:closed), do: true
+  def consumer_group_recoverable?(:not_connected), do: true
+  def consumer_group_recoverable?(:unknown), do: true
+  def consumer_group_recoverable?(_), do: false
+
+  @doc """
+  Manager-layer: SyncGroup errors that warrant a Manager rejoin — `:illegal_generation`
+  and `:unknown_member_id` (re-identify + rejoin), else `consumer_group_recoverable?/1`.
+  The inverse view of the client-layer `sync_group_retryable?/1`, which returns false
+  for these so they bubble up to the Manager.
+  """
+  @spec sync_rejoinable?(error()) :: boolean()
+  def sync_rejoinable?(:illegal_generation), do: true
+  def sync_rejoinable?(:unknown_member_id), do: true
+  def sync_rejoinable?(reason), do: consumer_group_recoverable?(reason)
+
+  @doc """
   Check if a Heartbeat error is safe to retry at the client layer.
 
   The heartbeat process stops on any error and lets the manager react

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -478,4 +478,41 @@ defmodule KafkaEx.Support.RetryTest do
       refute Retry.coordinator_refresh_error?(:timeout)
     end
   end
+
+  describe "consumer_group_recoverable?/1 (Manager-layer)" do
+    test "recovers coordinator, transport and unknown-topic errors" do
+      for e <- [
+            :coordinator_not_available,
+            :not_coordinator,
+            :coordinator_load_in_progress,
+            :unknown_topic_or_partition,
+            :no_broker,
+            :timeout,
+            :closed,
+            :not_connected,
+            :unknown
+          ] do
+        assert Retry.consumer_group_recoverable?(e)
+      end
+    end
+
+    test "does not recover terminal/identity errors" do
+      refute Retry.consumer_group_recoverable?(:fenced_instance_id)
+      refute Retry.consumer_group_recoverable?(:group_authorization_failed)
+      refute Retry.consumer_group_recoverable?(:illegal_generation)
+    end
+  end
+
+  describe "sync_rejoinable?/1 (Manager-layer)" do
+    test "rejoins on identity errors and recoverable errors" do
+      assert Retry.sync_rejoinable?(:illegal_generation)
+      assert Retry.sync_rejoinable?(:unknown_member_id)
+      assert Retry.sync_rejoinable?(:coordinator_not_available)
+    end
+
+    test "does not rejoin on terminal errors" do
+      refute Retry.sync_rejoinable?(:fenced_instance_id)
+      refute Retry.sync_rejoinable?(:group_authorization_failed)
+    end
+  end
 end


### PR DESCRIPTION
Part 2/6 of the v1.1.0 release. Stacked on part 1 (`rel/a-request-timeout-rename`).

Moves `Manager`'s local `recoverable_error?`/`sync_rejoinable?` into `Support.Retry` (`consumer_group_recoverable?/1`, `sync_rejoinable?/1`), extending #569's single-home-for-classification. No behavior change.

Files: `manager.ex`, `support/retry.ex`, `retry_test.exs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)