### PR TITLE
fix(produce, consumer): honour acks, and survive leader moves & SSL broker restarts (1.0.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@
   including `{:tcp_error, _, _}` / `{:ssl_error, _, _}`, which a connection reset delivers ahead of
   `{:tcp_closed, _}` — crashed the process and took every broker socket and all cluster metadata
   with it. Socket errors now close just that broker's socket; other messages are logged and
-  ignored.
+  ignored. Such a close reports `reason: :recv_error` on `[:kafka_ex, :connection, :close]`, so the
+  metadata stays within the documented set of atoms — the underlying reason, which for `:ssl_error`
+  can be a whole alert term, goes to the log instead.
 
 * **`[:kafka_ex, :produce, :start]` telemetry reports the value actually sent.** The
   `required_acks` metadata field previously reported its own default of `1` while `-1` went on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## 1.0.3 (2026-08-17)
+## 1.0.3 (2026-09-03)
 
 ### Fixed
 
@@ -19,11 +19,21 @@
   previously raised a `MatchError`. It does **not** cover establishing the starting offset at
   startup — `load_offsets/1` still raises if that cannot be read, so a consumer starting while its
   leader moves still fails to start. Note that `:commit_interval` is a deadline checked at the end
-  of a fetch cycle, not a timer, so a backoff stretches the interval between commits.
+  of a fetch cycle, not a timer, so a backoff stretches the interval between commits. Because the
+  retries never give up, a partition that is genuinely stuck (a deleted topic, a leader that never
+  returns) is surfaced once, after `:fetch_unavailable_warn_ms` (default 30000) of continuous
+  failure, as a `Logger.error` and a `[:kafka_ex, :consumer, :partition_unavailable]` telemetry
+  event — the consumer keeps retrying, but a non-recovering partition is now alertable.
+
+* **A broker restart over SSL no longer takes the consumer group down.** A non-atom transport
+  reason (an SSL `{:tls_alert, _}` tuple, say) was normalised to `:unknown`, which the fetch loop
+  treated as fatal — so on TLS clusters the very broker-restart case the retry fix targets still
+  killed the group. Such reasons are now normalised to a retryable `:transport_error`.
 
 * **`:no_broker` says why in the log.** Three different causes — unknown topic, unknown partition,
   unknown node — all surfaced as the same bare `:no_broker`, so a leaderless partition could not be
-  told apart from a deleted topic. The reason from node selection is now logged with the topic and
+  told apart from a deleted topic. The reason from node selection is now logged (at debug level —
+  the consumer's own throttled retry log is the operator-facing signal) with the topic and
   partition. The returned error is unchanged.
 
 * **The acks option reaches the broker again (regression since 1.0).** 0.x translated
@@ -34,7 +44,7 @@
   **deprecated alias** (removal in 2.0) and loses to `:acks` when both are given. The documented
   default was also wrong and is corrected: it is `-1` (all in-sync replicas), not `1`.
 
-  **Upgrade note — read this if you pass either option.** Callers who pass neither are unaffected.
+  **⚠️ BREAKING (produce durability) — read this if you pass either option.** Callers who pass neither are unaffected.
   Callers who do are moved from the durability they were silently getting to the one they asked
   for: `required_acks: 1` goes from all-in-sync-replicas to leader-only, and `required_acks: 0`
   goes from a fully acknowledged produce with a real offset to fire-and-forget with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   partition losing its leader killed every consumer in the group. Most visible with
   replication-factor 1, where there is no follower to promote and the partition is genuinely
   leaderless for the length of a broker restart, but the same path runs on any leader move. The
-  consumer now retries such errors indefinitely with jittered exponential backoff (500 ms to 5 s,
+  consumer now retries such errors indefinitely with jittered exponential backoff (250 ms to 5 s,
   configurable via `:fetch_retry_base_delay_ms` / `:fetch_retry_max_delay_ms`), logging a warning
   with the error and the consecutive failure count, and still stops on anything else. This matches
   brod, KafkaJS and librdkafka, none of which fail a consumer over a leaderless partition. The same
@@ -24,6 +24,15 @@
   returns) is surfaced once, after `:fetch_unavailable_warn_ms` (default 30000) of continuous
   failure, as a `Logger.error` and a `[:kafka_ex, :consumer, :partition_unavailable]` telemetry
   event — the consumer keeps retrying, but a non-recovering partition is now alertable.
+
+* **A key could silently change partition during a leader move.** Metadata parsing dropped every
+  partition the broker reported with an error, shrinking the count the default partitioner keys off
+  — so the same key could land on a different partition, and a transiently-leaderless partition was
+  indistinguishable from one that does not exist. Partitions carrying a leader-move error are now
+  retained with the reported leader (`-1` = leader unknown), `ClusterMetadata.select_node/2` answers
+  `{:error, :leader_not_available}` for them, and `PartitionInfo` carries the broker's `error_code`.
+  This keeps the partition assignable so the consumer's fetch retry (above) can recover it once the
+  leader returns, instead of the partition dropping out of the cluster model entirely.
 
 * **A broker restart over SSL no longer takes the consumer group down.** A non-atom transport
   reason (an SSL `{:tls_alert, _}` tuple, say) was normalised to `:unknown`, which the fetch loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   that `:commit_interval` is a deadline checked at the end of a fetch cycle, not a timer, so a
   backoff stretches the interval between commits.
 
+* **`:no_broker` says why in the log.** Three different causes — unknown topic, unknown partition,
+  unknown node — all surfaced as the same bare `:no_broker`, so a leaderless partition could not be
+  told apart from a deleted topic. The reason from node selection is now logged with the topic and
+  partition. The returned error is unchanged.
+
 * **The acks option reaches the broker again (regression since 1.0).** 0.x translated
   `required_acks` onto the wire in the legacy adapter; that adapter was removed in the 1.0 rewrite
   and the translation went with it, while `KafkaEx.API.produce/5` kept documenting the option. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # KafkaEx Changelog
 
+## 1.0.3 (2026-08-17)
+
+### Fixed
+
+* **The acks option reaches the broker again (regression since 1.0).** 0.x translated
+  `required_acks` onto the wire in the legacy adapter; that adapter was removed in the 1.0 rewrite
+  and the translation went with it, while `KafkaEx.API.produce/5` kept documenting the option. The
+  request builder reads `:acks`, so since 1.0 **every produce went out with `acks: -1`** no matter
+  what the caller asked for. `:acks` is now the canonical option; `:required_acks` is honoured as a
+  **deprecated alias** (removal in 2.0) and loses to `:acks` when both are given. The documented
+  default was also wrong and is corrected: it is `-1` (all in-sync replicas), not `1`.
+
+  **Upgrade note — read this if you pass either option.** Callers who pass neither are unaffected.
+  Callers who do are moved from the durability they were silently getting to the one they asked
+  for: `required_acks: 1` goes from all-in-sync-replicas to leader-only, and `required_acks: 0`
+  goes from a fully acknowledged produce with a real offset to fire-and-forget with
+  `base_offset: nil` — code doing arithmetic on that offset will break, and records can now be
+  lost. Pass `acks: -1` explicitly to keep the 1.0.x behavior.
+
+* **`acks: 0` (fire-and-forget) works.** It was unreachable through the public API and, once
+  reachable, crashed the client (`byte_size/1` on the async send result). A produce with `acks: 0`
+  is now sent asynchronously, **never retried** (a resend would duplicate records — the broker
+  sends no response to confirm the first one), and returns
+  `{:ok, %KafkaEx.Messages.RecordMetadata{base_offset: nil}}`. **Typespec change:**
+  `RecordMetadata.base_offset` is now `non_neg_integer() | nil`. Note that at `acks: 0` the broker
+  reports errors by closing the connection rather than answering, so a rejected batch surfaces as a
+  later disconnect, not as an error from the call that produced it.
+
+* **An acks value the wire cannot carry is now rejected** with `{:error, :invalid_acks}` instead of
+  reaching Kayrock's int16 encoder, where it raised and took the whole client down (`acks: :all`,
+  `acks: nil`) or silently truncated to a different value than the one the client acted on
+  (`acks: 65_536` was sent as `0` while the client waited for a response that never came).
+
+* **A socket error no longer kills the client.** `KafkaEx.Client` defines its own `handle_info/2`
+  clauses, which replaces the catch-all `use GenServer` provides, so any unmatched message —
+  including `{:tcp_error, _, _}` / `{:ssl_error, _, _}`, which a connection reset delivers ahead of
+  `{:tcp_closed, _}` — crashed the process and took every broker socket and all cluster metadata
+  with it. Socket errors now close just that broker's socket; other messages are logged and
+  ignored.
+
+* **`[:kafka_ex, :produce, :start]` telemetry reports the value actually sent.** The
+  `required_acks` metadata field previously reported its own default of `1` while `-1` went on the
+  wire. The field keeps its name in this patch; renaming it to `acks` is a contract change left
+  for a minor release. Note that the `:stop` event for an `acks: 0` produce carries **no**
+  `:offset` key, since there is no offset — a handler written as `metadata.offset` rather than
+  `Map.get/2` will raise and be detached by `:telemetry`.
+
+* **`KafkaEx.Network.NetworkClient.send_async_request/2` returns `{:error, reason}` on a failed
+  send**, as its behaviour already specified, instead of a bare reason atom, and now closes the
+  broken socket the way the synchronous send already did — otherwise the next produce reused a
+  dead socket.
+
 ## 1.0.2 (2026-07-27)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Fixed
 
+* **A moving partition leader no longer takes down the whole consumer group.** `GenConsumer`
+  stopped on any fetch error other than `:offset_out_of_range`, including errors the library itself
+  classifies as transient (`:no_broker`, `:not_leader_for_partition`, `:leader_not_available`,
+  `:timeout`). Because `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`, one
+  partition losing its leader killed every consumer in the group. Most visible with
+  replication-factor 1, where there is no follower to promote and the partition is genuinely
+  leaderless for the length of a broker restart, but the same path runs on any leader move. The
+  consumer now retries such errors indefinitely with jittered exponential backoff (500 ms to 5 s,
+  configurable via `:fetch_retry_base_delay_ms` / `:fetch_retry_max_delay_ms`), logging a warning
+  with the error and the consecutive failure count, and still stops on anything else. This matches
+  brod, KafkaJS and librdkafka, none of which fail a consumer over a leaderless partition. Note
+  that `:commit_interval` is a deadline checked at the end of a fetch cycle, not a timer, so a
+  backoff stretches the interval between commits.
+
 * **The acks option reaches the broker again (regression since 1.0).** 0.x translated
   `required_acks` onto the wire in the legacy adapter; that adapter was removed in the 1.0 rewrite
   and the translation went with it, while `KafkaEx.API.produce/5` kept documenting the option. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@
   consumer now retries such errors indefinitely with jittered exponential backoff (500 ms to 5 s,
   configurable via `:fetch_retry_base_delay_ms` / `:fetch_retry_max_delay_ms`), logging a warning
   with the error and the consecutive failure count, and still stops on anything else. This matches
-  brod, KafkaJS and librdkafka, none of which fail a consumer over a leaderless partition. Note
-  that `:commit_interval` is a deadline checked at the end of a fetch cycle, not a timer, so a
-  backoff stretches the interval between commits.
+  brod, KafkaJS and librdkafka, none of which fail a consumer over a leaderless partition. The same
+  backoff covers a failed `:offset_out_of_range` reset, which needs a live leader of its own and
+  previously raised a `MatchError`. It does **not** cover establishing the starting offset at
+  startup — `load_offsets/1` still raises if that cannot be read, so a consumer starting while its
+  leader moves still fails to start. Note that `:commit_interval` is a deadline checked at the end
+  of a fetch cycle, not a timer, so a backoff stretches the interval between commits.
 
 * **`:no_broker` says why in the log.** Three different causes — unknown topic, unknown partition,
   unknown node — all surfaced as the same bare `:no_broker`, so a leaderless partition could not be

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -766,8 +766,16 @@ defmodule KafkaEx.API do
     * `messages` - List of message maps with `:value`, optional `:key`, `:timestamp`, `:headers`
     * `opts` - Options including:
       * `:api_version` - API version to use. If omitted, resolved via `:api_versions` app-config or broker-negotiated max (`min(broker_max, kayrock_max)`). See CHANGELOG § 3-tier API version resolution.
-      * `:required_acks` - Number of acks required (default: 1)
-      * `:timeout` - Request timeout
+      * `:acks` - Acknowledgements required: `-1` (default) all in-sync replicas, `1` leader only,
+        `0` fire-and-forget. Any other value is rejected with `{:error, :invalid_acks}`.
+        With `0` the broker sends no response at all, so `{:ok, _}` means only that the batch was
+        handed to the socket, the call is never retried, the returned `RecordMetadata` has
+        `base_offset: nil`, and a broker-side rejection (stale leader, oversized batch) arrives as
+        a closed connection — records produced before the client notices are lost.
+      * `:required_acks` - Deprecated alias for `:acks`, honoured only when `:acks` is absent.
+        Will be removed in 2.0.
+      * `:timeout` - How long the broker waits for the required acknowledgements, in ms
+        (default 5000). Only has an effect with `acks: -1`.
       * `:partitioner` - Custom partitioner module (default: configured or `KafkaEx.Producer.Partitioner.Default`)
 
   ## Partitioning

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -371,9 +371,6 @@ defmodule KafkaEx.Client do
     {:noreply, state_out}
   end
 
-  # A broker rejecting an acks=0 produce answers by resetting the connection, so a socket error
-  # is a normal signal here, not an exotic one.
-  # The telemetry contract fixes reason to a known atom, so the raw term goes to the log instead.
   def handle_info({:tcp_error, socket, reason}, state) do
     {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
   end
@@ -382,10 +379,8 @@ defmodule KafkaEx.Client do
     {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
   end
 
-  # Defining any handle_info/2 replaces the catch-all `use GenServer` injects, and without one
-  # an unmatched message kills the client. Stray active-mode data ({:tcp, _, _} / {:ssl, _, _}) —
-  # e.g. a late reply on an acks=0 socket the broker never should have sent — is dropped here on
-  # purpose, not buffered.
+  # Defining any handle_info/2 replaces the catch-all use GenServer injects; without one an
+  # unmatched message would crash the client.
   def handle_info(message, state) do
     Logger.warning("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
     {:noreply, state}
@@ -633,9 +628,7 @@ defmodule KafkaEx.Client do
     end
   end
 
-  # :required_acks is the deprecated spelling of :acks, kept working until 2.0. Anything the
-  # broker rejects is caught here: unvalidated, it reaches Kayrock's int16 encoder and an
-  # exception there takes the whole client down.
+  # Reject a bad acks value here; unvalidated it reaches Kayrock's int16 encoder and crashes the client.
   defp resolve_acks(opts) do
     case Keyword.get(opts, :acks, Keyword.get(opts, :required_acks, -1)) do
       acks when acks in [-1, 0, 1] -> {:ok, acks}
@@ -934,8 +927,8 @@ defmodule KafkaEx.Client do
   end
 
   defp build_transport_error(reason) when is_atom(reason), do: Error.build(reason, %{})
-  # A non-atom reason (SSL `{:tls_alert, _}` etc.) would collapse to :unknown, which the consumer
-  # fetch loop treats as fatal and stops — taking the whole group down. Tag it retryable instead.
+  # A non-atom reason (SSL {:tls_alert, _}) would collapse to :unknown, which the fetch loop treats
+  # as fatal; tag it retryable instead.
   defp build_transport_error(reason), do: Error.build(:transport_error, %{transport_reason: reason})
 
   defp handle_request_error(%RequestContext{} = ctx, state, retry_count, error) do
@@ -1135,9 +1128,7 @@ defmodule KafkaEx.Client do
 
         case State.select_broker(updated_state, selector) do
           {:error, reason} ->
-            # :no_broker alone cannot tell a missing topic from a leaderless partition from an
-            # unknown node, so name the reason. Debug, not warning: the consumer's fetch loop
-            # retries this same lookup and owns the throttled operator-facing log.
+            # Debug, not warning: the consumer's fetch loop retries this lookup and owns the throttled log.
             Logger.debug("No broker for #{describe_selector(selector)} after metadata refresh: #{inspect(reason)}")
 
             {nil, updated_state}

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -26,6 +26,7 @@ defmodule KafkaEx.Client do
   alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Messages.Fetch
   alias KafkaEx.Messages.FindCoordinator, as: FindCoordinatorMsg
+  alias KafkaEx.Messages.RecordMetadata
   alias KafkaEx.Support.OptionalDeps
   alias KafkaEx.Support.Retry
 
@@ -370,6 +371,23 @@ defmodule KafkaEx.Client do
     {:noreply, state_out}
   end
 
+  # A broker rejecting an acks=0 produce answers by resetting the connection, so a socket error
+  # is a normal signal here, not an exotic one.
+  def handle_info({:tcp_error, socket, reason}, state) do
+    {:noreply, close_broker_by_socket(state, socket, reason)}
+  end
+
+  def handle_info({:ssl_error, socket, reason}, state) do
+    {:noreply, close_broker_by_socket(state, socket, reason)}
+  end
+
+  # Defining any handle_info/2 replaces the catch-all `use GenServer` injects, and without one
+  # an unmatched message kills the client.
+  def handle_info(message, state) do
+    Logger.debug("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
   defp update_metadata_with_retry(_state, retries_left) when retries_left <= 0 do
     raise KafkaEx.MetadataUpdateError, attempts: @max_metadata_update_retries
   end
@@ -588,16 +606,14 @@ defmodule KafkaEx.Client do
   end
 
   defp produce_request(topic, partition, messages, opts, state) do
-    message_count = length(messages)
-    required_acks = Keyword.get(opts, :required_acks, 1)
-    client_id = Config.client_id()
+    with {:ok, acks} <- resolve_acks(opts) do
+      metadata = Telemetry.produce_metadata(topic, partition, Config.client_id(), acks)
+      start_measurements = %{message_count: length(messages)}
 
-    metadata = Telemetry.produce_metadata(topic, partition, client_id, required_acks)
-    start_measurements = %{message_count: message_count}
-
-    Telemetry.span([:kafka_ex, :produce], Map.merge(metadata, start_measurements), fn ->
-      do_produce_request(topic, partition, messages, opts, state, metadata)
-    end)
+      Telemetry.span([:kafka_ex, :produce], Map.merge(metadata, start_measurements), fn ->
+        do_produce_request(topic, partition, messages, Keyword.put(opts, :acks, acks), state, metadata)
+      end)
+    end
   end
 
   defp do_produce_request(topic, partition, messages, opts, state, metadata) do
@@ -611,6 +627,16 @@ defmodule KafkaEx.Client do
     else
       {:error, error} -> {{:error, error}, metadata}
       error_result -> {error_result, metadata}
+    end
+  end
+
+  # :required_acks is the deprecated spelling of :acks, kept working until 2.0. Anything the
+  # broker rejects is caught here: unvalidated, it reaches Kayrock's int16 encoder and an
+  # exception there takes the whole client down.
+  defp resolve_acks(opts) do
+    case Keyword.get(opts, :acks, Keyword.get(opts, :required_acks, -1)) do
+      acks when acks in [-1, 0, 1] -> {:ok, acks}
+      _ -> {:error, :invalid_acks}
     end
   end
 
@@ -790,6 +816,20 @@ defmodule KafkaEx.Client do
       retryable?: &Retry.sync_group_retryable?/1
     }
     |> handle_request_with_retry(state)
+  end
+
+  # acks=0: the broker sends no response, and a resend would duplicate records.
+  defp handle_produce_request(%{acks: 0} = request, node_selector, state) do
+    %NodeSelector{topic: topic, partition: partition} = node_selector
+
+    case network_request(request, node_selector, state) do
+      {{:ok, :no_response}, updated_state} ->
+        {{:ok, RecordMetadata.build(topic: topic, partition: partition, base_offset: nil)}, updated_state}
+
+      {{:error, reason}, updated_state} ->
+        Logger.warning("Fire-and-forget produce to #{topic}/#{partition} failed with #{inspect(reason)}")
+        {{:error, build_transport_error(reason)}, updated_state}
+    end
   end
 
   defp handle_produce_request(request, node_selector, state) do
@@ -1328,6 +1368,9 @@ defmodule KafkaEx.Client do
       case send_request.(wire_request) do
         {{:error, reason}, broker} ->
           {{:error, reason}, 0, broker_to_telemetry_info(broker)}
+
+        {:ok, broker} ->
+          {{:ok, :no_response}, 0, broker_to_telemetry_info(broker)}
 
         {data, broker} when synchronous ->
           {deserialize(data, client_request), byte_size(data), broker_to_telemetry_info(broker)}

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -383,7 +383,9 @@ defmodule KafkaEx.Client do
   end
 
   # Defining any handle_info/2 replaces the catch-all `use GenServer` injects, and without one
-  # an unmatched message kills the client.
+  # an unmatched message kills the client. Stray active-mode data ({:tcp, _, _} / {:ssl, _, _}) —
+  # e.g. a late reply on an acks=0 socket the broker never should have sent — is dropped here on
+  # purpose, not buffered.
   def handle_info(message, state) do
     Logger.warning("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
     {:noreply, state}
@@ -932,7 +934,9 @@ defmodule KafkaEx.Client do
   end
 
   defp build_transport_error(reason) when is_atom(reason), do: Error.build(reason, %{})
-  defp build_transport_error(reason), do: Error.build(:unknown, %{transport_reason: reason})
+  # A non-atom reason (SSL `{:tls_alert, _}` etc.) would collapse to :unknown, which the consumer
+  # fetch loop treats as fatal and stops — taking the whole group down. Tag it retryable instead.
+  defp build_transport_error(reason), do: Error.build(:transport_error, %{transport_reason: reason})
 
   defp handle_request_error(%RequestContext{} = ctx, state, retry_count, error) do
     request_name = ctx.request.__struct__
@@ -1131,9 +1135,10 @@ defmodule KafkaEx.Client do
 
         case State.select_broker(updated_state, selector) do
           {:error, reason} ->
-            # :no_broker alone cannot tell a missing topic from a leaderless
-            # partition from an unknown node, so name the reason here.
-            Logger.warning("No broker for #{describe_selector(selector)} after metadata refresh: #{inspect(reason)}")
+            # :no_broker alone cannot tell a missing topic from a leaderless partition from an
+            # unknown node, so name the reason. Debug, not warning: the consumer's fetch loop
+            # retries this same lookup and owns the throttled operator-facing log.
+            Logger.debug("No broker for #{describe_selector(selector)} after metadata refresh: #{inspect(reason)}")
 
             {nil, updated_state}
 

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -373,12 +373,13 @@ defmodule KafkaEx.Client do
 
   # A broker rejecting an acks=0 produce answers by resetting the connection, so a socket error
   # is a normal signal here, not an exotic one.
+  # The telemetry contract fixes reason to a known atom, so the raw term goes to the log instead.
   def handle_info({:tcp_error, socket, reason}, state) do
-    {:noreply, close_broker_by_socket(state, socket, reason)}
+    {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
   end
 
   def handle_info({:ssl_error, socket, reason}, state) do
-    {:noreply, close_broker_by_socket(state, socket, reason)}
+    {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
   end
 
   # Defining any handle_info/2 replaces the catch-all `use GenServer` injects, and without one
@@ -1485,10 +1486,10 @@ defmodule KafkaEx.Client do
     {topic_metadata, %{updated_state | allow_auto_topic_creation: allow_auto_topic_creation}}
   end
 
-  defp close_broker_by_socket(state, socket, reason \\ :remote_closed) do
+  defp close_broker_by_socket(state, socket, reason \\ :remote_closed, detail \\ nil) do
     State.update_brokers(state, fn broker ->
       if Broker.has_socket?(broker, socket) do
-        Logger.debug("#{Broker.to_string(broker)} closed connection")
+        log_connection_close(broker, detail)
         # Socket is already closed (received :tcp_closed/:ssl_closed), just emit telemetry
         NetworkClient.close_socket(broker, socket, reason)
         Broker.put_socket(broker, nil)
@@ -1497,4 +1498,9 @@ defmodule KafkaEx.Client do
       end
     end)
   end
+
+  defp log_connection_close(broker, nil), do: Logger.debug("#{Broker.to_string(broker)} closed connection")
+
+  defp log_connection_close(broker, detail),
+    do: Logger.warning("#{Broker.to_string(broker)} closed connection: #{inspect(detail)}")
 end

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -384,7 +384,7 @@ defmodule KafkaEx.Client do
   # Defining any handle_info/2 replaces the catch-all `use GenServer` injects, and without one
   # an unmatched message kills the client.
   def handle_info(message, state) do
-    Logger.debug("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
+    Logger.warning("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
     {:noreply, state}
   end
 

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -1130,14 +1130,27 @@ defmodule KafkaEx.Client do
         updated_state = state_updater.(state)
 
         case State.select_broker(updated_state, selector) do
-          {:error, _} -> {nil, updated_state}
-          {:ok, broker} -> ensure_broker_connected(broker, updated_state)
+          {:error, reason} ->
+            # :no_broker alone cannot tell a missing topic from a leaderless
+            # partition from an unknown node, so name the reason here.
+            Logger.warning("No broker for #{describe_selector(selector)} after metadata refresh: #{inspect(reason)}")
+
+            {nil, updated_state}
+
+          {:ok, broker} ->
+            ensure_broker_connected(broker, updated_state)
         end
 
       {:ok, broker} ->
         ensure_broker_connected(broker, state)
     end
   end
+
+  defp describe_selector(%NodeSelector{strategy: :topic_partition, topic: topic, partition: partition}),
+    do: "#{topic}/#{partition}"
+
+  defp describe_selector(%NodeSelector{strategy: :consumer_group, consumer_group_name: group}),
+    do: "consumer group #{group}"
 
   # Ensures broker is connected, reconnecting if necessary.
   # Returns {broker, updated_state} where broker may have a new socket,

--- a/lib/kafka_ex/cluster/cluster_metadata.ex
+++ b/lib/kafka_ex/cluster/cluster_metadata.ex
@@ -23,7 +23,8 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
   @typedoc """
   Possible errors given by `select_node/2`
   """
-  @type node_select_error :: :no_such_node | :no_such_topic | :no_such_partition | :no_such_consumer_group
+  @type node_select_error ::
+          :no_such_node | :no_such_topic | :no_such_partition | :no_such_consumer_group | :leader_not_available
 
   @doc """
   List names of topics known by the cluster metadata
@@ -78,6 +79,7 @@ defmodule KafkaEx.Cluster.ClusterMetadata do
       {:ok, %Topic{partition_leaders: partition_leaders}} ->
         case Map.fetch(partition_leaders, partition) do
           :error -> {:error, :no_such_partition}
+          {:ok, node_id} when node_id < 0 -> {:error, :leader_not_available}
           {:ok, node_id} -> {:ok, node_id}
         end
     end

--- a/lib/kafka_ex/cluster/partition_info.ex
+++ b/lib/kafka_ex/cluster/partition_info.ex
@@ -8,13 +8,17 @@ defmodule KafkaEx.Cluster.PartitionInfo do
   Java equivalent: `org.apache.kafka.common.PartitionInfo`
   """
 
-  defstruct partition_id: nil, leader: -1, replicas: [], isr: []
+  alias Kayrock.ErrorCode
+
+  # Informational only: node selection keys off `leader` (< 0 = no leader), not this field.
+  defstruct partition_id: nil, leader: -1, replicas: [], isr: [], error_code: :no_error
 
   @type t :: %__MODULE__{
           partition_id: integer(),
           leader: integer(),
           replicas: [integer()],
-          isr: [integer()]
+          isr: [integer()],
+          error_code: atom()
         }
 
   @doc """
@@ -23,7 +27,8 @@ defmodule KafkaEx.Cluster.PartitionInfo do
   ## Parameters
 
   The metadata map should contain:
-    - `:error_code` - Must be 0 for successful parsing
+    - `:error_code` - The broker's partition error code (0 = no error), retained as-is. Unlike the
+      production `parse_partitions/1`, this constructor applies no error-code whitelist
     - `:partition` - The partition number
     - `:leader` - The leader node ID
     - `:replicas` - List of replica node IDs
@@ -32,7 +37,7 @@ defmodule KafkaEx.Cluster.PartitionInfo do
   """
   @spec from_partition_metadata(map()) :: t()
   def from_partition_metadata(%{
-        error_code: 0,
+        error_code: error_code,
         partition_index: partition,
         leader_id: leader,
         replica_nodes: replicas,
@@ -42,7 +47,8 @@ defmodule KafkaEx.Cluster.PartitionInfo do
       partition_id: partition,
       leader: leader,
       replicas: replicas,
-      isr: isr
+      isr: isr,
+      error_code: ErrorCode.code_to_atom(error_code)
     }
   end
 

--- a/lib/kafka_ex/cluster/topic.ex
+++ b/lib/kafka_ex/cluster/topic.ex
@@ -23,16 +23,13 @@ defmodule KafkaEx.Cluster.Topic do
         partitions: partition_metadata,
         is_internal: is_internal
       }) do
-    partition_leaders =
-      Enum.into(
-        partition_metadata,
-        %{},
-        fn %{error_code: 0, leader_id: leader, partition_index: partition_id} ->
-          {partition_id, leader}
-        end
-      )
-
     partitions = Enum.map(partition_metadata, &PartitionInfo.from_partition_metadata/1)
+
+    # Keep leaderless partitions (leader -1); dropping them shrinks the count the partitioner keys off.
+    partition_leaders =
+      Enum.into(partitions, %{}, fn %PartitionInfo{partition_id: id, leader: leader} ->
+        {id, leader}
+      end)
 
     %__MODULE__{
       name: name,

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -126,9 +126,15 @@ defmodule KafkaEx.Consumer.GenConsumer do
   `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`. Retries are
   unbounded, matching brod, KafkaJS and librdkafka, with jittered exponential
   backoff from `:fetch_retry_base_delay_ms` (500) to `:fetch_retry_max_delay_ms`
-  (5000), both settable in the `:kafka_ex` app environment. Every retry logs a
-  warning naming the error and the consecutive failure count. Any other fetch
-  error still stops the consumer.
+  (5000), both settable in the `:kafka_ex` app environment. A warning naming the
+  error and the consecutive failure count is logged while the backoff ramps, then
+  roughly once a minute. Any other fetch error still stops the consumer.
+
+  The same backoff covers a failed `:offset_out_of_range` reset, which needs a
+  live leader of its own. It does **not** cover establishing the starting offset
+  at startup: `load_offsets/1` still raises if the committed offset or the reset
+  offset cannot be read, so a consumer that starts while its leader is moving
+  still fails to start.
 
   ## Handler state and interaction
 
@@ -875,8 +881,10 @@ defmodule KafkaEx.Consumer.GenConsumer do
         handle_new_fetch_response(fetch_result, clear_fetch_errors(state))
 
       {:error, :offset_out_of_range} ->
-        new_state = handle_offset_out_of_range(clear_fetch_errors(state))
-        handle_commit(:async_commit, new_state)
+        case handle_offset_out_of_range(clear_fetch_errors(state)) do
+          {:ok, new_state} -> handle_commit(:async_commit, new_state)
+          {:error, reason} -> {:error, reason, state}
+        end
 
       {:error, reason} ->
         {:error, reason, state}
@@ -900,10 +908,12 @@ defmodule KafkaEx.Consumer.GenConsumer do
     if Retry.fetch_retryable?(reason) do
       delay = Retry.backoff_delay_jittered(count, fetch_retry_base_delay_ms(), fetch_retry_max_delay_ms())
 
-      Logger.warning(
-        "Fetch failed for #{state.topic}/#{state.partition} with #{inspect(reason)}, " <>
-          "retrying in #{delay}ms (consecutive failures: #{count + 1})"
-      )
+      if log_fetch_retry?(count) do
+        Logger.warning(
+          "Fetch failed for #{state.topic}/#{state.partition} with #{inspect(reason)}, " <>
+            "retrying in #{delay}ms (consecutive failures: #{count + 1})"
+        )
+      end
 
       new_state = %State{
         state
@@ -916,6 +926,10 @@ defmodule KafkaEx.Consumer.GenConsumer do
       {:stop, reason, state}
     end
   end
+
+  # Loud while the backoff ramps, then roughly once a minute at the cap, so a
+  # permanently unavailable partition stays visible without flooding the log.
+  defp log_fetch_retry?(count), do: count < 5 or rem(count, 12) == 0
 
   defp fetch_backoff_remaining(%State{fetch_retry_at: nil}), do: 0
 
@@ -995,29 +1009,30 @@ defmodule KafkaEx.Consumer.GenConsumer do
            auto_offset_reset: auto_offset_reset
          } = state
        ) do
-    offset =
-      case auto_offset_reset do
-        :earliest ->
-          {:ok, offset} = KafkaExAPI.earliest_offset(client, topic, partition)
-          offset
+    # The reset needs a live leader too, so it fails exactly when a leader is
+    # moving. Hand that back rather than letting a MatchError kill the group.
+    case reset_offset(client, topic, partition, auto_offset_reset) do
+      {:ok, offset} ->
+        report_offset_reset(state, auto_offset_reset, offset, :offset_out_of_range)
 
-        :latest ->
-          {:ok, offset} = KafkaExAPI.latest_offset(client, topic, partition)
-          offset
+        {:ok,
+         %State{
+           state
+           | current_offset: offset,
+             committed_offset: offset,
+             acked_offset: offset
+         }}
 
-        :none ->
-          raise "Offset out of range while consuming topic #{topic}, partition #{partition}."
-      end
-
-    report_offset_reset(state, auto_offset_reset, offset, :offset_out_of_range)
-
-    %State{
-      state
-      | current_offset: offset,
-        committed_offset: offset,
-        acked_offset: offset
-    }
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
+
+  defp reset_offset(client, topic, partition, :earliest), do: KafkaExAPI.earliest_offset(client, topic, partition)
+  defp reset_offset(client, topic, partition, :latest), do: KafkaExAPI.latest_offset(client, topic, partition)
+
+  defp reset_offset(_client, topic, partition, :none),
+    do: raise("Offset out of range while consuming topic #{topic}, partition #{partition}.")
 
   defp handle_commit(:sync_commit, %State{} = state), do: commit(state)
 

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -509,16 +509,11 @@ defmodule KafkaEx.Consumer.GenConsumer do
   @commit_max_attempts 3
   @commit_base_delay_ms 100
 
-  # Capped near librdkafka's retry.backoff.max.ms (1s) and brod's flat 1s rather
-  # than KafkaJS's 30s: a leader move is usually sub-second, so a high cap only
-  # delays noticing recovery. Jittered because a broker restart fails every
-  # partition it led at the same instant.
+  # Low cap — a leader move is usually sub-second; jittered against a synchronized restart.
   @fetch_retry_base_delay_ms 500
   @fetch_retry_max_delay_ms 5_000
 
-  # Retries stay unbounded (as in brod/Java/librdkafka), but after this long of continuous fetch
-  # failure the partition is clearly not just mid-leader-move — surface it once. Mirrors
-  # librdkafka's topic.metadata.propagation.max.ms default.
+  # After this long of continuous failure a partition is clearly stuck, not mid-move; surface it once.
   @fetch_unavailable_warn_ms 30_000
 
   # Client API
@@ -817,8 +812,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
   end
 
   def handle_info(:timeout, %State{} = state) do
-    # Any inbound message re-arms this callback with timeout 0, so an unrelated
-    # message would otherwise cut a backoff short. The deadline is the truth.
+    # Any inbound message re-arms this at timeout 0, so honour the backoff deadline held in state.
     case fetch_backoff_remaining(state) do
       0 -> consume_cycle(state)
       remaining -> {:noreply, state, remaining}
@@ -949,8 +943,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
     end
   end
 
-  # Retries never stop the consumer, so a partition that is genuinely stuck (missing topic, leader
-  # that never returns) would otherwise only ever show up in logs. Surface it once via telemetry.
+  # Retries never stop, so a genuinely stuck partition would otherwise only show in logs; flag it once.
   defp maybe_report_unavailable(%State{fetch_unavailable_reported: true} = state, _reason, _elapsed), do: state
 
   defp maybe_report_unavailable(%State{} = state, reason, elapsed) do
@@ -967,8 +960,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
     end
   end
 
-  # Loud while the backoff ramps, then roughly once a minute at the cap, so a
-  # permanently unavailable partition stays visible without flooding the log.
+  # Loud while the backoff ramps, then ~once a minute, so a stuck partition stays visible.
   defp log_fetch_retry?(count), do: count < 5 or rem(count, 12) == 0
 
   defp fetch_backoff_remaining(%State{fetch_retry_at: nil}), do: 0

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -130,6 +130,14 @@ defmodule KafkaEx.Consumer.GenConsumer do
   error and the consecutive failure count is logged while the backoff ramps, then
   roughly once a minute. Any other fetch error still stops the consumer.
 
+  Retries never give up, so a partition that is not merely mid-leader-move but genuinely stuck (a
+  deleted topic, a leader that never returns) is surfaced once, after
+  `:fetch_unavailable_warn_ms` (default 30000, settable in the `:kafka_ex` app environment) of
+  continuous failure, as a `Logger.error` and a `[:kafka_ex, :consumer, :partition_unavailable]`
+  telemetry event. The consumer keeps retrying; the signal just makes a non-recovering partition
+  alertable without a human reading the logs. This mirrors librdkafka's
+  `topic.metadata.propagation.max.ms`.
+
   The same backoff covers a failed `:offset_out_of_range` reset, which needs a
   live leader of its own. It does **not** cover establishing the starting offset
   at startup: `load_offsets/1` still raises if the committed offset or the reset
@@ -461,7 +469,9 @@ defmodule KafkaEx.Consumer.GenConsumer do
       :api_versions,
       :group_manager_pid,
       :fetch_retry_at,
-      fetch_error_count: 0
+      :fetch_failing_since,
+      fetch_error_count: 0,
+      fetch_unavailable_reported: false
     ]
 
     @type t :: %__MODULE__{
@@ -484,7 +494,9 @@ defmodule KafkaEx.Consumer.GenConsumer do
             api_versions: map(),
             group_manager_pid: pid() | nil,
             fetch_retry_at: integer() | nil,
-            fetch_error_count: non_neg_integer()
+            fetch_failing_since: integer() | nil,
+            fetch_error_count: non_neg_integer(),
+            fetch_unavailable_reported: boolean()
           }
   end
 
@@ -503,6 +515,11 @@ defmodule KafkaEx.Consumer.GenConsumer do
   # partition it led at the same instant.
   @fetch_retry_base_delay_ms 500
   @fetch_retry_max_delay_ms 5_000
+
+  # Retries stay unbounded (as in brod/Java/librdkafka), but after this long of continuous fetch
+  # failure the partition is clearly not just mid-leader-move — surface it once. Mirrors
+  # librdkafka's topic.metadata.propagation.max.ms default.
+  @fetch_unavailable_warn_ms 30_000
 
   # Client API
 
@@ -906,6 +923,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   defp handle_fetch_error(reason, %State{fetch_error_count: count} = state) do
     if Retry.fetch_retryable?(reason) do
+      now = :erlang.monotonic_time(:milli_seconds)
+      failing_since = state.fetch_failing_since || now
       delay = Retry.backoff_delay_jittered(count, fetch_retry_base_delay_ms(), fetch_retry_max_delay_ms())
 
       if log_fetch_retry?(count) do
@@ -915,15 +934,36 @@ defmodule KafkaEx.Consumer.GenConsumer do
         )
       end
 
-      new_state = %State{
-        state
-        | fetch_error_count: count + 1,
-          fetch_retry_at: :erlang.monotonic_time(:milli_seconds) + delay
-      }
+      new_state =
+        %State{
+          state
+          | fetch_error_count: count + 1,
+            fetch_retry_at: now + delay,
+            fetch_failing_since: failing_since
+        }
+        |> maybe_report_unavailable(reason, now - failing_since)
 
       {:noreply, new_state, delay}
     else
       {:stop, reason, state}
+    end
+  end
+
+  # Retries never stop the consumer, so a partition that is genuinely stuck (missing topic, leader
+  # that never returns) would otherwise only ever show up in logs. Surface it once via telemetry.
+  defp maybe_report_unavailable(%State{fetch_unavailable_reported: true} = state, _reason, _elapsed), do: state
+
+  defp maybe_report_unavailable(%State{} = state, reason, elapsed) do
+    if elapsed >= fetch_unavailable_warn_ms() do
+      Logger.error(
+        "Partition #{state.topic}/#{state.partition} has been unavailable for #{elapsed}ms " <>
+          "(#{inspect(reason)}); still retrying"
+      )
+
+      Telemetry.emit_partition_unavailable(state.group, state.topic, state.partition, elapsed, reason)
+      %State{state | fetch_unavailable_reported: true}
+    else
+      state
     end
   end
 
@@ -936,14 +976,26 @@ defmodule KafkaEx.Consumer.GenConsumer do
   defp fetch_backoff_remaining(%State{fetch_retry_at: retry_at}),
     do: max(retry_at - :erlang.monotonic_time(:milli_seconds), 0)
 
-  defp clear_fetch_errors(%State{fetch_error_count: 0, fetch_retry_at: nil} = state), do: state
-  defp clear_fetch_errors(%State{} = state), do: %{state | fetch_error_count: 0, fetch_retry_at: nil}
+  defp clear_fetch_errors(%State{fetch_error_count: 0, fetch_retry_at: nil, fetch_failing_since: nil} = state),
+    do: state
+
+  defp clear_fetch_errors(%State{} = state),
+    do: %{
+      state
+      | fetch_error_count: 0,
+        fetch_retry_at: nil,
+        fetch_failing_since: nil,
+        fetch_unavailable_reported: false
+    }
 
   defp fetch_retry_base_delay_ms,
     do: Application.get_env(:kafka_ex, :fetch_retry_base_delay_ms, @fetch_retry_base_delay_ms)
 
   defp fetch_retry_max_delay_ms,
     do: Application.get_env(:kafka_ex, :fetch_retry_max_delay_ms, @fetch_retry_max_delay_ms)
+
+  defp fetch_unavailable_warn_ms,
+    do: Application.get_env(:kafka_ex, :fetch_unavailable_warn_ms, @fetch_unavailable_warn_ms)
 
   # The broker returned batches but every record was filtered out (control
   # batches — transaction commit/abort markers). Advance past them to next_offset, otherwise the

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -91,7 +91,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   * `:commit_interval` is the maximum time (in milliseconds) that a
     `KafkaEx.Consumer.GenConsumer` will delay committing the offset for an acknowledged
-    message.
+    message. The interval is a deadline checked at the end of a fetch cycle, not a
+    timer, so a fetch backoff (see *Fetch failure handling*) stretches it.
 
   * `:commit_threshold` is the maximum number of acknowledged messages that a
     `KafkaEx.Consumer.GenConsumer` will allow to be uncommitted before triggering a
@@ -115,6 +116,19 @@ defmodule KafkaEx.Consumer.GenConsumer do
   For low-volume topics, `:commit_interval` is the dominant factor for how
   often a `KafkaEx.Consumer.GenConsumer` auto-commits. For high-volume topics,
   `:commit_threshold` is the dominant factor.
+
+  ## Fetch failure handling
+
+  A fetch error that `KafkaEx.Support.Retry.fetch_retryable?/1` accepts — a leader
+  move (`:not_leader_for_partition`, `:leader_not_available`), `:no_broker`, a
+  closed socket, a timeout — makes the consumer back off and retry rather than
+  stop. Stopping would take the whole group down, because
+  `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`. Retries are
+  unbounded, matching brod, KafkaJS and librdkafka, with jittered exponential
+  backoff from `:fetch_retry_base_delay_ms` (500) to `:fetch_retry_max_delay_ms`
+  (5000), both settable in the `:kafka_ex` app environment. Every retry logs a
+  warning naming the error and the consecutive failure count. Any other fetch
+  error still stops the consumer.
 
   ## Handler state and interaction
 
@@ -439,7 +453,9 @@ defmodule KafkaEx.Consumer.GenConsumer do
       :auto_offset_reset,
       :fetch_options,
       :api_versions,
-      :group_manager_pid
+      :group_manager_pid,
+      :fetch_retry_at,
+      fetch_error_count: 0
     ]
 
     @type t :: %__MODULE__{
@@ -460,7 +476,9 @@ defmodule KafkaEx.Consumer.GenConsumer do
             auto_offset_reset: :none | :earliest | :latest,
             fetch_options: Keyword.t(),
             api_versions: map(),
-            group_manager_pid: pid() | nil
+            group_manager_pid: pid() | nil,
+            fetch_retry_at: integer() | nil,
+            fetch_error_count: non_neg_integer()
           }
   end
 
@@ -472,6 +490,13 @@ defmodule KafkaEx.Consumer.GenConsumer do
   # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff
   @commit_max_attempts 3
   @commit_base_delay_ms 100
+
+  # Capped near librdkafka's retry.backoff.max.ms (1s) and brod's flat 1s rather
+  # than KafkaJS's 30s: a leader move is usually sub-second, so a high cap only
+  # delays noticing recovery. Jittered because a broker restart fails every
+  # partition it led at the same instant.
+  @fetch_retry_base_delay_ms 500
+  @fetch_retry_max_delay_ms 5_000
 
   # Client API
 
@@ -769,15 +794,11 @@ defmodule KafkaEx.Consumer.GenConsumer do
   end
 
   def handle_info(:timeout, %State{} = state) do
-    case consume(state) do
-      {:error, reason} ->
-        {:stop, reason, state}
-
-      {:noreply, new_state} ->
-        {:noreply, new_state, 0}
-
-      {:stop, _reason, _final_state} = stop ->
-        stop
+    # Any inbound message re-arms this callback with timeout 0, so an unrelated
+    # message would otherwise cut a backoff short. The deadline is the truth.
+    case fetch_backoff_remaining(state) do
+      0 -> consume_cycle(state)
+      remaining -> {:noreply, state, remaining}
     end
   end
 
@@ -851,16 +872,64 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
     case KafkaExAPI.fetch(client, topic, partition, offset, fetch_opts) do
       {:ok, fetch_result} ->
-        handle_new_fetch_response(fetch_result, state)
+        handle_new_fetch_response(fetch_result, clear_fetch_errors(state))
 
       {:error, :offset_out_of_range} ->
-        new_state = handle_offset_out_of_range(state)
+        new_state = handle_offset_out_of_range(clear_fetch_errors(state))
         handle_commit(:async_commit, new_state)
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, reason, state}
     end
   end
+
+  defp consume_cycle(%State{} = state) do
+    case consume(state) do
+      {:error, reason, new_state} ->
+        handle_fetch_error(reason, new_state)
+
+      {:noreply, new_state} ->
+        {:noreply, new_state, 0}
+
+      {:stop, _reason, _final_state} = stop ->
+        stop
+    end
+  end
+
+  defp handle_fetch_error(reason, %State{fetch_error_count: count} = state) do
+    if Retry.fetch_retryable?(reason) do
+      delay = Retry.backoff_delay_jittered(count, fetch_retry_base_delay_ms(), fetch_retry_max_delay_ms())
+
+      Logger.warning(
+        "Fetch failed for #{state.topic}/#{state.partition} with #{inspect(reason)}, " <>
+          "retrying in #{delay}ms (consecutive failures: #{count + 1})"
+      )
+
+      new_state = %State{
+        state
+        | fetch_error_count: count + 1,
+          fetch_retry_at: :erlang.monotonic_time(:milli_seconds) + delay
+      }
+
+      {:noreply, new_state, delay}
+    else
+      {:stop, reason, state}
+    end
+  end
+
+  defp fetch_backoff_remaining(%State{fetch_retry_at: nil}), do: 0
+
+  defp fetch_backoff_remaining(%State{fetch_retry_at: retry_at}),
+    do: max(retry_at - :erlang.monotonic_time(:milli_seconds), 0)
+
+  defp clear_fetch_errors(%State{fetch_error_count: 0, fetch_retry_at: nil} = state), do: state
+  defp clear_fetch_errors(%State{} = state), do: %{state | fetch_error_count: 0, fetch_retry_at: nil}
+
+  defp fetch_retry_base_delay_ms,
+    do: Application.get_env(:kafka_ex, :fetch_retry_base_delay_ms, @fetch_retry_base_delay_ms)
+
+  defp fetch_retry_max_delay_ms,
+    do: Application.get_env(:kafka_ex, :fetch_retry_max_delay_ms, @fetch_retry_max_delay_ms)
 
   # The broker returned batches but every record was filtered out (control
   # batches — transaction commit/abort markers). Advance past them to next_offset, otherwise the

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -125,7 +125,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
   stop. Stopping would take the whole group down, because
   `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`. Retries are
   unbounded, matching brod, KafkaJS and librdkafka, with jittered exponential
-  backoff from `:fetch_retry_base_delay_ms` (500) to `:fetch_retry_max_delay_ms`
+  backoff from `:fetch_retry_base_delay_ms` (250) to `:fetch_retry_max_delay_ms`
   (5000), both settable in the `:kafka_ex` app environment. A warning naming the
   error and the consecutive failure count is logged while the backoff ramps, then
   roughly once a minute. Any other fetch error still stops the consumer.
@@ -510,7 +510,7 @@ defmodule KafkaEx.Consumer.GenConsumer do
   @commit_base_delay_ms 100
 
   # Low cap — a leader move is usually sub-second; jittered against a synchronized restart.
-  @fetch_retry_base_delay_ms 500
+  @fetch_retry_base_delay_ms 250
   @fetch_retry_max_delay_ms 5_000
 
   # After this long of continuous failure a partition is clearly stuck, not mid-move; surface it once.

--- a/lib/kafka_ex/messages/record_metadata.ex
+++ b/lib/kafka_ex/messages/record_metadata.ex
@@ -11,7 +11,8 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
     * `:topic` - The topic the messages were produced to
     * `:partition` - The partition the messages were produced to
-    * `:base_offset` - The offset assigned to the first message in the batch
+    * `:base_offset` - The offset assigned to the first message in the batch; `nil` when
+      produced with `acks: 0`, where the broker sends no response
     * `:log_append_time` - The timestamp assigned by the broker (v2+, -1 if not available)
     * `:log_start_offset` - The start offset of the log (v5+)
     * `:throttle_time_ms` - Time in ms the request was throttled (v3+)
@@ -29,7 +30,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
   @type t :: %__MODULE__{
           topic: String.t(),
           partition: non_neg_integer(),
-          base_offset: non_neg_integer(),
+          base_offset: non_neg_integer() | nil,
           log_append_time: integer() | nil,
           log_start_offset: non_neg_integer() | nil,
           throttle_time_ms: non_neg_integer() | nil
@@ -42,7 +43,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
     * `:topic` - (required) The topic name
     * `:partition` - (required) The partition number
-    * `:base_offset` - (required) The base offset assigned to the batch
+    * `:base_offset` - (required) The base offset assigned to the batch, `nil` for `acks: 0`
     * `:log_append_time` - The broker-assigned timestamp (-1 if not using LogAppendTime)
     * `:log_start_offset` - The log start offset (v5+)
     * `:throttle_time_ms` - Request throttle time in milliseconds (v3+)
@@ -64,7 +65,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
   This is an alias for `base_offset` to match Java API.
   """
-  @spec offset(t()) :: non_neg_integer()
+  @spec offset(t()) :: non_neg_integer() | nil
   def offset(%__MODULE__{base_offset: offset}), do: offset
 
   @doc """

--- a/lib/kafka_ex/network/network_client.ex
+++ b/lib/kafka_ex/network/network_client.ex
@@ -102,7 +102,9 @@ defmodule KafkaEx.Network.NetworkClient do
       {_, reason} ->
         broker_str = inspect_broker(broker.host, broker.port)
         Logger.error("Asynchronously sending data to broker #{broker_str} failed with #{inspect(reason)}")
-        close_socket(broker, socket, :send_error)
+        # Free the fd but do not emit a close event: the socket is active-mode, so the client's
+        # {:tcp_error}/{:tcp_closed} handler is the single owner of the connection-close telemetry.
+        Socket.close(socket)
         {:error, reason}
     end
   end

--- a/lib/kafka_ex/network/network_client.ex
+++ b/lib/kafka_ex/network/network_client.ex
@@ -102,7 +102,8 @@ defmodule KafkaEx.Network.NetworkClient do
       {_, reason} ->
         broker_str = inspect_broker(broker.host, broker.port)
         Logger.error("Asynchronously sending data to broker #{broker_str} failed with #{inspect(reason)}")
-        reason
+        close_socket(broker, socket, :send_error)
+        {:error, reason}
     end
   end
 

--- a/lib/kafka_ex/network/network_client.ex
+++ b/lib/kafka_ex/network/network_client.ex
@@ -102,8 +102,7 @@ defmodule KafkaEx.Network.NetworkClient do
       {_, reason} ->
         broker_str = inspect_broker(broker.host, broker.port)
         Logger.error("Asynchronously sending data to broker #{broker_str} failed with #{inspect(reason)}")
-        # Free the fd but do not emit a close event: the socket is active-mode, so the client's
-        # {:tcp_error}/{:tcp_closed} handler is the single owner of the connection-close telemetry.
+        # The client's {:tcp_error}/{:tcp_closed} handler owns the connection-close telemetry.
         Socket.close(socket)
         {:error, reason}
     end

--- a/lib/kafka_ex/protocol/kayrock/metadata/response_helpers.ex
+++ b/lib/kafka_ex/protocol/kayrock/metadata/response_helpers.ex
@@ -85,16 +85,31 @@ defmodule KafkaEx.Protocol.Kayrock.Metadata.ResponseHelpers do
   @spec parse_partitions([map()]) :: [PartitionInfo.t()]
   def parse_partitions(kayrock_partitions) when is_list(kayrock_partitions) do
     kayrock_partitions
-    |> Enum.filter(&(ErrorCode.code_to_atom(&1.error_code) == :no_error))
-    |> Enum.map(fn partition_map ->
+    |> Enum.map(&{ErrorCode.code_to_atom(&1.error_code), &1})
+    |> Enum.filter(fn {error, _} -> usable_partition?(error) end)
+    |> Enum.map(fn {error, partition_map} ->
       %PartitionInfo{
         partition_id: partition_map.partition_index,
         leader: partition_map.leader_id,
         replicas: partition_map.replica_nodes || [],
-        isr: partition_map.isr_nodes || []
+        isr: partition_map.isr_nodes || [],
+        error_code: error
       }
     end)
   end
+
+  # A partition whose leader is moving comes back with an error code and leader
+  # -1. Dropping it makes it indistinguishable from a partition that does not
+  # exist, and shrinks the partition count the partitioner keys off. Keep it and
+  # let node selection report :leader_not_available. Mirrors kpro's
+  # discover_partition_leader/4 and librdkafka's NULL broker delegation.
+  defp usable_partition?(:no_error), do: true
+  defp usable_partition?(:leader_not_available), do: true
+  defp usable_partition?(:replica_not_available), do: true
+  defp usable_partition?(:not_leader_for_partition), do: true
+  defp usable_partition?(:not_leader_or_follower), do: true
+  defp usable_partition?(:kafka_storage_error), do: true
+  defp usable_partition?(_), do: false
 
   @doc """
   Checks if the metadata response contains any errors.

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -208,6 +208,9 @@ defmodule KafkaEx.Support.Retry do
   def transient_error?(:parse_error), do: true
   def transient_error?(:closed), do: true
   def transient_error?(:no_broker), do: true
+  # A non-atom socket reason (e.g. an SSL `{:tls_alert, _}` tuple) is normalised to this by the
+  # client; a broken connection is transient, so the fetch loop must retry rather than stop.
+  def transient_error?(:transport_error), do: true
   def transient_error?(error), do: coordinator_error?(error)
 
   @doc """

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -42,6 +42,9 @@ defmodule KafkaEx.Support.Retry do
   @default_max_attempts 3
   @default_base_delay_ms 100
   @default_max_delay_ms :infinity
+  # ±20% uniform jitter on each backoff, matching Kafka's KIP-580. Decorrelates
+  # retries across many members so a shared failure does not produce a herd.
+  @jitter_fraction 0.2
 
   @doc """
   Calculate exponential backoff delay.
@@ -73,6 +76,39 @@ defmodule KafkaEx.Support.Retry do
     case max_ms do
       :infinity -> delay
       cap when is_integer(cap) -> min(delay, cap)
+    end
+  end
+
+  @doc """
+  Exponential backoff (`backoff_delay/3`) with ±20% uniform jitter (KIP-580).
+
+  Returns a delay drawn uniformly from `[0.8 × base, 1.2 × base]`, where `base` is
+  the capped exponential value, so concurrent retriers spread their re-attempts
+  instead of retrying in lockstep. A zero base stays zero.
+  """
+  @spec backoff_delay_jittered(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
+          non_neg_integer()
+  def backoff_delay_jittered(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
+    jittered =
+      attempt
+      |> backoff_delay(base_ms, max_ms)
+      |> apply_jitter()
+
+    case max_ms do
+      :infinity -> jittered
+      cap when is_integer(cap) -> min(jittered, cap)
+    end
+  end
+
+  defp apply_jitter(0), do: 0
+
+  defp apply_jitter(delay) do
+    spread = trunc(delay * @jitter_fraction)
+
+    if spread <= 0 do
+      delay
+    else
+      delay - spread + (:rand.uniform(2 * spread + 1) - 1)
     end
   end
 
@@ -183,6 +219,17 @@ defmodule KafkaEx.Support.Retry do
   def leadership_error?(:fenced_leader_epoch), do: true
   def leadership_error?(:unknown_topic_or_partition), do: true
   def leadership_error?(_), do: false
+
+  @doc """
+  Retriability for the consumer's fetch loop.
+
+  A leader move leaves the partition unreachable for as long as the new leader
+  takes to open it, so stopping the consumer would take the whole group down with
+  it. brod (`err_op/1` → `reset_connection`), KafkaJS (`retriable` errors restart
+  the consumer) and librdkafka (fast leader query) all back off and retry instead.
+  """
+  @spec fetch_retryable?(error()) :: boolean()
+  def fetch_retryable?(error), do: transient_error?(error) or leadership_error?(error)
 
   @doc """
   Check if error is safe to retry for produce operations.

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -42,8 +42,7 @@ defmodule KafkaEx.Support.Retry do
   @default_max_attempts 3
   @default_base_delay_ms 100
   @default_max_delay_ms :infinity
-  # ±20% uniform jitter on each backoff, matching Kafka's KIP-580. Decorrelates
-  # retries across many members so a shared failure does not produce a herd.
+  # ±20% jitter (KIP-580) decorrelates retries so members don't thundering-herd after a shared failure.
   @jitter_fraction 0.2
   # Past this the delay dwarfs any sane cap; clamping keeps the shift cheap.
   @max_backoff_exponent 32
@@ -73,8 +72,7 @@ defmodule KafkaEx.Support.Retry do
   @spec backoff_delay(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
           non_neg_integer()
   def backoff_delay(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
-    # Integer shift, not :math.pow: the float overflows into ArithmeticError past
-    # attempt 1023, and an unbounded retry loop does reach that.
+    # Integer shift, not :math.pow, which overflows to ArithmeticError past attempt 1023.
     delay = base_ms * Bitwise.bsl(1, min(attempt, @max_backoff_exponent))
 
     case max_ms do
@@ -208,8 +206,7 @@ defmodule KafkaEx.Support.Retry do
   def transient_error?(:parse_error), do: true
   def transient_error?(:closed), do: true
   def transient_error?(:no_broker), do: true
-  # A non-atom socket reason (e.g. an SSL `{:tls_alert, _}` tuple) is normalised to this by the
-  # client; a broken connection is transient, so the fetch loop must retry rather than stop.
+  # Normalised non-atom socket reason (e.g. SSL {:tls_alert, _}); a broken connection is transient.
   def transient_error?(:transport_error), do: true
   def transient_error?(error), do: coordinator_error?(error)
 

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -45,6 +45,8 @@ defmodule KafkaEx.Support.Retry do
   # ±20% uniform jitter on each backoff, matching Kafka's KIP-580. Decorrelates
   # retries across many members so a shared failure does not produce a herd.
   @jitter_fraction 0.2
+  # Past this the delay dwarfs any sane cap; clamping keeps the shift cheap.
+  @max_backoff_exponent 32
 
   @doc """
   Calculate exponential backoff delay.
@@ -71,7 +73,9 @@ defmodule KafkaEx.Support.Retry do
   @spec backoff_delay(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
           non_neg_integer()
   def backoff_delay(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
-    delay = trunc(base_ms * :math.pow(2, attempt))
+    # Integer shift, not :math.pow: the float overflows into ArithmeticError past
+    # attempt 1023, and an unbounded retry loop does reach that.
+    delay = base_ms * Bitwise.bsl(1, min(attempt, @max_backoff_exponent))
 
     case max_ms do
       :infinity -> delay

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -194,6 +194,14 @@ defmodule KafkaEx.Telemetry do
     * Measurements: `%{offset: integer()}`
     * Metadata: `%{group_id: binary(), topic: binary(), partition: integer(), reset: :earliest | :latest, reason: :no_committed_offset | :offset_out_of_range}`
 
+  * `[:kafka_ex, :consumer, :partition_unavailable]` - Emitted once when a partition has been
+    continuously unavailable to a consumer for longer than `:fetch_unavailable_warn_ms` (default
+    30s). The consumer keeps retrying regardless; this only flags a partition that is not
+    recovering (a persistently missing topic, a leader that never returns). Attach to alert on a
+    stuck partition without waiting for a human to read the logs.
+    * Measurements: `%{unavailable_ms: non_neg_integer()}`
+    * Metadata: `%{group_id: binary(), topic: binary(), partition: non_neg_integer(), reason: atom()}`
+
   ### Metadata Events
 
   * `[:kafka_ex, :metadata, :update, :start]` - Emitted when a metadata request begins
@@ -274,6 +282,7 @@ defmodule KafkaEx.Telemetry do
   @consumer_rebalance [:kafka_ex, :consumer, :rebalance]
   @consumer_commit_failed [:kafka_ex, :consumer, :commit_failed]
   @consumer_offset_reset [:kafka_ex, :consumer, :offset_reset]
+  @consumer_partition_unavailable [:kafka_ex, :consumer, :partition_unavailable]
 
   @metadata_update_start [:kafka_ex, :metadata, :update, :start]
   @metadata_update_stop [:kafka_ex, :metadata, :update, :stop]
@@ -297,7 +306,12 @@ defmodule KafkaEx.Telemetry do
                            @consumer_sync_events ++
                            @consumer_heartbeat_events ++
                            @consumer_leave_events ++
-                           [@consumer_rebalance, @consumer_commit_failed, @consumer_offset_reset]
+                           [
+                             @consumer_rebalance,
+                             @consumer_commit_failed,
+                             @consumer_offset_reset,
+                             @consumer_partition_unavailable
+                           ]
   @consumer_process_events [@consumer_process_start, @consumer_process_stop, @consumer_process_exception]
   @consumer_events @consumer_commit_events ++ @consumer_group_events ++ @consumer_process_events
   @metadata_events [@metadata_update_start, @metadata_update_stop, @metadata_update_exception]
@@ -539,6 +553,27 @@ defmodule KafkaEx.Telemetry do
         reset: reset,
         reason: reason
       }
+    )
+  end
+
+  @doc """
+  Emitted once when a partition has been continuously unavailable to a consumer for longer than
+  `:fetch_unavailable_warn_ms` (default 30s). The consumer keeps retrying — this only surfaces a
+  partition that is not recovering (a persistently missing topic, a leader that never returns).
+  `unavailable_ms` is how long the failure streak had lasted; `reason` is the last fetch error.
+  """
+  @spec emit_partition_unavailable(
+          group_id :: binary(),
+          topic :: binary(),
+          partition :: non_neg_integer(),
+          unavailable_ms :: non_neg_integer(),
+          reason :: atom()
+        ) :: :ok
+  def emit_partition_unavailable(group_id, topic, partition, unavailable_ms, reason) do
+    :telemetry.execute(
+      @consumer_partition_unavailable,
+      %{unavailable_ms: unavailable_ms},
+      %{group_id: group_id, topic: topic, partition: partition, reason: reason}
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KafkaEx.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kafkaex/kafka_ex"
-  @version "1.0.2"
+  @version "1.0.3"
 
   def project do
     [

--- a/test/integration/produce/reliability_test.exs
+++ b/test/integration/produce/reliability_test.exs
@@ -21,6 +21,11 @@ defmodule KafkaEx.Integration.Produce.ReliabilityTest do
       topic_name = generate_random_string()
       _ = create_topic(client, topic_name)
 
+      # A fire-and-forget batch is dropped without a trace while the partition leader is still
+      # being elected, so establish the leader with an acknowledged produce first.
+      {:ok, %RecordMetadata{base_offset: base_offset}} =
+        API.produce(client, topic_name, 0, [%{value: "leader-warmup"}], acks: -1)
+
       messages = [%{value: "acks-0-message"}]
 
       {:ok, result} = API.produce(client, topic_name, 0, messages, acks: 0)
@@ -33,22 +38,35 @@ defmodule KafkaEx.Integration.Produce.ReliabilityTest do
 
       # Two async sends followed by a synchronous request on the same socket: proves the
       # response-less produce leaves no bytes behind to desynchronise the next request.
-      Process.sleep(500)
-      {:ok, latest} = API.latest_offset(client, topic_name, 0)
-      assert latest >= 2
+      wait_for(
+        fn ->
+          {:ok, latest} = API.latest_offset(client, topic_name, 0)
+          latest >= base_offset + 3
+        end,
+        200,
+        25
+      )
     end
 
     test "produce with the deprecated required_acks: 0 alias still fires and forgets", %{client: client} do
       topic_name = generate_random_string()
       _ = create_topic(client, topic_name)
 
+      {:ok, %RecordMetadata{base_offset: base_offset}} =
+        API.produce(client, topic_name, 0, [%{value: "leader-warmup"}], acks: -1)
+
       {:ok, result} = API.produce(client, topic_name, 0, [%{value: "alias-message"}], required_acks: 0)
 
       assert %RecordMetadata{base_offset: nil} = result
 
-      Process.sleep(500)
-      {:ok, latest} = API.latest_offset(client, topic_name, 0)
-      assert latest >= 1
+      wait_for(
+        fn ->
+          {:ok, latest} = API.latest_offset(client, topic_name, 0)
+          latest >= base_offset + 2
+        end,
+        200,
+        25
+      )
     end
 
     test "produce with acks=1 (leader only) succeeds", %{client: client} do

--- a/test/integration/produce/reliability_test.exs
+++ b/test/integration/produce/reliability_test.exs
@@ -17,19 +17,35 @@ defmodule KafkaEx.Integration.Produce.ReliabilityTest do
   end
 
   describe "produce with different acks settings" do
-    test "produce with acks=0 (fire and forget) succeeds", %{client: client} do
+    test "produce with acks=0 (fire and forget) returns no offset", %{client: client} do
       topic_name = generate_random_string()
       _ = create_topic(client, topic_name)
 
       messages = [%{value: "acks-0-message"}]
 
-      {:ok, result} = API.produce(client, topic_name, 0, messages, required_acks: 0)
+      {:ok, result} = API.produce(client, topic_name, 0, messages, acks: 0)
+      {:ok, _} = API.produce(client, topic_name, 0, messages, acks: 0)
 
       assert %RecordMetadata{} = result
       assert result.topic == topic_name
       assert result.partition == 0
+      assert result.base_offset == nil
 
-      # Wait for message to arrive and verify via fetch
+      # Two async sends followed by a synchronous request on the same socket: proves the
+      # response-less produce leaves no bytes behind to desynchronise the next request.
+      Process.sleep(500)
+      {:ok, latest} = API.latest_offset(client, topic_name, 0)
+      assert latest >= 2
+    end
+
+    test "produce with the deprecated required_acks: 0 alias still fires and forgets", %{client: client} do
+      topic_name = generate_random_string()
+      _ = create_topic(client, topic_name)
+
+      {:ok, result} = API.produce(client, topic_name, 0, [%{value: "alias-message"}], required_acks: 0)
+
+      assert %RecordMetadata{base_offset: nil} = result
+
       Process.sleep(500)
       {:ok, latest} = API.latest_offset(client, topic_name, 0)
       assert latest >= 1

--- a/test/kafka_ex/api_test.exs
+++ b/test/kafka_ex/api_test.exs
@@ -307,6 +307,13 @@ defmodule KafkaEx.APITest do
       assert [{:topic_metadata, ["test-topic"]}, {:produce, "test-topic", _partition, ^messages}] = calls
     end
 
+    test "counts a partition whose leader is moving, so keys keep their partition" do
+      settled = %Topic{name: "test-topic", partition_leaders: %{0 => 1, 1 => 2, 2 => 1}}
+      moving = %Topic{name: "test-topic", partition_leaders: %{0 => 1, 1 => -1, 2 => 1}}
+
+      assert partition_for(settled, "user-123") == partition_for(moving, "user-123")
+    end
+
     test "returns error when topic has no partitions (nil partition)" do
       topic_info = %Topic{name: "test-topic", partition_leaders: %{}}
 
@@ -702,5 +709,18 @@ defmodule KafkaEx.APITest do
 
       assert {:error, :invalid_consumer_group} = KafkaEx.API.set_consumer_group_for_auto_commit(client, nil)
     end
+  end
+
+  defp partition_for(topic_info, key) do
+    {:ok, client} =
+      MockClient.start_link(%{
+        topic_metadata: {:ok, [topic_info]},
+        produce: {:ok, %RecordMetadata{topic: topic_info.name, partition: 0, base_offset: 0}}
+      })
+
+    {:ok, _} = KafkaEx.API.produce(client, topic_info.name, nil, [%{key: key, value: "data"}])
+
+    [_, {:produce, _, partition, _}] = MockClient.get_calls(client)
+    partition
   end
 end

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -1,13 +1,18 @@
 defmodule KafkaEx.ClientTest do
   use ExUnit.Case, async: false
+  use Mimic
 
   import ExUnit.CaptureLog
   import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
+  alias KafkaEx.Client.Error
   alias KafkaEx.Client.State
   alias KafkaEx.Cluster.Broker
   alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Cluster.Topic
+  alias KafkaEx.Messages.RecordMetadata
+  alias KafkaEx.Network.NetworkClient
   alias KafkaEx.Network.Socket
 
   # Tiny GenServer that delegates :tcp_closed/:ssl_closed to
@@ -98,6 +103,107 @@ defmodule KafkaEx.ClientTest do
         )
 
       assert match?({:reply, _, _}, result)
+    end
+  end
+
+  # Regression: `:required_acks` never reached the wire (the request builder reads `:acks`), so
+  # `acks: 0` was unreachable — and once reachable it crashed on `byte_size(:ok)` and was retried.
+  describe "handle_call/3 - produce acks" do
+    setup :set_mimic_private
+
+    setup do
+      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+      {:ok, lport} = :inet.port(listen)
+      {:ok, sock} = :gen_tcp.connect(~c"localhost", lport, [:binary, active: false])
+
+      on_exit(fn ->
+        :gen_tcp.close(sock)
+        :gen_tcp.close(listen)
+      end)
+
+      broker = %Broker{node_id: 1, host: "localhost", port: lport, socket: %Socket{socket: sock, ssl: false}}
+
+      state = %State{
+        api_versions: %{0 => {0, 8}},
+        correlation_id: 1,
+        cluster_metadata: %ClusterMetadata{
+          brokers: %{1 => broker},
+          topics: %{"t" => %Topic{name: "t", partition_leaders: %{0 => 1}}}
+        }
+      }
+
+      {:ok, state: state}
+    end
+
+    test "acks: 0 is sent fire-and-forget, exactly once, and returns no offset", %{state: state} do
+      stub_sends(:ok)
+
+      {:reply, reply, state_out} = produce(state, acks: 0)
+
+      assert {:ok, %RecordMetadata{topic: "t", partition: 0, base_offset: nil}} = reply
+      assert state_out.correlation_id == state.correlation_id + 1
+      assert_received :async_sent
+      refute_received :async_sent
+      refute_received :sync_sent
+    end
+
+    test "a failed fire-and-forget send is reported as an error, not a crash, and is sent once", %{state: state} do
+      stub_sends({:error, :closed})
+
+      {:reply, reply, state_out} = produce(state, acks: 0)
+
+      assert {:error, %Error{error: :closed}} = reply
+      assert state_out.correlation_id == state.correlation_id + 1
+      assert_received :async_sent
+      refute_received :async_sent
+    end
+
+    test "an acks value the wire cannot carry is rejected without touching the socket", %{state: state} do
+      stub_sends(:ok)
+
+      for opts <- [[acks: :all], [required_acks: 65_536], [acks: nil], [required_acks: 2]] do
+        assert {:reply, {:error, :invalid_acks}, ^state} = produce(state, opts)
+      end
+
+      refute_received :async_sent
+      refute_received :sync_sent
+    end
+
+    test "the deprecated :required_acks is honoured when :acks is absent", %{state: state} do
+      stub_sends(:ok)
+
+      {:reply, reply, _state} = produce(state, required_acks: 0)
+
+      assert {:ok, %RecordMetadata{base_offset: nil}} = reply
+      assert_received :async_sent
+    end
+
+    test "the deprecated :required_acks loses to an explicit :acks", %{state: state} do
+      stub_sends()
+
+      produce(state, required_acks: 0, acks: 1)
+
+      assert_received :sync_sent
+      refute_received :sync_sent
+      refute_received :async_sent
+    end
+
+    test "telemetry reports the acks value that reaches the wire", %{state: state} do
+      stub_sends()
+      attach_produce_start_handler()
+
+      produce(state, acks: 1, required_acks: -1)
+
+      assert_received {:produce_start, %{required_acks: 1}}
+    end
+
+    test "acks defaults to -1 when neither option is given", %{state: state} do
+      stub_sends()
+      attach_produce_start_handler()
+
+      produce(state, [])
+
+      assert_received {:produce_start, %{required_acks: -1}}
     end
   end
 
@@ -343,6 +449,37 @@ defmodule KafkaEx.ClientTest do
     end
   end
 
+  # A broker rejecting an acks=0 produce signals it by resetting the connection, so these
+  # messages are on the normal error path for fire-and-forget, not an exotic case.
+  describe "handle_info/2 - socket errors and unknown messages" do
+    test "{:tcp_error, port, reason} clears the matching broker's socket" do
+      port = open_tcp_port()
+      state = build_state(%{1 => broker_with_port(1, port)})
+
+      assert {:noreply, new_state} = Client.handle_info({:tcp_error, port, :econnreset}, state)
+
+      [broker] = State.brokers(new_state)
+      assert broker.socket == nil
+    end
+
+    test "{:ssl_error, ref, reason} clears the matching broker's socket" do
+      ref = make_ref()
+      state = build_state(%{1 => broker_with_ssl_ref(1, ref)})
+
+      assert {:noreply, new_state} = Client.handle_info({:ssl_error, ref, :closed}, state)
+
+      [broker] = State.brokers(new_state)
+      assert broker.socket == nil
+    end
+
+    test "an unknown message does not kill the client" do
+      port = open_tcp_port()
+      state = build_state(%{1 => broker_with_port(1, port)})
+
+      assert {:noreply, ^state} = Client.handle_info(:something_unexpected, state)
+    end
+  end
+
   describe "telemetry emission on remote close [issue #449]" do
     test "emits [:kafka_ex, :connection, :close] with :remote_closed on :tcp_closed" do
       port = open_tcp_port()
@@ -530,5 +667,36 @@ defmodule KafkaEx.ClientTest do
     after
       0 -> :ok
     end
+  end
+
+  defp produce(state, opts) do
+    Client.handle_call({:produce, "t", 0, [%{value: "v"}], opts}, self(), state)
+  end
+
+  defp stub_sends(async_result \\ :ok) do
+    test_pid = self()
+
+    stub(NetworkClient, :send_async_request, fn _broker, _wire ->
+      send(test_pid, :async_sent)
+      async_result
+    end)
+
+    stub(NetworkClient, :send_sync_request, fn _broker, _wire, _timeout ->
+      send(test_pid, :sync_sent)
+      {:error, :stubbed}
+    end)
+  end
+
+  defp attach_produce_start_handler do
+    handler_id = "produce-acks-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :produce, :start],
+      fn _event, _measurements, metadata, pid -> send(pid, {:produce_start, metadata}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
   end
 end

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -472,11 +472,17 @@ defmodule KafkaEx.ClientTest do
       assert broker.socket == nil
     end
 
-    test "an unknown message does not kill the client" do
+    test "an unknown message does not kill the client and is logged" do
       port = open_tcp_port()
       state = build_state(%{1 => broker_with_port(1, port)})
 
-      assert {:noreply, ^state} = Client.handle_info(:something_unexpected, state)
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^state} = Client.handle_info(:something_unexpected, state)
+        end)
+
+      assert log =~ "ignoring unexpected message"
+      assert log =~ ":something_unexpected"
     end
   end
 

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -517,6 +517,35 @@ defmodule KafkaEx.ClientTest do
       end)
     end
 
+    test "emits :recv_error on :tcp_error rather than the raw posix reason" do
+      port = open_tcp_port()
+      broker = broker_with_port(1, port)
+      state = build_state(%{1 => broker})
+
+      with_telemetry_handler(fn ->
+        log = capture_log(fn -> {:noreply, _} = Client.handle_info({:tcp_error, port, :econnreset}, state) end)
+
+        assert_receive {:telemetry, [:kafka_ex, :connection, :close], %{count: 1}, metadata}
+        assert metadata.reason == :recv_error
+        assert log =~ ":econnreset"
+      end)
+    end
+
+    test "emits :recv_error on :ssl_error even when the reason is a complex term" do
+      ref = make_ref()
+      broker = broker_with_ssl_ref(1, ref)
+      state = build_state(%{1 => broker})
+      alert = {:tls_alert, {:handshake_failure, ~c"bad certificate"}}
+
+      with_telemetry_handler(fn ->
+        log = capture_log(fn -> {:noreply, _} = Client.handle_info({:ssl_error, ref, alert}, state) end)
+
+        assert_receive {:telemetry, [:kafka_ex, :connection, :close], %{count: 1}, metadata}
+        assert metadata.reason == :recv_error
+        assert log =~ "handshake_failure"
+      end)
+    end
+
     test "does not emit when no broker matches the socket" do
       port_in_state = open_tcp_port()
       port_unknown = open_tcp_port()

--- a/test/kafka_ex/client/no_broker_reason_test.exs
+++ b/test/kafka_ex/client/no_broker_reason_test.exs
@@ -1,0 +1,48 @@
+defmodule KafkaEx.Client.NoBrokerReasonTest do
+  @moduledoc """
+  `:no_broker` collapses three different causes — unknown topic, unknown
+  partition, unknown node — so the reason has to reach the log, otherwise a
+  leaderless partition is indistinguishable from a deleted topic.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias KafkaEx.Client
+  alias KafkaEx.Client.NodeSelector
+  alias KafkaEx.Client.State
+  alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Cluster.Topic
+
+  defp state_with(topics) do
+    %State{cluster_metadata: %ClusterMetadata{brokers: %{}, topics: topics}}
+  end
+
+  defp fetch_from(state, topic, partition) do
+    request = %Kayrock.Fetch.V0.Request{replica_id: -1, max_wait_time: 1, min_bytes: 1, topics: []}
+    selector = NodeSelector.topic_partition(topic, partition)
+
+    capture_log(fn ->
+      {:reply, reply, _} = Client.handle_call({:network_request, request, selector}, self(), state)
+      send(self(), {:reply, reply})
+    end)
+  end
+
+  test "names the missing partition behind :no_broker" do
+    state = state_with(%{"t" => %Topic{name: "t", partition_leaders: %{0 => 1}}})
+
+    log = fetch_from(state, "t", 7)
+
+    assert_received {:reply, {:error, :no_broker}}
+    assert log =~ "No broker for t/7"
+    assert log =~ ":no_such_partition"
+  end
+
+  test "names the missing topic behind :no_broker" do
+    log = fetch_from(state_with(%{}), "gone", 0)
+
+    assert_received {:reply, {:error, :no_broker}}
+    assert log =~ "No broker for gone/0"
+    assert log =~ ":no_such_topic"
+  end
+end

--- a/test/kafka_ex/cluster/cluster_metadata_test.exs
+++ b/test/kafka_ex/cluster/cluster_metadata_test.exs
@@ -396,4 +396,23 @@ defmodule KafkaEx.Cluster.ClusterMetadataTest do
       assert ClusterMetadata.known_topics(updated_cluster) == ["topic-one"]
     end
   end
+
+  describe "select_node/2 with a leaderless partition" do
+    test "reports :leader_not_available rather than a bogus node id" do
+      metadata = %ClusterMetadata{
+        brokers: %{1 => %KafkaEx.Cluster.Broker{node_id: 1, host: "h", port: 9092}},
+        topics: %{"t" => %KafkaEx.Cluster.Topic{name: "t", partition_leaders: %{0 => 1, 1 => -1}}}
+      }
+
+      alias KafkaEx.Client.NodeSelector
+
+      assert {:ok, 1} = ClusterMetadata.select_node(metadata, NodeSelector.topic_partition("t", 0))
+
+      assert {:error, :leader_not_available} =
+               ClusterMetadata.select_node(metadata, NodeSelector.topic_partition("t", 1))
+
+      assert {:error, :no_such_partition} =
+               ClusterMetadata.select_node(metadata, NodeSelector.topic_partition("t", 9))
+    end
+  end
 end

--- a/test/kafka_ex/cluster/partition_info_test.exs
+++ b/test/kafka_ex/cluster/partition_info_test.exs
@@ -39,6 +39,21 @@ defmodule KafkaEx.Cluster.PartitionInfoTest do
 
       assert partition.isr == [21]
     end
+
+    test "maps a zero error_code to :no_error", %{metadata: metadata} do
+      partition = PartitionInfo.from_partition_metadata(metadata)
+
+      assert partition.error_code == :no_error
+    end
+
+    test "retains a leader-move partition instead of crashing, mapping its error_code" do
+      metadata = %{error_code: 5, partition_index: 0, leader_id: -1, replica_nodes: [], isr_nodes: []}
+
+      partition = PartitionInfo.from_partition_metadata(metadata)
+
+      assert partition.leader == -1
+      assert partition.error_code == :leader_not_available
+    end
   end
 
   describe "build/1" do

--- a/test/kafka_ex/cluster/topic_test.exs
+++ b/test/kafka_ex/cluster/topic_test.exs
@@ -83,7 +83,7 @@ defmodule KafkaEx.Cluster.TopicTest do
       assert topic.name == "__consumer_offsets"
     end
 
-    test "raises FunctionClauseError on partition with non-zero error_code" do
+    test "keeps a partition carrying a leader-move error code, with leader -1" do
       metadata = %{
         name: "error-topic",
         is_internal: false,
@@ -92,9 +92,12 @@ defmodule KafkaEx.Cluster.TopicTest do
         ]
       }
 
-      assert_raise FunctionClauseError, fn ->
-        Topic.from_topic_metadata(metadata)
-      end
+      topic = Topic.from_topic_metadata(metadata)
+
+      assert topic.partition_leaders == %{0 => -1}
+
+      assert [%KafkaEx.Cluster.PartitionInfo{partition_id: 0, leader: -1, error_code: :leader_not_available}] =
+               topic.partitions
     end
 
     test "handles empty partitions list" do

--- a/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
@@ -111,4 +111,30 @@ defmodule KafkaEx.Consumer.GenConsumerFetchRetryTest do
     wait_until(fn -> fetch_count(client) > recovered + 2 end)
     assert Process.alive?(pid)
   end
+
+  test "backs off instead of crashing when the offset reset cannot reach a leader" do
+    {:ok, client} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: 0, error_code: :no_error}]}]},
+        fetch: {:error, Error.build(:offset_out_of_range, %{})},
+        list_offsets: {:error, Error.build(:no_broker, %{})},
+        offset_commit: {:ok, []}
+      })
+
+    Process.unlink(client)
+
+    {:ok, pid} = GenServer.start_link(GenConsumer, {TestConsumer, "g", "t", 0, [client: client]})
+    Process.unlink(pid)
+
+    on_exit(fn ->
+      stop_safely(pid)
+      stop_safely(client)
+    end)
+
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
 end

