### PR TITLE
fix: scope client send-once to coordinator requests, keep data-plane retry

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -963,15 +963,18 @@ defmodule KafkaEx.Client do
     Logger.warning("Request #{inspect(request_name)} failed with error #{inspect(error_atom)}")
 
     cond do
-      # A socket recv-timeout is sent send-once: this loop runs synchronously
-      # inside the Client GenServer, so retrying the same attempt would block the
-      # whole client for another full network_timeout. Re-issue is delegated to
-      # the higher-level loops (ConsumerGroup.Manager, GenConsumer commit, Stream),
-      # which back off with jitter in their own processes. Mirrors Java/kafka-python/
-      # librdkafka, which treat a request timeout as connection failure rather than
-      # a same-socket retry.
-      Retry.transport_timeout?(error_atom) ->
-        Logger.info("Request #{inspect(request_name)} timed out; not retrying at the client (send-once)")
+      # A recv-timeout on a coordinator request (JoinGroup/SyncGroup/Heartbeat/commit,
+      # routed via the :consumer_group selector) is sent send-once: the broker
+      # legitimately holds these for the rebalance/session window, so retrying the
+      # same synchronous attempt just blocks the client for another full
+      # network_timeout — re-issue is owned by the higher-level loops
+      # (ConsumerGroup.Manager rejoin, GenConsumer commit), which back off with
+      # jitter in their own processes. Data-plane requests (fetch/metadata/offset)
+      # have no such higher-level retry, so they fall through to ctx.retryable?
+      # and are retried at the client as before (produce stays non-retryable on
+      # timeout via its own classifier, avoiding duplicates).
+      Retry.transport_timeout?(error_atom) and coordinator_request?(ctx.node_selector) ->
+        Logger.info("Coordinator request #{inspect(request_name)} timed out; not retrying at the client (send-once)")
         {{:error, error}, state}
 
       ctx.retryable?.(error_atom) ->


### PR DESCRIPTION
From the v1.1.0 release review (major). The send-once recv-timeout short-circuit fired for every request type before `ctx.retryable?`, so a transient Fetch/metadata timeout — previously retried up to @retry_count inside the client — now killed the consumer on the first blip (no higher-level retry). Gate send-once on `coordinator_request?/1` so only join/sync/heartbeat/commit short-circuit; data-plane falls through to `ctx.retryable?` (produce stays non-retryable on timeout → no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)