### PR TITLE
cleanup: trim verbose comments from the review-fix PRs

### DIFF
--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -963,16 +963,8 @@ defmodule KafkaEx.Client do
     Logger.warning("Request #{inspect(request_name)} failed with error #{inspect(error_atom)}")
 
     cond do
-      # A recv-timeout on a coordinator request (JoinGroup/SyncGroup/Heartbeat/commit,
-      # routed via the :consumer_group selector) is sent send-once: the broker
-      # legitimately holds these for the rebalance/session window, so retrying the
-      # same synchronous attempt just blocks the client for another full
-      # network_timeout — re-issue is owned by the higher-level loops
-      # (ConsumerGroup.Manager rejoin, GenConsumer commit), which back off with
-      # jitter in their own processes. Data-plane requests (fetch/metadata/offset)
-      # have no such higher-level retry, so they fall through to ctx.retryable?
-      # and are retried at the client as before (produce stays non-retryable on
-      # timeout via its own classifier, avoiding duplicates).
+      # Send-once only for coordinator requests (broker holds them for the rebalance/
+      # session window; rejoin/commit re-issue higher up). Data-plane retries via ctx.retryable?.
       Retry.transport_timeout?(error_atom) and coordinator_request?(ctx.node_selector) ->
         Logger.info("Coordinator request #{inspect(request_name)} timed out; not retrying at the client (send-once)")
         {{:error, error}, state}

--- a/lib/kafka_ex/config.ex
+++ b/lib/kafka_ex/config.ex
@@ -301,8 +301,7 @@ defmodule KafkaEx.Config do
       trimmed == "" ->
         raise ArgumentError, "group_instance_id must be a non-empty string; got #{inspect(value)}"
 
-      # Reject padded ids: they are sent verbatim on the wire, so two sources
-      # differing only in whitespace would register as distinct static members.
+      # Padded ids are sent verbatim → two whitespace-different sources = distinct members.
       trimmed != value ->
         raise ArgumentError, "group_instance_id must not have leading/trailing whitespace; got #{inspect(value)}"
 

--- a/lib/kafka_ex/consumer/consumer_group/assignment.ex
+++ b/lib/kafka_ex/consumer/consumer_group/assignment.ex
@@ -20,13 +20,8 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Assignment do
   `UNKNOWN_TOPIC_OR_PARTITION` with exponential backoff (Java-client pattern);
   after `#{@max_topic_retries}` attempts it assigns whatever topics were found.
 
-  > #### Blocking hazard {: .warning}
-  > Called by the leader inside the `ConsumerGroup.Manager` GenServer callback,
-  > this `:timer.sleep`s between retries — up to ~1.5s across #{@max_topic_retries}
-  > sequential metadata round-trips — during which the Manager cannot service
-  > heartbeats, introspection, or shutdown. Removing this synchronous block is the
-  > deferred non-blocking-Manager follow-up (run join/sync/assignment off the
-  > callback in a monitored `Task`).
+  Runs synchronously in the `Manager` callback and `:timer.sleep`s between retries,
+  briefly blocking heartbeats/shutdown — removed by the non-blocking-Manager follow-up.
   """
   @spec assignable_partitions(pid(), [binary()], binary()) :: [{binary(), integer()}]
   def assignable_partitions(client, topics, group_name),

--- a/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
+++ b/lib/kafka_ex/consumer/consumer_group/heartbeat.ex
@@ -121,9 +121,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Heartbeat do
       {:stop, {:shutdown, {:error, normalize_exit_reason(reason)}}, state}
   end
 
-  # Unwrap the {reason, {GenServer, :call, _}} client-call exit wrapper regardless
-  # of the inner shape, so a compound reason (e.g. {:shutdown, _}) is classified on
-  # its real value rather than misclassified as the whole nested tuple.
+  # Unwrap the {reason, {GenServer, :call, _}} exit regardless of inner shape (compound reasons too).
   defp normalize_exit_reason({reason, {GenServer, :call, _}}), do: reason
   defp normalize_exit_reason(reason), do: reason
 end

--- a/lib/kafka_ex/consumer/consumer_group/manager.ex
+++ b/lib/kafka_ex/consumer/consumer_group/manager.ex
@@ -188,10 +188,7 @@ defmodule KafkaEx.Consumer.ConsumerGroup.Manager do
     Keyword.get(opts, key, Application.get_env(:kafka_ex, key, default))
   end
 
-  # Fail loudly on a bad crash-loop bound: a non-negative integer bounds it,
-  # :infinity disables it. Anything else (negative, string, float, …) would
-  # otherwise slip through register_heartbeat_crash/1's guard and silently
-  # disable the bound — a footgun for an option meant to fail fast.
+  # A bad value (negative/string/float) would silently disable the crash-loop bound — fail loud.
   defp validate_crash_rejoin_max_restarts!(:infinity), do: :ok
   defp validate_crash_rejoin_max_restarts!(n) when is_integer(n) and n >= 0, do: :ok
 

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -440,8 +440,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
       :fetch_options,
       :api_versions,
       :group_manager_pid,
-      # true only when this GenConsumer started its own client (see resolve_client/2);
-      # a caller-supplied :client is shared and must NOT be stopped on terminate.
+      # true only when we started the client — a caller-supplied (shared) :client must not be stopped.
       owns_client: false
     ]
 
@@ -676,9 +675,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
     end
   end
 
-  # Resolves the client to use for Kafka operations
-  # Returns {client, owns_client?}. A caller-supplied :client is shared (owns? =
-  # false); otherwise we start our own and own its lifecycle.
+  # Returns {client, owns_client?} — false for a caller-supplied (shared) :client.
   defp resolve_client(opts, group_name) do
     case Keyword.get(opts, :client) do
       nil ->


### PR DESCRIPTION
Comment-only. The #578–#583 review fixes added multi-line comment blocks that restated the code; trimmed each to a single non-obvious "why" (or removed where the name is self-documenting). No logic change; compile/format/`test.unit` (3087, 0 failures) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)