--- a/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
@@ -93,11 +93,48 @@ defmodule KafkaEx.Consumer.GenConsumerFetchRetryTest do
     wait_until(fn -> fetch_count(client) > before + 1 end)
   end
 
+  test "keeps retrying a non-atom transport error (e.g. an SSL alert) instead of stopping" do
+    {client, pid} =
+      start_consumer({:error, Error.build(:transport_error, %{transport_reason: {:tls_alert, :bad_record_mac}})})
+
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
+
   test "still stops on a fetch error that is not retryable" do
     {_client, pid} = start_consumer({:error, Error.build(:topic_authorization_failed, %{})})
     ref = Process.monitor(pid)
 
     assert_receive {:DOWN, ^ref, :process, ^pid, :topic_authorization_failed}, 2_000
+  end
+
+  test "surfaces a persistently unavailable partition once via telemetry, without stopping" do
+    Application.put_env(:kafka_ex, :fetch_unavailable_warn_ms, 0)
+    on_exit(fn -> Application.delete_env(:kafka_ex, :fetch_unavailable_warn_ms) end)
+
+    handler_id = "gen-consumer-unavailable-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :partition_unavailable],
+      fn _name, measurements, metadata, _ -> send(test_pid, {:unavailable, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+
+    assert_receive {:unavailable, %{unavailable_ms: ms}, %{topic: "t", partition: 0, reason: :no_broker}}, 1_000
+    assert is_integer(ms) and ms >= 0
+
+    wait_until(fn -> fetch_count(client) >= 5 end)
+    refute_receive {:unavailable, _, _}, 200
+    assert Process.alive?(pid)
   end
 
   test "recovers and resumes consuming once the leader is back" do

--- a/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
@@ -1,0 +1,114 @@
+defmodule KafkaEx.Consumer.GenConsumerFetchRetryTest do
+  @moduledoc """
+  A transient fetch error must not kill the consumer.
+
+  When a partition's leader moves (broker restart, RF=1 makes the window wide),
+  the client answers `:no_broker`. Stopping on it takes the whole group down with
+  it, because the ConsumerGroup supervisor runs `max_restarts: 0`. brod, KafkaJS
+  and librdkafka all back off and retry instead.
+
+  Driven through the real consume loop and the real `KafkaEx.API.fetch/5` reply
+  path, so the error is unwrapped by `normalize_reply/1` exactly as in production.
+  """
+  use ExUnit.Case, async: false
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Client.Error
+  alias KafkaEx.Consumer.GenConsumer
+  alias KafkaEx.Test.MockClient
+
+  defmodule TestConsumer do
+    use KafkaEx.Consumer.GenConsumer
+    def handle_message_set(_messages, state), do: {:async_commit, state}
+    def handle_call(:ping, _from, state), do: {:reply, :pong, state}
+  end
+
+  setup do
+    Application.put_env(:kafka_ex, :fetch_retry_base_delay_ms, 10)
+    Application.put_env(:kafka_ex, :fetch_retry_max_delay_ms, 40)
+
+    on_exit(fn ->
+      Application.delete_env(:kafka_ex, :fetch_retry_base_delay_ms)
+      Application.delete_env(:kafka_ex, :fetch_retry_max_delay_ms)
+    end)
+
+    :ok
+  end
+
+  defp start_consumer(fetch_response) do
+    {:ok, client} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: 0, error_code: :no_error}]}]},
+        fetch: fetch_response,
+        offset_commit: {:ok, []}
+      })
+
+    Process.unlink(client)
+
+    {:ok, pid} = GenServer.start_link(GenConsumer, {TestConsumer, "g", "t", 0, [client: client]})
+    Process.unlink(pid)
+
+    on_exit(fn ->
+      stop_safely(pid)
+      stop_safely(client)
+    end)
+
+    {client, pid}
+  end
+
+  defp fetch_count(client) do
+    client |> MockClient.get_calls() |> Enum.count(&match?({:fetch, _, _, _, _}, &1))
+  end
+
+  defp wait_until(fun, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() -> :ok
+      System.monotonic_time(:millisecond) >= deadline -> flunk("condition not met before deadline")
+      true -> Process.sleep(10) && do_wait_until(fun, deadline)
+    end
+  end
+
+  test "keeps retrying a transient fetch error instead of stopping" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
+
+  test "a call served during backoff does not strand the consumer" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+    wait_until(fn -> fetch_count(client) >= 2 end)
+
+    before = fetch_count(client)
+    assert GenConsumer.call(pid, :ping) == :pong
+
+    wait_until(fn -> fetch_count(client) > before + 1 end)
+  end
+
+  test "still stops on a fetch error that is not retryable" do
+    {_client, pid} = start_consumer({:error, Error.build(:topic_authorization_failed, %{})})
+    ref = Process.monitor(pid)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :topic_authorization_failed}, 2_000
+  end
+
+  test "recovers and resumes consuming once the leader is back" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+
+    wait_until(fn -> fetch_count(client) >= 3 end)
+
+    MockClient.put_response(client, :fetch, {:ok, %KafkaEx.Messages.Fetch{topic: "t", partition: 0, records: []}})
+
+    recovered = fetch_count(client)
+    wait_until(fn -> fetch_count(client) > recovered + 2 end)
+    assert Process.alive?(pid)
+  end
+end

