### PR TITLE
cleanup: pack_assignments via Enum.group_by (O(n))

### DIFF
--- a/lib/kafka_ex/consumer/consumer_group/assignment.ex
+++ b/lib/kafka_ex/consumer/consumer_group/assignment.ex
@@ -89,9 +89,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Assignment do
 
   defp pack_assignments(assignments) do
     assignments
-    |> Enum.reduce(%{}, fn {topic, partition}, acc ->
-      Map.update(acc, topic, [partition], &(&1 ++ [partition]))
-    end)
+    |> Enum.group_by(fn {topic, _partition} -> topic end, fn {_topic, partition} -> partition end)
     |> Map.to_list()
   end
 


### PR DESCRIPTION
From the v1.1.0 release-review nit list — the one safe, tested cleanup worth doing. Other nits (typespec polish, Keyword.pop/precedence dedup, re-query-only-missing, dead need_commit? clause) were judged cosmetic/negligible/behavior-touching and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)