### PR TITLE
docs: correct release-review doc inaccuracies (group_instance_id, timeouts, jitter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,10 @@ def start(_type, _args) do
             # `member_terminated` telemetry with `terminal_class: :fenced`).
             # Raise session_timeout to cover your restart/deploy window.
             # Default: nil (dynamic membership, feature off).
-            # group_instance_id: System.get_env("POD_NAME") || (node() |> to_string())
+            # Do NOT fall back to node(): on an unclustered BEAM it is
+            # :nonode@nohost on every instance, so a second consumer would
+            # fence the first. Fail loudly instead if the env var is missing.
+            # group_instance_id: System.fetch_env!("POD_NAME")
           ]
         ]
       }

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -118,12 +118,14 @@ timeouts** (e.g. `60_000`), you can remove it — JoinGroup/SyncGroup no longer
 use it. A large `:request_timeout` now only widens the window before a
 silently-unresponsive broker is detected on other requests.
 
-**Behavior note.** A socket recv-timeout is no longer retried inside the
-(synchronous) client `GenServer`; it is surfaced to the higher-level loops
-(consumer-group manager, `GenConsumer` commit, stream), which re-issue with
-±20% jittered backoff (KIP-580). Protocol errors (e.g.
-`not_leader_for_partition`, `not_coordinator`) keep their in-client retry with
-metadata/coordinator refresh.
+**Behavior note.** A socket recv-timeout on a *coordinator* request
+(JoinGroup/SyncGroup/Heartbeat/commit) is no longer retried inside the
+(synchronous) client `GenServer`; it is surfaced to the owning higher-level loop.
+The consumer-group manager rejoins using its own exponential backoff (not
+jittered); `GenConsumer` commit and the stream re-issue with ±20% jittered
+backoff (KIP-580). Data-plane requests (fetch, metadata) keep their in-client
+retry, as do protocol errors (e.g. `not_leader_for_partition`, `not_coordinator`)
+with metadata/coordinator refresh.
 
 **Data-plane failure latency.** Because the generic per-attempt timeout default
 rose (effectively ~1 s → `:request_timeout` = 15 s) and a socket timeout is now
@@ -140,7 +142,7 @@ whose recv times out is **not** retried in-client (previously up to 3×); it
 escalates to a rejoin, which under a persistent coordinator stall means a
 rebalance — matching the Java/librdkafka "mark coordinator dead, rejoin" model.
 Keep `heartbeat_interval` well below `session_timeout / 3`: the outer heartbeat
-budget is `heartbeat_interval × 3`, so an over-large interval could let a
+budget is `heartbeat_interval × 3 + 5s`, so an over-large interval could let a
 retrying heartbeat span the whole session.
 
 **Consumer-group manager responsiveness during a rebalance.** JoinGroup/SyncGroup

--- a/config/config.exs
+++ b/config/config.exs
@@ -40,11 +40,10 @@ config :kafka_ex,
   # KafkaEx worker to start during application start-up -
   # i.e., if you want to start your own set of named workers
   disable_default_worker: false,
-  # Timeout value, in msec, for synchronous operations (e.g., network calls).
   # Per-attempt request socket-recv timeout (ms) for synchronous requests that do
-  # not derive their own (metadata, offset, heartbeat, produce ack, …). Consumer-group
-  # JoinGroup/SyncGroup derive their own, longer deadlines from the group's
-  # rebalance/session timeouts. Was `:sync_timeout` (now a deprecated alias, removed in 2.0).
+  # not derive their own (metadata, offset, produce ack, …). Consumer-group
+  # JoinGroup/SyncGroup/Heartbeat derive their own deadlines (rebalance/session
+  # window; heartbeat_interval). Was `:sync_timeout` (now a deprecated alias, removed in 2.0).
   request_timeout: 15000,
   # Supervision max_restarts - the maximum amount of restarts allowed in a time frame
   max_restarts: 10,

--- a/lib/kafka_ex/client/request_context.ex
+++ b/lib/kafka_ex/client/request_context.ex
@@ -18,21 +18,20 @@ defmodule KafkaEx.Client.RequestContext do
       clients (Java `RetriableException`, KafkaJS `error.retriable`, librdkafka)
       classify retriability on the error, but that cannot work here: the same
       error atom (e.g. `:request_timed_out`) is retryable for fetch yet unsafe
-      for produce (duplicate writes). Only produce overrides the default with
-      `&KafkaEx.Support.Retry.produce_retryable?/1`; everything else inherits
-      always-retry. `KafkaEx.Support.Retry` centralizes error-code
-      classification for the separate `with_retry` loop (stream/consumer);
-      converging the two is deferred follow-up.
+      for produce (duplicate writes). The default is
+      `&KafkaEx.Support.Retry.data_plane_retryable?/1`; produce narrows it to
+      `produce_retryable?/1`, and the consumer-group operations use their own
+      classifiers. All of them live in `KafkaEx.Support.Retry` — the single home
+      for error classification, shared with the `with_retry` loop (stream/consumer).
 
     * `network_timeout` is the **per-attempt** `Socket.recv` deadline. It is set
-      explicitly by the requests the broker legitimately holds — fetch (derived
-      from `:max_wait_time`), JoinGroup (rebalance_timeout + a fixed grace) and
-      SyncGroup (session window) — each widens its matching `GenServer.call` budget
-      in `KafkaEx.API` so the two cannot mismatch (issue #357). Leave `nil` for
-      every other request so it falls back to the generic `:request_timeout`
-      (`KafkaEx.Config.request_timeout/0`); those callers derive their outer
-      `GenServer.call` budget from the same value. It is per-attempt, NOT the
-      total budget.
+      explicitly by the requests that need a non-generic deadline — fetch (from
+      `:max_wait_time`), JoinGroup (rebalance_timeout + grace), SyncGroup (session
+      window), Heartbeat (heartbeat_interval) and CreateTopics/DeleteTopics (broker
+      op timeout + grace) — each widening its matching `GenServer.call` budget in
+      `KafkaEx.API` so the two cannot mismatch (issue #357). Leave `nil` for every
+      other request so it falls back to the generic `:request_timeout`
+      (`KafkaEx.Config.request_timeout/0`). It is per-attempt, NOT the total budget.
 
     * Backoff/jitter between attempts is intentionally absent — the client loop
       retries immediately (refreshing metadata on leadership errors). If added


### PR DESCRIPTION
From the v1.1.0 release review. README group_instance_id `node()` fallback (fences on unclustered BEAM), config.exs heartbeat-in-generic-list, request_context stale retryable?/network_timeout docs, UPGRADING send-once scope + jitter attribution + heartbeat `×3+5s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)