### PR TITLE
fix: harden group_instance_id, crash-rejoin bound, and heartbeat exit unwrap

### DIFF
--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -295,11 +295,20 @@ defmodule KafkaEx.Config do
   defp validate_group_instance_id(nil), do: nil
 
   defp validate_group_instance_id(value) when is_binary(value) do
-    if String.trim(value) == "" do
-      raise ArgumentError, "group_instance_id must be a non-empty string; got #{inspect(value)}"
-    end
+    trimmed = String.trim(value)
 
-    value
+    cond do
+      trimmed == "" ->
+        raise ArgumentError, "group_instance_id must be a non-empty string; got #{inspect(value)}"
+
+      # Reject padded ids: they are sent verbatim on the wire, so two sources
+      # differing only in whitespace would register as distinct static members.
+      trimmed != value ->
+        raise ArgumentError, "group_instance_id must not have leading/trailing whitespace; got #{inspect(value)}"
+
+      true ->
+        value
+    end
   end
 
   defp validate_group_instance_id(value) do

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -121,6 +121,9 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 
-  defp normalize_exit_reason({reason, {GenServer, :call, _}}) when is_atom(reason), do: reason
+  # Unwrap the {reason, {GenServer, :call, _}} client-call exit wrapper regardless
+  # of the inner shape, so a compound reason (e.g. {:shutdown, _}) is classified on
+  # its real value rather than misclassified as the whole nested tuple.
+  defp normalize_exit_reason({reason, {GenServer, :call, _}}), do: reason
   defp normalize_exit_reason(reason), do: reason
 end

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -188,6 +188,18 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     Keyword.get(opts, key, Application.get_env(:kafka_ex, key, default))
   end
 
+  # Fail loudly on a bad crash-loop bound: a non-negative integer bounds it,
+  # :infinity disables it. Anything else (negative, string, float, …) would
+  # otherwise slip through register_heartbeat_crash/1's guard and silently
+  # disable the bound — a footgun for an option meant to fail fast.
+  defp validate_crash_rejoin_max_restarts!(:infinity), do: :ok
+  defp validate_crash_rejoin_max_restarts!(n) when is_integer(n) and n >= 0, do: :ok
+
+  defp validate_crash_rejoin_max_restarts!(other) do
+    raise ArgumentError,
+          "crash_rejoin_max_restarts must be a non-negative integer or :infinity; got #{inspect(other)}"
+  end
+
   @type assignments :: [{binary(), integer()}]
 
   # Client API
@@ -214,6 +226,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     sync_retry_backoff_ms = get_with_default(opts, :sync_retry_backoff_ms, @sync_retry_backoff_ms)
     crash_rejoin_max_jitter_ms = get_with_default(opts, :crash_rejoin_max_jitter_ms, @crash_rejoin_max_jitter_ms)
     crash_rejoin_max_restarts = get_with_default(opts, :crash_rejoin_max_restarts, @crash_rejoin_max_restarts)
+    validate_crash_rejoin_max_restarts!(crash_rejoin_max_restarts)
     crash_rejoin_window_ms = get_with_default(opts, :crash_rejoin_window_ms, @crash_rejoin_window_ms)
 
     group_instance_id =


### PR DESCRIPTION
From the v1.1.0 release review (minor correctness). Reject whitespace-padded group_instance_id; validate crash_rejoin_max_restarts at init (bad value silently disabled the bound); unwrap the GenServer.call exit wrapper regardless of inner shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)