### PR TITLE
fix: Stream auto-commit no longer commits past the last delivered offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 
 ### Fixed
 
+* **`KafkaEx.Consumer.Stream` auto-commit no longer commits past the last delivered offset.**
+  A stream consumed with `Enum.take/2` spanning more than one fetch batch could commit an offset
+  beyond the last record the caller actually received (the reduce accumulator was captured once and
+  read stale on every batch), so a restart resumed past the gap — silent data loss. The stream now
+  commits a batch's offset only once it is proven fully delivered (deferred by one poll); a
+  truncated `Enum.take` leaves the last partial batch uncommitted, re-delivered on restart
+  (at-least-once). Pre-existing since the v1.0 Kayrock release.
+
 * **Consumer-group cold start no longer times out (JoinGroup/SyncGroup socket timeouts).**
   JoinGroup/SyncGroup previously fell back to the `1000` ms generic socket-recv timeout, while the
   broker legitimately holds a JoinGroup response for up to `group.initial.rebalance.delay.ms`

--- a/lib/kafka_ex/consumer/stream.ex
+++ b/lib/kafka_ex/consumer/stream.ex
@@ -30,17 +30,28 @@ defmodule KafkaEx.Consumer.Stream do
     alias KafkaEx.Consumer.Stream, as: ConsumerStream
 
     def reduce(%ConsumerStream{} = data, acc, fun) do
-      start_fun = fn -> data.offset end
-      # each iteration we need to take care of fetching and (possibly) committing offsets
-      next_fun = fn offset ->
-        data
-        |> fetch_response(offset)
-        |> maybe_commit_offset(data, acc)
-        |> stream_control(data, offset)
+      # {fetch_offset, pending_commit}: a batch commits only once proven fully delivered (next poll).
+      start_fun = fn -> {data.offset, nil} end
+
+      next_fun = fn {offset, pending} ->
+        case commit_pending(data, pending) do
+          :halt -> {:halt, {offset, nil}}
+          :ok -> fetch_and_advance(data, offset)
+        end
       end
 
-      after_fun = fn _last_offset -> :ok end
+      after_fun = fn _acc -> :ok end
       Stream.resource(start_fun, next_fun, after_fun).(acc, fun)
+    end
+
+    defp fetch_and_advance(data, offset) do
+      response = fetch_response(data, offset)
+      new_pending = pending_offset(response, data)
+
+      case stream_control(response, data, offset) do
+        {:halt, next_offset} -> {:halt, {next_offset, nil}}
+        {records, next_offset} -> {records, {next_offset, new_pending}}
+      end
     end
 
     def count(_stream) do
@@ -57,10 +68,6 @@ defmodule KafkaEx.Consumer.Stream do
 
     ######################################################################
     # Main stream flow control
-
-    defp stream_control(:commit_halt, %ConsumerStream{}, offset) do
-      {:halt, offset}
-    end
 
     # error response -> halt + log
     #
@@ -126,26 +133,30 @@ defmodule KafkaEx.Consumer.Stream do
     ######################################################################
     # Offset management
 
-    defp maybe_commit_offset(fetch_response, %ConsumerStream{} = stream_data, acc) do
+    defp commit_pending(_stream_data, nil), do: :ok
+
+    defp commit_pending(%ConsumerStream{} = stream_data, offset) do
+      case commit_offset(stream_data, offset) do
+        {:error, reason} ->
+          Logger.error(
+            "Stream halting: offset commit failed for #{stream_data.topic}/#{stream_data.partition} " <>
+              "at offset #{offset}: #{inspect(reason)}"
+          )
+
+          :halt
+
+        _ ->
+          :ok
+      end
+    end
+
+    defp pending_offset(response, %ConsumerStream{} = stream_data) do
       auto_commit = Keyword.get(stream_data.fetch_options, :auto_commit, false)
 
-      if need_commit?(fetch_response, auto_commit) do
-        offset_to_commit = last_offset(acc, fetch_response.message_set)
-
-        case commit_offset(stream_data, offset_to_commit) do
-          {:error, reason} ->
-            Logger.error(
-              "Stream halting: offset commit failed for #{stream_data.topic}/#{stream_data.partition} " <>
-                "at offset #{offset_to_commit}: #{inspect(reason)}"
-            )
-
-            :commit_halt
-
-          _ ->
-            fetch_response
-        end
+      if need_commit?(response, auto_commit) do
+        response.message_set |> List.last() |> Map.get(:offset)
       else
-        fetch_response
+        nil
       end
     end
 
@@ -157,23 +168,6 @@ defmodule KafkaEx.Consumer.Stream do
     defp need_commit?(%{message_set: []}, _auto_commit), do: false
     # otherwise, use the auto_commit setting
     defp need_commit?(_fetch_response, auto_commit), do: auto_commit
-
-    # if we have requested fewer messages than we fetched, commit the offset
-    # of the last one we will actually consume
-    defp last_offset({:cont, {_, n}}, message_set) when n <= length(message_set) do
-      case Enum.at(message_set, n - 1) do
-        nil -> nil
-        message -> message.offset
-      end
-    end
-
-    # otherwise, commit the offset of the last message
-    defp last_offset({:cont, _}, message_set) do
-      case List.last(message_set) do
-        nil -> nil
-        message -> message.offset
-      end
-    end
 
     # Commit retry settings (issue #425)
     # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff

