### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## 1.1.0 (2026-07-16)
+## 1.1.0 (2026-07-21)
 
 ### Added
 
@@ -66,12 +66,6 @@
   (`:fenced | :auth | :crash_loop | :crashed | :error | :client_died | :other`)
   for alert routing.
 
-* **Data-plane requests retry again on transient connection drops (`:econnreset` / `:not_connected`).**
-  The retry-classification rework narrowed data-plane retriability to a transient/leadership set;
-  these two recoverable transport atoms fell outside it and began failing fast where v1.0.x retried
-  and self-healed (the client retry loop reconnects the broker on the next attempt). Both are treated
-  as transient again, restoring v1.0.x resilience for fetch/metadata/offset requests.
-
 ### Deprecated
 
 * **`:sync_timeout` is deprecated in favour of `:request_timeout`** and will be removed in
@@ -91,9 +85,11 @@
 
 * **Data-plane requests fail fast on fatal broker errors.** Metadata / offset / find_coordinator /
   admin requests previously retried *any* error inside the client's synchronous loop; they now
-  retry only transient/leadership errors and return fatal codes
-  (`:topic_authorization_failed`, `:unsupported_version`, `:invalid_request`, …) immediately
-  instead of burning the retry budget. Mirrors Java's `RetriableException` vs fatal `KafkaException`.
+  retry only transient/leadership errors — including transient connection drops (`:closed` /
+  `:econnreset` / `:not_connected` / `:timeout`) and leadership/coordinator errors (with
+  metadata/coordinator refresh) — and return fatal codes (`:topic_authorization_failed`,
+  `:unsupported_version`, `:invalid_request`, …) immediately instead of burning the retry budget.
+  Mirrors Java's `RetriableException` vs fatal `KafkaException`.
 
 ## 1.0.1 (2026-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## Unreleased
+## 1.1.0 (2026-07-16)
 
 ### Added
 
@@ -14,11 +14,16 @@
 
 * **Per-attempt request timeout is now configurable via `:request_timeout`** (default
   `15_000` ms) — the `Socket.recv` deadline for a single synchronous broker request attempt
-  (metadata, offset commit/fetch, heartbeat, produce ack, …). Consumer-group JoinGroup/SyncGroup
-  derive their own, longer per-attempt deadlines from the group's rebalance/session timeouts.
+  (metadata, offset commit/fetch, produce ack, …). Consumer-group JoinGroup/SyncGroup/Heartbeat
+  derive their own, longer per-attempt deadlines (rebalance/session window; heartbeat_interval).
 
 * **Retry backoff now applies ±20% jitter (KIP-580)** in `KafkaEx.Support.Retry.with_retry/2`,
   decorrelating retries across many consumer-group members after a shared coordinator/broker blip.
+
+* **Cluster-wide `list_groups/2` admin API (#565).** `KafkaEx.API.list_groups/1,2` fans a
+  ListGroups request out across all brokers and returns `KafkaEx.Messages.ConsumerGroupListing`
+  structs; all-or-nothing (`{:error, {:node_error, node_id, reason}}` if any broker fails). Adds
+  the ListGroups protocol op (v0–v3).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@
   (`:fenced | :auth | :crash_loop | :crashed | :error | :client_died | :other`)
   for alert routing.
 
+* **Data-plane requests retry again on transient connection drops (`:econnreset` / `:not_connected`).**
+  The retry-classification rework narrowed data-plane retriability to a transient/leadership set;
+  these two recoverable transport atoms fell outside it and began failing fast where v1.0.x retried
+  and self-healed (the client retry loop reconnects the broker on the next attempt). Both are treated
+  as transient again, restoring v1.0.x resilience for fetch/metadata/offset requests.
+
 ### Deprecated
 
 * **`:sync_timeout` is deprecated in favour of `:request_timeout`** and will be removed in

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -212,6 +212,8 @@ defmodule KafkaEx.Support.Retry do
   def transient_error?(:parse_error), do: true
   def transient_error?(:closed), do: true
   def transient_error?(:no_broker), do: true
+  def transient_error?(:econnreset), do: true
+  def transient_error?(:not_connected), do: true
   def transient_error?(error), do: coordinator_error?(error)
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KafkaEx.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kafkaex/kafka_ex"
-  @version "1.0.1"
+  @version "1.1.0"
 
   def project do
     [

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -218,6 +218,14 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.transient_error?(:no_broker)
     end
 
+    test "econnreset is transient" do
+      assert Retry.transient_error?(:econnreset)
+    end
+
+    test "not_connected is transient" do
+      assert Retry.transient_error?(:not_connected)
+    end
+
     test "coordinator errors are transient" do
       assert Retry.transient_error?(:coordinator_not_available)
       assert Retry.transient_error?(:not_coordinator)


### PR DESCRIPTION
Release cut for **KafkaEx v1.1.0** — merges the version bump plus final release-prep fixes into `master`. All prior release work (#544–#587) is already on `master`; this is the last PR before tagging `v1.1.0`.

## Commits
- **`chore: release v1.1.0`** — `@version "1.1.0"` + CHANGELOG `1.1.0` section.
- **`fix: retry data-plane requests on :econnreset / :not_connected (v1.0.x parity)`** — the v1.1.0 retry-classification rework narrowed data-plane retriability to `transient_error? ∪ leadership_error?`; these two recoverable transport atoms fell outside it and began failing fast where v1.0.x retried and self-healed (the client retry loop reconnects the broker on the next attempt). Reclassified as transient, with a regression test.
- **`docs: finalize 1.1.0 CHANGELOG`** — set the release date (2026-07-21) and fold the transient-connection-drop clarification (`:closed` / `:econnreset` / `:not_connected` / `:timeout` still retry) into the existing "data-plane fail fast on fatal errors" entry, rather than a standalone Fixed bullet that implied a released regression.

## Verification
- **Regression review** of the full `v1.0.0..HEAD` delta (47 commits, 40 `lib/` files) across four subsystem passes: **no release blockers**. The only new-in-1.1.0 behavior narrowing worth acting on was the data-plane retry set above, now hardened. (The `auto_offset_reset :none → :latest` change surfaced by the diff shipped in **v1.0.1** and is already documented there.)
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix test.unit` — green.

## After merge (maintainer)
Tag `v1.1.0` + `mix hex.publish`.

Files: `mix.exs`, `CHANGELOG.md`, `lib/kafka_ex/support/retry.ex`, `test/kafka_ex/support/retry_test.exs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