--- a/test/kafka_ex/network/network_client_test.exs
+++ b/test/kafka_ex/network/network_client_test.exs
@@ -1,5 +1,6 @@
 defmodule KafkaEx.Network.NetworkClientTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
   import KafkaEx.TestHelpers
 
   alias KafkaEx.Network.NetworkClient
@@ -103,6 +104,39 @@ defmodule KafkaEx.Network.NetworkClientTest do
 
       Process.exit(pid, :normal)
       :gen_tcp.close(tcp_socket)
+    end
+
+    test "a failed send returns the reason and closes the socket with :send_error" do
+      port = get_free_port(3070)
+      pid = KafkaEx.TestSupport.Server.start(port)
+
+      {:ok, tcp_socket} = :gen_tcp.connect(~c"localhost", port, [:binary, {:active, false}, {:packet, 0}])
+
+      kafka_socket = %KafkaEx.Network.Socket{socket: tcp_socket, ssl: false}
+      broker = %{socket: kafka_socket, host: "localhost", port: port}
+      :ok = :gen_tcp.close(tcp_socket)
+
+      handler_id = "network-client-send-error-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:kafka_ex, :connection, :close],
+          fn _name, measurements, metadata, _ -> send(test_pid, {:telemetry, measurements, metadata}) end,
+          nil
+        )
+
+      try do
+        capture_log(fn ->
+          assert {:error, :closed} == NetworkClient.send_async_request(broker, "test data")
+        end)
+
+        assert_receive {:telemetry, %{count: 1}, %{reason: :send_error, port: ^port}}
+      after
+        :telemetry.detach(handler_id)
+        Process.exit(pid, :normal)
+      end
     end
   end
 

