### PR TITLE
docs: fix stale figures + remove redundant comments

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -151,12 +151,11 @@ synchronously, so while a *rebalance* is in progress it is busy for that window
 default 3s). Two consequences for that window:
 
   * The `KafkaEx.Consumer.ConsumerGroup` introspection calls
-    (`generation_id/1`, `member_id/1`, `assignments/1`, `active?/1`, …) use a
-    5s `GenServer.call`; during a long rebalance they may exit with a call
-    timeout. Wrap them or pass a longer timeout if you poll them during
-    rebalances.
-  * If your supervisor stops the group mid-rebalance, the default 5s child
-    shutdown may cut off `terminate/2` before it sends `LeaveGroup`; a dynamic
+    (`generation_id/1`, `member_id/1`, `assignments/1`, `active?/1`, …) default
+    to a 30s `GenServer.call`; a rebalance longer than that can still exit them
+    with a call timeout. Pass a longer timeout if you poll them during rebalances.
+  * If your supervisor stops the group mid-rebalance, the 25s child shutdown may
+    cut off `terminate/2` before it sends `LeaveGroup`; a dynamic
     member's partitions then wait `session_timeout` to redistribute (static
     members, KIP-345, intentionally skip LeaveGroup anyway). Raise the group's
     child `shutdown:` if graceful mid-rebalance leave matters for your deploys.

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -888,7 +888,6 @@ defmodule KafkaEx.API do
     produce(client, topic, partition, [message], produce_opts)
   end
 
-  # Resolves partition using the configured partitioner
   defp resolve_partition(client, topic, messages, opts) do
     partitioner = Keyword.get(opts, :partitioner, Partitioner.get_partitioner())
 
@@ -898,7 +897,6 @@ defmodule KafkaEx.API do
     key = Map.get(first_message, :key)
     value = Map.get(first_message, :value, "")
 
-    # Get partition count from metadata
     case topics_metadata(client, [topic], true) do
       {:ok, [topic_info]} ->
         partition_count = map_size(topic_info.partition_leaders)
@@ -1187,7 +1185,6 @@ defmodule KafkaEx.API do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # Helper to conditionally add keys to a map only if value is not nil
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -86,8 +86,7 @@ defmodule KafkaEx.Client do
   def retry_count, do: @retry_count
 
   @doc false
-  # Client-level attempts for JoinGroup/SyncGroup (send-once). KafkaEx.API sizes
-  # their outer call budget from this so the budget and the loop can't drift.
+  # Exposed so KafkaEx.API can size the JoinGroup/SyncGroup call budget from it.
   @spec coordinator_max_attempts() :: pos_integer()
   def coordinator_max_attempts, do: @coordinator_max_attempts
 
@@ -374,7 +373,6 @@ defmodule KafkaEx.Client do
     {:reply, response, updated_state}
   end
 
-  # Simple handler for consumer group name retrieval
   def handle_call(:consumer_group, _from, state) do
     {:reply, state.consumer_group_for_auto_commit, state}
   end
@@ -981,7 +979,6 @@ defmodule KafkaEx.Client do
         handle_request_with_retry(ctx, updated_state, retry_count - 1, error)
 
       true ->
-        # Non-retryable error - fail immediately
         Logger.info("Error #{inspect(error_atom)} is not retryable for #{inspect(request_name)}, failing immediately")
         {{:error, error}, state}
     end
@@ -1151,7 +1148,6 @@ defmodule KafkaEx.Client do
       reconnected_broker = reconnect_broker(broker, state)
 
       if Broker.connected?(reconnected_broker) do
-        # Update the broker in state with new socket
         updated_state = update_broker_in_state(state, reconnected_broker)
         {reconnected_broker, updated_state}
       else

