### PR TITLE
fix(test): de-flake "survives multiple rapid rebalances" (was a 90s hang)

### DIFF
--- a/test/integration/consumer_group/resilience_test.exs
+++ b/test/integration/consumer_group/resilience_test.exs
@@ -39,7 +39,12 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
         # Produce messages during rebalance
         {:ok, _} = API.produce(client, topic_name, rem(i, 4), [%{value: "rebalance-msg-#{i}"}])
 
-        stop_safely(temp_consumer)
+        # Kill the throwaway consumer abruptly (crash-style departure, the KAFKA-6829
+        # pattern) rather than a graceful stop: while it is still mid-join its Manager
+        # cannot process a graceful shutdown, so GenServer.stop would block the full
+        # child shutdown timeout (~25s). Unlink first so the :kill does not reach us.
+        Process.unlink(temp_consumer)
+        Process.exit(temp_consumer, :kill)
 
         Process.sleep(1_000)
       end)
@@ -52,7 +57,11 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
 
       # Produce final message and verify consumer receives it
       {:ok, _} = API.produce(client, topic_name, 0, [%{value: "final-message"}])
-      received = receive_messages_until_found("final-message", 15_000)
+      # Generous budget: the abruptly-killed temp consumers linger as ghosts until
+      # their session times out (~session_timeout), so consumer1 fully reclaims the
+      # partitions only after that. The absolute deadline returns as soon as the
+      # message arrives (~14s observed).
+      received = receive_messages_until_found("final-message", 30_000)
       assert "final-message" in received, "Consumer should receive messages after rebalances"
 
       stop_safely(consumer1)
@@ -181,31 +190,52 @@ defmodule KafkaEx.Integration.ConsumerGroup.ResilienceTest do
   end
 
   # Helper functions
-  defp receive_messages_until(count, timeout), do: receive_messages_until(count, timeout, [])
-  defp receive_messages_until(count, _timeout, acc) when length(acc) >= count, do: acc
+  #
+  # `timeout` is an ABSOLUTE budget for the whole wait, not a per-message idle
+  # timeout: we compute a monotonic deadline once and shrink the `receive ... after`
+  # window as messages arrive. A per-message reset would loop indefinitely under a
+  # steady message stream (e.g. re-delivery during rapid rebalances).
+  defp receive_messages_until(count, timeout) do
+    receive_messages_until(count, System.monotonic_time(:millisecond) + timeout, [])
+  end
 
-  defp receive_messages_until(count, timeout, acc) do
-    receive do
-      {:messages_received, messages} -> receive_messages_until(count, timeout, acc ++ messages)
-    after
-      timeout -> acc
+  defp receive_messages_until(count, _deadline, acc) when length(acc) >= count, do: acc
+
+  defp receive_messages_until(count, deadline, acc) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      acc
+    else
+      receive do
+        {:messages_received, messages} -> receive_messages_until(count, deadline, acc ++ messages)
+      after
+        remaining -> acc
+      end
     end
   end
 
   defp receive_messages_until_found(target, timeout) do
-    receive_messages_until_found(target, timeout, [])
+    receive_messages_until_found(target, System.monotonic_time(:millisecond) + timeout, [])
   end
 
-  defp receive_messages_until_found(target, timeout, acc) do
-    if target in acc do
-      acc
-    else
-      receive do
-        {:messages_received, messages} ->
-          receive_messages_until_found(target, timeout, acc ++ messages)
-      after
-        timeout -> acc
-      end
+  defp receive_messages_until_found(target, deadline, acc) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    cond do
+      target in acc ->
+        acc
+
+      remaining <= 0 ->
+        acc
+
+      true ->
+        receive do
+          {:messages_received, messages} ->
+            receive_messages_until_found(target, deadline, acc ++ messages)
+        after
+          remaining -> acc
+        end
     end
   end
 


### PR DESCRIPTION
## Problem

`KafkaEx.Integration.ConsumerGroup.ResilienceTest` — "consumer survives multiple rapid rebalances" — hangs and **times out at 90s ~87% of the time**, which times out the whole **Consumer Group Tests** CI job (20 min) once CI's flaky-retry re-runs it. It has been failing intermittently on `master` (the `cancelled` runs), not just on stacked PRs.

## Root cause (found by instrumenting the test's phases)

The hang is **not** an assertion failure and **not** flaky infra. Timing breakdown of a run:

```
iter 1: produced +4.6s → temp stopped +29.6s   (stop = ~25s)
iter 2: produced +31.7s → temp stopped +56.7s  (stop = ~25s)
iter 3: produced +58.7s → temp stopped +83.7s  (stop = ~25s)
restabilize / final produced / received: instant
```

Each `stop_safely(temp_consumer)` takes **~25s** — exactly the Manager child's `shutdown` timeout. The temp consumer is stopped ~1s after start, **while its Manager is still in the synchronous JoinGroup/SyncGroup** (whose deadline is correctly long since #566: `rebalance_timeout + 5s`). The Manager can't process a graceful shutdown until that call returns, so the supervisor waits the full 25s before force-killing. 3 × 25s ≈ 75s, right at the 90s cap → tips over intermittently.

This is the known **synchronous-Manager** limitation (tracked as the non-blocking-Manager follow-up, "Improvement 22", v1.2.0), surfaced by the correct longer join deadlines. Not introduced by any single PR — it lives on `master`.

## Fix (test-only)

1. **Kill the throwaway temp consumers abruptly** (`Process.unlink` + `Process.exit(:kill)`) instead of a graceful `stop_safely`. They exist only to trigger rebalances; an abrupt crash-style departure is exactly the KAFKA-6829 pattern the test is named for, and it's instant.
2. **`receive_messages_until` / `receive_messages_until_found`: absolute monotonic deadline** instead of a per-message idle `after timeout`. The old form reset the window on every message, so a steady re-delivery stream during rebalances looped indefinitely — turning a slow wait into a 90s hang. (Real latent bug in the helpers.)
3. **Final-message budget 15s → 30s**: abruptly-killed temps linger as ghosts until their session times out, so `consumer1` reclaims the partitions only after ~14s (observed). The absolute deadline returns as soon as the message arrives.

## Verification

Local Testcontainers cluster: the target test **8/8 green, ~10–29s each** (was 86s pass / 90s hang); full `resilience_test.exs` **5/5 green**. Test-only change — no library code touched. The underlying synchronous-Manager shutdown cost remains tracked for v1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)