--- a/test/kafka_ex/network/network_client_test.exs
+++ b/test/kafka_ex/network/network_client_test.exs
@@ -106,7 +106,7 @@ defmodule KafkaEx.Network.NetworkClientTest do
       :gen_tcp.close(tcp_socket)
     end
 
-    test "a failed send returns the reason and closes the socket with :send_error" do
+    test "a failed send returns the reason and closes the socket without emitting a close event" do
       port = get_free_port(3070)
       pid = KafkaEx.TestSupport.Server.start(port)
 
@@ -132,7 +132,8 @@ defmodule KafkaEx.Network.NetworkClientTest do
           assert {:error, :closed} == NetworkClient.send_async_request(broker, "test data")
         end)
 
-        assert_receive {:telemetry, %{count: 1}, %{reason: :send_error, port: ^port}}
+        assert {:error, :closed} == :gen_tcp.send(tcp_socket, <<>>)
+        refute_receive {:telemetry, _, _}
       after
         :telemetry.detach(handler_id)
         Process.exit(pid, :normal)

--- a/test/kafka_ex/protocol/kayrock/metadata/response_helpers_test.exs
+++ b/test/kafka_ex/protocol/kayrock/metadata/response_helpers_test.exs
@@ -202,17 +202,28 @@ defmodule KafkaEx.Protocol.Kayrock.Metadata.ResponseHelpersTest do
       assert partition.isr == [1, 2]
     end
 
