### PR TITLE
feat: fail fast on fatal data-plane errors (tighten data_plane_retryable?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@
   (fewer spurious rebalances on transient hiccups), and heartbeats are sent more frequently.
   Override `:session_timeout` / `:heartbeat_interval` to restore the old values. See UPGRADING.md.
 
+* **Data-plane requests fail fast on fatal broker errors.** Metadata / offset / find_coordinator /
+  admin requests previously retried *any* error inside the client's synchronous loop; they now
+  retry only transient/leadership errors and return fatal codes
+  (`:topic_authorization_failed`, `:unsupported_version`, `:invalid_request`, …) immediately
+  instead of burning the retry budget. Mirrors Java's `RetriableException` vs fatal `KafkaException`.
+
 ## 1.0.1 (2026-06-26)
 
 ### Breaking Changes

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -226,9 +226,15 @@ defmodule KafkaEx.Support.Retry do
   def transport_timeout?(:timeout), do: true
   def transport_timeout?(_), do: false
 
-  @doc "Permissive retriability default for data-plane requests (metadata, offset, produce, fetch, admin); tightening it is a follow-up."
+  @doc """
+  Retriability default for data-plane requests (metadata, offset, find_coordinator,
+  admin). Retries only transient/leadership errors — fatal broker codes
+  (`:topic_authorization_failed`, `:unsupported_version`, `:invalid_request`, …)
+  fail fast instead of burning the client's synchronous retry loop. Mirrors Java's
+  `RetriableException` vs fatal `KafkaException` split.
+  """
   @spec data_plane_retryable?(error()) :: boolean()
-  def data_plane_retryable?(_error), do: true
+  def data_plane_retryable?(error), do: transient_error?(error) or leadership_error?(error)
 
   @doc """
   Coordinator errors that warrant re-discovering the coordinator before retrying.

--- a/test/kafka_ex/client/request_context_test.exs
+++ b/test/kafka_ex/client/request_context_test.exs
@@ -11,15 +11,16 @@ defmodule KafkaEx.Client.RequestContextTest do
   alias KafkaEx.Client.RequestContextTest.FakeRequest
 
   describe "struct defaults" do
-    test "retryable? defaults to always-true and network_timeout to nil" do
+    test "retryable? defaults to the data-plane classifier (transient/leadership retry, fatal fail-fast); network_timeout nil" do
       ctx = %RequestContext{
         request: %FakeRequest{},
         parser_fn: fn _ -> {:ok, :parsed} end,
         node_selector: NodeSelector.first_available()
       }
 
-      assert ctx.retryable?.(:anything) == true
       assert ctx.retryable?.(:not_leader_for_partition) == true
+      assert ctx.retryable?.(:timeout) == true
+      assert ctx.retryable?.(:topic_authorization_failed) == false
       assert ctx.network_timeout == nil
     end
 

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -455,11 +455,18 @@ defmodule KafkaEx.Support.RetryTest do
   end
 
   describe "data_plane_retryable?/1" do
-    test "is permissive — retries any error" do
+    test "retries transient and leadership errors" do
       assert Retry.data_plane_retryable?(:not_leader_for_partition)
       assert Retry.data_plane_retryable?(:request_timed_out)
-      assert Retry.data_plane_retryable?(:topic_authorization_failed)
-      assert Retry.data_plane_retryable?(:anything)
+      assert Retry.data_plane_retryable?(:timeout)
+      assert Retry.data_plane_retryable?(:coordinator_not_available)
+      assert Retry.data_plane_retryable?(:unknown_topic_or_partition)
+    end
+
+    test "fails fast on fatal broker codes" do
+      refute Retry.data_plane_retryable?(:topic_authorization_failed)
+      refute Retry.data_plane_retryable?(:unsupported_version)
+      refute Retry.data_plane_retryable?(:invalid_request)
     end
   end
 


### PR DESCRIPTION
Part 3/6 of the v1.1.0 release. Stacked on part 2 (`rel/b-manager-retry-classifiers`).

Tightens `Retry.data_plane_retryable?/1` (was permissive-always) so fatal data-plane errors fail fast instead of being retried. **Behavior change** — see CHANGELOG entry.

Files: `support/retry.ex`, `CHANGELOG.md`, `request_context_test.exs`, `retry_test.exs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)