--- a/test/kafka_ex/consumer/stream_test.exs
+++ b/test/kafka_ex/consumer/stream_test.exs
@@ -109,8 +109,9 @@ defmodule KafkaEx.Consumer.StreamTest do
       end
     end
 
-    def handle_call({:offset_commit, _group, _commits, _opts}, _from, state) do
-      {:reply, {:ok, []}, %{state | commits: [DateTime.utc_now() | state.commits]}}
+    def handle_call({:offset_commit, _group, topic_partitions, _opts}, _from, state) do
+      offsets = for {_topic, partitions} <- topic_partitions, %{offset: o} <- partitions, do: o
+      {:reply, {:ok, []}, %{state | commits: state.commits ++ offsets}}
     end
 
     def handle_call(:get_commits, _from, state) do
@@ -222,6 +223,55 @@ defmodule KafkaEx.Consumer.StreamTest do
         |> Enum.map(& &1.value)
 
       assert values == ["a", "b", "c", "d", "e"]
+    end
+  end
+
+  describe "auto-commit offset accuracy (deferred-by-one-batch)" do
+    alias KafkaEx.Consumer.Stream, as: ConsumerStream
+
+    defp batch(offsets),
+      do: {:ok, %{last_offset: Enum.max(offsets), records: for(o <- offsets, do: %{offset: o, value: "v"})}}
+
+    defp empty(last), do: {:ok, %{last_offset: last, records: []}}
+
+    defp auto_commit_stream(mock, opts \\ [auto_commit: true]),
+      do: %ConsumerStream{
+        client: mock,
+        topic: "t",
+        partition: 0,
+        offset: 100,
+        consumer_group: "g",
+        no_wait_at_logend: true,
+        fetch_options: opts,
+        api_versions: %{}
+      }
+
+    test "truncated Enum.take never commits past the last delivered batch (regression)" do
+      # b1: 100..102, b2: 103..106. take(5) delivers 100,101,102,103,104.
+      {:ok, mock} = MockClient.start_link([batch(100..102), batch(103..106)])
+
+      taken = mock |> auto_commit_stream() |> Enum.take(5) |> Enum.map(& &1.offset)
+
+      assert taken == [100, 101, 102, 103, 104]
+      # b1 fully delivered → committed; truncated b2 not (pre-fix wrongly committed 106).
+      assert MockClient.commits(mock) == [102]
+    end
+
+    test "full drain commits every fully-delivered batch's last offset" do
+      {:ok, mock} = MockClient.start_link([batch(100..102), batch(103..105), empty(105)])
+
+      values = mock |> auto_commit_stream() |> Enum.to_list() |> Enum.map(& &1.offset)
+
+      assert values == [100, 101, 102, 103, 104, 105]
+      assert MockClient.commits(mock) == [102, 105]
+    end
+
+    test "auto_commit: false never commits" do
+      {:ok, mock} = MockClient.start_link([batch(100..102), empty(102)])
+
+      _ = mock |> auto_commit_stream(auto_commit: false) |> Enum.to_list()
+
+      assert MockClient.commits(mock) == []
     end
   end
 


### PR DESCRIPTION
Pulled into **v1.1.0** from the release-review deferred list (user decision). Full design cycle: research → spec → /grill-me → plan.

## Problem

`KafkaEx.Consumer.Stream.reduce/3` captured the initial reduce accumulator in the `next_fun` closure and read it (stale) on every fetch batch. For `Enum.take(stream, n)` the frozen `n` made `last_offset/2` commit `List.last(batch)` once the take spanned more than one batch — **past the last record the caller consumed**. On restart the group resumed past the gap → **silent data loss**.

Confirmed **pre-existing** since `573296b [Kayrock] Release V1 (#514)` (before v1.0.1); v1.1.0 only removed comments from the file. Not a regression — surfaced by the review.

## Fix — deferred-by-one-batch commit (grilled design)

Thread `{fetch_offset, pending_commit_offset}`. A batch's last offset is committed only once it is **proven fully delivered** — on the next `next_fun`/poll. A truncated `Enum.take` leaves the last partial batch uncommitted, re-delivered on restart (**at-least-once**, no loss). Commit failure still halts before emitting the next fetch. The frozen-acc `last_offset/2` peek is deleted; `#357` behaviors (error-halt, control-batch skip, `no_wait_at_logend`) and the public `Enumerable` API are unchanged.

- Continuous consumption commits each batch on the next poll.
- Full drain commits every batch (flushed by the terminal empty/error poll).
- Truncated take re-delivers the last batch (Kafka auto-commit is at-least-once).

## Tests (MockClient, deterministic)

- **Regression:** b1 100–102, b2 103–106; `Enum.take(5)` delivers 100–104 and commits **`[102]`**, never 106 (pre-fix committed 106).
- Full drain commits `[102, 105]`; `auto_commit: false` commits nothing; all existing `#357` tests unchanged.

Gates: compile (warnings-as-errors), format, credo, `mix test.unit` (3090, 0 failures) all green.

Merge **before** the release bump so it ships in v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)