-    test "filters out partitions with errors" do
+    test "keeps a partition whose leader is moving, tagged with the broker's error" do
       partitions = [
         %{partition_index: 0, error_code: 0, leader_id: 1, replica_nodes: [], isr_nodes: []},
         %{partition_index: 1, error_code: 9, leader_id: -1, replica_nodes: [], isr_nodes: []}
       ]
 
-      result = ResponseHelpers.parse_partitions(partitions)
+      assert [first, second] = ResponseHelpers.parse_partitions(partitions)
+      assert first.partition_id == 0
+      assert first.error_code == :no_error
+      assert second.partition_id == 1
+      assert second.leader == -1
+      assert second.error_code == :replica_not_available
+    end
 
-      assert length(result) == 1
-      [partition] = result
-      assert partition.partition_id == 0
+    test "drops a partition whose error is not a leader move" do
+      partitions = [
+        %{partition_index: 0, error_code: 0, leader_id: 1, replica_nodes: [], isr_nodes: []},
+        %{partition_index: 1, error_code: 29, leader_id: -1, replica_nodes: [], isr_nodes: []}
+      ]
+
+      assert [only] = ResponseHelpers.parse_partitions(partitions)
+      assert only.partition_id == 0
     end
 
     test "handles nil replicas and isr" do

