### PR TITLE
make metadata_missing_test hermetic

### DIFF
--- a/test/kafka_ex/client/metadata_missing_test.exs
+++ b/test/kafka_ex/client/metadata_missing_test.exs
@@ -38,17 +38,17 @@ defmodule KafkaEx.Client.MetadataMissingTest do
       tracked_topics: MapSet.new(["present-topic", "missing-topic"])
     }
 
-    {:ok, state: state, broker: broker}
+    {:ok, state: state, broker: broker, port: lport}
   end
 
-  defp stub_metadata_response(topic_names) do
+  defp stub_metadata_response(topic_names, port) do
     stub(NetworkClient, :send_sync_request, fn _broker, _wire, _timeout ->
-      build_v0_metadata_response(topic_names)
+      build_v0_metadata_response(topic_names, port)
     end)
   end
 
   # Hand-rolled V0 wire bytes: Kayrock ships no response serializer.
-  defp build_v0_metadata_response(topic_names) do
+  defp build_v0_metadata_response(topic_names, port) do
     partition = [
       <<0::16-signed, 0::32-signed, 1::32-signed>>,
       int32_array([1]),
@@ -63,7 +63,7 @@ defmodule KafkaEx.Client.MetadataMissingTest do
     [
       <<1::32-signed>>,
       int32_array_len(1),
-      [<<1::32-signed>>, string("localhost"), <<9092::32-signed>>],
+      [<<1::32-signed>>, string("localhost"), <<port::32-signed>>],
       int32_array_len(length(topic_names)),
       topics
     ]
@@ -74,8 +74,8 @@ defmodule KafkaEx.Client.MetadataMissingTest do
   defp int32_array_len(n), do: <<n::32-signed>>
   defp int32_array(values), do: [<<length(values)::32-signed>>, Enum.map(values, &<<&1::32-signed>>)]
 
-  test "give-up merges: missing topic doesn't discard metadata for topics that ARE present", %{state: state} do
-    stub_metadata_response(["present-topic"])
+  test "give-up merges: missing topic doesn't discard metadata for topics that ARE present", %{state: state, port: port} do
+    stub_metadata_response(["present-topic"], port)
 
     {{:reply, {:ok, cluster_metadata}, updated_state}, _log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state) end)
@@ -89,8 +89,8 @@ defmodule KafkaEx.Client.MetadataMissingTest do
     assert updated_state.metadata_missing == MapSet.new(["missing-topic"])
   end
 
-  test "warning logged once when a tracked topic first goes missing", %{state: state} do
-    stub_metadata_response(["present-topic"])
+  test "warning logged once when a tracked topic first goes missing", %{state: state, port: port} do
+    stub_metadata_response(["present-topic"], port)
 
     log =
       capture_log(fn ->
@@ -103,9 +103,10 @@ defmodule KafkaEx.Client.MetadataMissingTest do
   end
 
   test "edge-triggered: repeating the same missing set within the heartbeat window logs no second warning", %{
-    state: state
+    state: state,
+    port: port
   } do
-    stub_metadata_response(["present-topic"])
+    stub_metadata_response(["present-topic"], port)
 
     {{:reply, _, state_after_first}, first_log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state) end)
@@ -120,13 +121,13 @@ defmodule KafkaEx.Client.MetadataMissingTest do
     assert state_after_second.metadata_missing_logged_at == state_after_first.metadata_missing_logged_at
   end
 
-  test "recovery: topic reappearing logs exactly one info line and no warnings", %{state: state} do
-    stub_metadata_response(["present-topic"])
+  test "recovery: topic reappearing logs exactly one info line and no warnings", %{state: state, port: port} do
+    stub_metadata_response(["present-topic"], port)
 
     {{:reply, _, state_after_missing}, _first_log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state) end)
 
-    stub_metadata_response(["present-topic", "missing-topic"])
+    stub_metadata_response(["present-topic", "missing-topic"], port)
 
     {{:reply, {:ok, cluster_metadata}, recovered_state}, recovery_log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state_after_missing) end)
@@ -141,8 +142,8 @@ defmodule KafkaEx.Client.MetadataMissingTest do
     assert recovered_state.metadata_missing_logged_at == nil
   end
 
-  test "a changed missing set logs a fresh warning even within the heartbeat window", %{state: state} do
-    stub_metadata_response(["present-topic"])
+  test "a changed missing set logs a fresh warning even within the heartbeat window", %{state: state, port: port} do
+    stub_metadata_response(["present-topic"], port)
 
     {{:reply, _, state_after_first}, first_log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state) end)
@@ -152,7 +153,7 @@ defmodule KafkaEx.Client.MetadataMissingTest do
 
     # Both tracked topics now missing: the set changed, so a new warning must fire
     # despite still being inside the heartbeat window.
-    stub_metadata_response([])
+    stub_metadata_response([], port)
 
     {{:reply, _, state_after_second}, second_log} =
       capture_log_and_result(fn -> Client.handle_call(:update_metadata, self(), state_after_first) end)


### PR DESCRIPTION
The setup binds a real socket on an ephemeral port via :gen_tcp.listen(0), but build_v0_metadata_response hard-coded the advertised broker port as 9092. Because ClusterMetadata.merge_brokers/2 only preserves a live socket when both host and port match, the port mismatch caused the client to drop the stubbed socket and attempt a real, unstubbed reconnect to localhost:9092 on the second update_metadata call. On a clean host (CI) that reconnect fails with :econnrefused, producing 3 flaky failures; it only passed locally when something happened to be listening on 9092.

Thread the setup socket's real ephemeral port through setup -> stub_metadata_response -> build_v0_metadata_response and advertise it instead of 9092, so the test no longer depends on the network.