--- a/lib/kafka_ex/client/request_context.ex
+++ b/lib/kafka_ex/client/request_context.ex
@@ -26,8 +26,8 @@ defmodule KafkaEx.Client.RequestContext do
 
     * `network_timeout` is the **per-attempt** `Socket.recv` deadline. It is set
       explicitly by the requests the broker legitimately holds — fetch (derived
-      from `:max_wait_time`), JoinGroup (`rebalance_timeout + 5000`) and SyncGroup
-      (session window) — each of which widens its matching `GenServer.call` budget
+      from `:max_wait_time`), JoinGroup (rebalance_timeout + a fixed grace) and
+      SyncGroup (session window) — each widens its matching `GenServer.call` budget
       in `KafkaEx.API` so the two cannot mismatch (issue #357). Leave `nil` for
       every other request so it falls back to the generic `:request_timeout`
       (`KafkaEx.Config.request_timeout/0`); those callers derive their outer

--- a/lib/kafka_ex/client/state.ex
+++ b/lib/kafka_ex/client/state.ex
@@ -38,7 +38,6 @@ defmodule KafkaEx.Client.State do
 
   @default_metadata_update_interval 30_000
 
-  # initialize static parts of the state from args
   def static_init(args) do
     %__MODULE__{
       bootstrap_uris: Keyword.get(args, :uris, []),

--- a/lib/kafka_ex/consumer/consumer_group.ex
+++ b/lib/kafka_ex/consumer/consumer_group.ex
@@ -101,9 +101,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup do
 
   * `:heartbeat_interval` - How frequently, in milliseconds, to send heartbeats
      to the broker.  This impacts how quickly we will process partition
-     changes as consumers start/stop.  Default: 5000 (5 seconds).
+     changes as consumers start/stop.  Default: 3000 (3 seconds).
   * `:session_timeout` - Consumer group session timeout in milliseconds.
-     Default: 30000 (30 seconds).  See below.
+     Default: 45000 (45 seconds).  See below.
   * `:session_timeout_padding` - Timeout padding for consumer group options.
      Default: 10000 (10 seconds).  See below.
   * Any of `t:KafkaEx.GenConsumer.option/0`,

--- a/lib/kafka_ex/consumer/consumer_group/assignment.ex
+++ b/lib/kafka_ex/consumer/consumer_group/assignment.ex
@@ -5,8 +5,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Assignment do
   (retrying `UNKNOWN_TOPIC_OR_PARTITION`), run the assignment strategy over the
   members, and translate to/from the SyncGroup wire shape.
 
-  A distinct responsibility run only by the leader — the counterpart to the Java
-  client's `AbstractPartitionAssignor`, kept separate from the coordinator FSM.
+  Run only by the group leader, kept separate from the coordinator FSM.
   """
 
   alias KafkaEx.API, as: KafkaExAPI

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -27,8 +27,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   The following options can be passed when starting a consumer group:
 
-  - `:heartbeat_interval` - Interval between heartbeats in ms (default: 5000)
-  - `:session_timeout` - Session timeout in ms (default: 30000)
+  - `:heartbeat_interval` - Interval between heartbeats in ms (default: 3000)
+  - `:session_timeout` - Session timeout in ms (default: 45000)
   - `:session_timeout_padding` - Extra time added to request timeouts (default: 10000)
   - `:rebalance_timeout` - Time allowed for consumers to rejoin during rebalance (default: `session_timeout * 3`)
   - `:partition_assignment_callback` - Function for custom partition assignment (default: round-robin)

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -184,7 +184,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
   @crash_rejoin_max_restarts 10
   @crash_rejoin_window_ms 60_000
 
-  # Gets a value from opts, falling back to application config, then to default
   defp get_with_default(opts, key, default) do
     Keyword.get(opts, key, Application.get_env(:kafka_ex, key, default))
   end
@@ -897,7 +896,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
 
   ### Consumer Management
 
-  # Starts consuming from the member's assigned partitions.
   defp start_consumer(
          %State{
            consumer_module: consumer_module,
@@ -910,7 +908,6 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
          } = state,
          assignments
        ) do
-    # add member_id, generation_id, and group_manager_pid (for rejoin signalling) to the consumer opts
     consumer_opts =
       Keyword.merge(consumer_opts,
         generation_id: generation_id,

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -820,7 +820,6 @@ defmodule KafkaEx.Consumer.GenConsumer do
       :exit, _ -> :ok
     end
 
-    # Safely stop the client if it's still alive
     if Process.alive?(state.client) do
       Process.unlink(state.client)
 
@@ -879,7 +878,6 @@ defmodule KafkaEx.Consumer.GenConsumer do
   end
 
   defp handle_new_fetch_response(fetch_result, state) do
-    # Pass records directly to the callback
     handle_message_set(fetch_result.records, state)
   end
 

--- a/lib/kafka_ex/consumer/stream.ex
+++ b/lib/kafka_ex/consumer/stream.ex
@@ -39,7 +39,6 @@ defmodule KafkaEx.Consumer.Stream do
         |> stream_control(data, offset)
       end
 
-      # there isn't really any cleanup, so we don't need to do anything with the after_fun callback
       after_fun = fn _last_offset -> :ok end
       Stream.resource(start_fun, next_fun, after_fun).(acc, fun)
     end
@@ -127,7 +126,6 @@ defmodule KafkaEx.Consumer.Stream do
     ######################################################################
     # Offset management
 
-    # first, determine if we even need to commit an offset
     defp maybe_commit_offset(fetch_response, %ConsumerStream{} = stream_data, acc) do
       auto_commit = Keyword.get(stream_data.fetch_options, :auto_commit, false)
 
@@ -207,7 +205,6 @@ defmodule KafkaEx.Consumer.Stream do
 
     ######################################################################
 
-    # make the actual fetch request
     defp fetch_response(data, offset) do
       opts = VersionHelper.maybe_put_api_version(data.fetch_options, data.api_versions, :fetch)
 

--- a/lib/kafka_ex/protocol/kayrock/join_group/request_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/join_group/request_helpers.ex
@@ -29,7 +29,6 @@ defmodule KafkaEx.Protocol.Kayrock.JoinGroup.RequestHelpers do
     }
   end
 
-  # Returns group_protocols if provided, otherwise builds from topics
   defp get_or_build_group_protocols(opts) do
     case Keyword.get(opts, :group_protocols) do
       nil ->


### PR DESCRIPTION
Part 5/6 of the v1.1.0 release. Stacked on part 4 (`rel/d-extract-assignment`).

Non-functional. Fixes stale default/timeout figures in docs (UPGRADING + moduledocs) after the timeout-model changes, and removes redundant comments that merely restate the adjacent code (kept every 'why' / issue-ref / decision-table / public @doc).

Files: `UPGRADING.md` + doc/comment lines across `api`, `client`, `state`, `manager`, `gen_consumer`, `stream`, `assignment`, `consumer_group`, `join_group/request_helpers`, `request_context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)