--- a/test/kafka_ex/protocol/kayrock/metadata/response_test.exs
+++ b/test/kafka_ex/protocol/kayrock/metadata/response_test.exs
@@ -170,7 +170,7 @@ defmodule KafkaEx.Protocol.Kayrock.Metadata.ResponseTest do
       refute cluster_metadata.topics["bad-topic"]
     end
 
-    test "filters out partitions with errors" do
+    test "keeps a partition whose leader is moving, and drops a fatal one" do
       response = %V0.Response{
         brokers: [
           %{node_id: 1, host: "broker1.example.com", port: 9092}
@@ -181,7 +181,8 @@ defmodule KafkaEx.Protocol.Kayrock.Metadata.ResponseTest do
             name: "test-topic",
             partitions: [
               %{error_code: 0, partition_index: 0, leader_id: 1, replica_nodes: [1], isr_nodes: [1]},
-              %{error_code: 5, partition_index: 1, leader_id: -1, replica_nodes: [], isr_nodes: []}
+              %{error_code: 5, partition_index: 1, leader_id: -1, replica_nodes: [], isr_nodes: []},
+              %{error_code: 29, partition_index: 2, leader_id: -1, replica_nodes: [], isr_nodes: []}
             ]
           }
         ]
@@ -190,8 +191,8 @@ defmodule KafkaEx.Protocol.Kayrock.Metadata.ResponseTest do
       {:ok, cluster_metadata} = MetadataResponse.parse_response(response)
 
       topic = cluster_metadata.topics["test-topic"]
-      assert length(topic.partitions) == 1
-      assert Enum.at(topic.partitions, 0).partition_id == 0
+      assert Enum.map(topic.partitions, & &1.partition_id) == [0, 1]
+      assert topic.partition_leaders == %{0 => 1, 1 => -1}
     end
   end
 

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -188,6 +188,11 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.transient_error?(:no_broker)
     end
 
+    test "transport_error (normalised non-atom socket reason) is transient" do
+      assert Retry.transient_error?(:transport_error)
+      assert Retry.fetch_retryable?(:transport_error)
+    end
+
     test "coordinator errors are transient" do
       assert Retry.transient_error?(:coordinator_not_available)
       assert Retry.transient_error?(:not_coordinator)

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -423,4 +423,11 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.heartbeat_retryable?(:coordinator_not_available)
     end
   end
+
+  describe "backoff_delay/3 with an unbounded retry loop" do
+    test "stays at the cap instead of overflowing the exponent" do
+      assert Retry.backoff_delay(2000, 500, 5000) == 5000
+      assert Retry.backoff_delay_jittered(2000, 500, 5000) <= 5000
+    end
+  end
 end

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -180,8 +180,8 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_events()
 
       # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 3 process = 21
-      assert length(events) == 21
+      # + 1 offset_reset + 1 partition_unavailable + 3 process = 22
+      assert length(events) == 22
 
       # Commit events
       assert [:kafka_ex, :consumer, :commit, :start] in events
@@ -203,6 +203,7 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :consumer, :leave, :exception] in events
       assert [:kafka_ex, :consumer, :rebalance] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
+      assert [:kafka_ex, :consumer, :partition_unavailable] in events
 
       # Process events
       assert [:kafka_ex, :consumer, :process, :start] in events
@@ -216,11 +217,12 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_group_events()
 
       # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset = 15
-      assert length(events) == 15
+      # + 1 offset_reset + 1 partition_unavailable = 16
+      assert length(events) == 16
 
       assert [:kafka_ex, :consumer, :commit_failed] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
+      assert [:kafka_ex, :consumer, :partition_unavailable] in events
 
       # Group lifecycle events
       assert [:kafka_ex, :consumer, :join, :start] in events

--- a/test/support/mock_client.ex
+++ b/test/support/mock_client.ex
@@ -134,6 +134,10 @@ defmodule KafkaEx.Test.MockClient do
     {:reply, Enum.reverse(state.calls), state}
   end
 
+  def handle_call({:put_response, operation, response}, _from, state) do
+    {:reply, :ok, %{state | responses: Map.put(state.responses, operation, response)}}
+  end
+
   defp record_call(state, call) do
     %{state | calls: [call | state.calls]}
   end
@@ -142,6 +146,11 @@ defmodule KafkaEx.Test.MockClient do
   Returns the list of calls made to the mock client in order.
   """
   def get_calls(pid), do: GenServer.call(pid, :get_calls)
+
+  @doc """
+  Swaps the canned reply for one operation, so a test can script recovery.
+  """
+  def put_response(pid, operation, response), do: GenServer.call(pid, {:put_response, operation, response})
 
   @doc """
   Polls until at least `expected_count` calls have been recorded, then returns them.

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -52,6 +52,19 @@ messages = [%{value: "msg1", key: "k1"}, %{value: "msg2", key: "k2"}]
 # CORRECT - With compression
 {:ok, metadata} = KafkaEx.API.produce(client, "topic", 0, messages, compression: :gzip)
 
+# CORRECT - Durability: -1 (default) all in-sync replicas, 1 leader only.
+# Only -1, 0 and 1 are accepted; anything else returns {:error, :invalid_acks}
+{:ok, metadata} = KafkaEx.API.produce(client, "topic", 0, messages, acks: 1)
+
+# CAUTION - acks: 0 is fire-and-forget: {:ok, _} only means "handed to the socket",
+# metadata.base_offset is nil, nothing is retried, and a broker-side rejection shows up
+# as a closed connection, so records can be lost silently. The call still round-trips
+# through the client process, so it is not a latency escape hatch.
+{:ok, %{base_offset: nil}} = KafkaEx.API.produce(client, "topic", 0, messages, acks: 0)
+
+# DEPRECATED - :required_acks is an alias for :acks, removed in 2.0
+KafkaEx.API.produce(client, "topic", 0, messages, required_acks: 1)
+
 # WRONG - Missing client parameter
 KafkaEx.produce("topic", 0, "message")  # This is legacy API, don't use in v1.0 code
 ```


### PR DESCRIPTION
Backport of #590 onto the 1.0.x maintenance line, plus the 1.0.3 bump. Two resilience fixes:

### 1. Produce honours `acks` again

Since 1.0 every produce silently ran at `acks: -1` — the option was read under a key the request builder never used. `:acks` is now canonical (`:required_acks` a deprecated alias), bad values are rejected with `{:error, :invalid_acks}`, and `acks: 0` is true fire-and-forget (`base_offset: nil`, no retry).

> ⚠️ **Breaking on a patch line:** `required_acks: 0` (silently durable before) becomes fire-and-forget — records can be lost. `required_acks: 1` becomes leader-only. Pass `acks: -1` to keep the 1.0.x behaviour.

### 2. A leader move / broker restart no longer kills the whole group

At replication-factor 1 a restart left a partition leaderless → `:no_broker` → `GenConsumer` stops → `ConsumerGroup` (`max_restarts: 0`) takes the group down. Now the fetch loop retries transient errors unbounded with jittered backoff (as brod/Java/librdkafka), SSL `{:tls_alert, _}` reasons are retryable, and a partition stuck past `:fetch_unavailable_warn_ms` (30s) is flagged once via `[:kafka_ex, :consumer, :partition_unavailable]`.

**1.0.x scoping:** kept minimal — only `:transport_error` was added to `transient_error?/1`; the 1.1.x-only `member_terminated` / `heartbeat_crash` events and `:econnreset` / `:not_connected` classifications were not backported.

**Why this targets `release/v1.0.x`:** the workflow only ran checks for `master`; `release/v1.0.x` starts at the `v1.0.2` tag and adds itself to the CI filters so this line is verified.

### Verification

Unit 3016/0, `format` + `compile --warnings-as-errors` clean, `dialyzer` only the known local MapSet false-positive. Integration and full `credo` need CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
