### PR TITLE
fix(produce): honour the acks option and make acks=0 fire-and-forget work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # KafkaEx Changelog
 
+## 1.1.2 (unreleased)
+
+### Changed (Breaking)
+
+* **`acks` / `required_acks` now reaches the broker.** Since 1.0 every produce ran at `acks: -1`
+  regardless of the option. `required_acks: 1` now means leader-only and `required_acks: 0` means
+  fire-and-forget (records can be lost, `base_offset: nil`). Pass `acks: -1` to keep the old
+  behaviour. `:acks` is canonical; `:required_acks` is a deprecated alias (removed in 2.0).
+
+### Fixed
+
+* **The `acks` option is honoured again (regression since 1.0).** Resolved once to the wire;
+  invalid values are rejected with `{:error, :invalid_acks}` instead of crashing Kayrock's int16
+  encoder; `:all` / `:any` map to `-1`.
+* **`acks: 0` fire-and-forget works.** Sent asynchronously, never retried, returns
+  `base_offset: nil`. A failed async send closes the socket, and the client now handles
+  `{:tcp_error}` / `{:ssl_error}` plus a catch-all `handle_info/2` instead of crashing on an
+  unmatched message.
+
 ## 1.1.1 (2026-07-24)
 
 ### Fixed

--- a/lib/kafka_ex/api.ex
+++ b/lib/kafka_ex/api.ex
@@ -810,8 +810,17 @@ defmodule KafkaEx.API do
     * `messages` - List of message maps with `:value`, optional `:key`, `:timestamp`, `:headers`
     * `opts` - Options including:
       * `:api_version` - API version to use. If omitted, resolved via `:api_versions` app-config or broker-negotiated max (`min(broker_max, kayrock_max)`). See CHANGELOG § 3-tier API version resolution.
-      * `:required_acks` - Number of acks required (default: 1)
-      * `:timeout` - Request timeout
+      * `:acks` - Acknowledgements required: `-1` (default) all in-sync replicas, `1` leader only,
+        `0` fire-and-forget. `:all` / `:any` (the Java/librdkafka spelling) are accepted as `-1`.
+        Any other value is rejected with `{:error, :invalid_acks}`.
+        With `0` the broker sends no response at all, so `{:ok, _}` means only that the batch was
+        handed to the socket, the call is never retried, the returned `RecordMetadata` has
+        `base_offset: nil`, and a broker-side rejection (stale leader, oversized batch) arrives as
+        a closed connection — records produced before the client notices are lost.
+      * `:required_acks` - Deprecated alias for `:acks`, honoured only when `:acks` is absent.
+        Will be removed in 2.0.
+      * `:timeout` - How long the broker waits for the required acknowledgements, in ms
+        (default 5000). Only has an effect with `acks: -1`.
       * `:partitioner` - Custom partitioner module (default: configured or `KafkaEx.Producer.Partitioner.Default`)
 
   ## Partitioning

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -27,6 +27,7 @@ defmodule KafkaEx.Client do
   alias KafkaEx.Cluster.ClusterMetadata
   alias KafkaEx.Messages.Fetch
   alias KafkaEx.Messages.FindCoordinator, as: FindCoordinatorMsg
+  alias KafkaEx.Messages.RecordMetadata
   alias KafkaEx.Support.OptionalDeps
   alias KafkaEx.Support.Retry
 
@@ -395,6 +396,21 @@ defmodule KafkaEx.Client do
     {:noreply, state_out}
   end
 
+  def handle_info({:tcp_error, socket, reason}, state) do
+    {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
+  end
+
+  def handle_info({:ssl_error, socket, reason}, state) do
+    {:noreply, close_broker_by_socket(state, socket, :recv_error, reason)}
+  end
+
+  # Defining any handle_info/2 replaces the catch-all use GenServer injects; without one an
+  # unmatched message would crash the client.
+  def handle_info(message, state) do
+    Logger.warning("#{inspect(__MODULE__)} ignoring unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
   defp update_metadata_with_retry(_state, retries_left) when retries_left <= 0 do
     raise KafkaEx.MetadataUpdateError, attempts: @max_metadata_update_retries
   end
@@ -629,16 +645,14 @@ defmodule KafkaEx.Client do
   end
 
   defp produce_request(topic, partition, messages, opts, state) do
-    message_count = length(messages)
-    required_acks = Keyword.get(opts, :required_acks, 1)
-    client_id = Config.client_id()
+    with {:ok, acks} <- resolve_acks(opts) do
+      metadata = Telemetry.produce_metadata(topic, partition, Config.client_id(), acks)
+      start_measurements = %{message_count: length(messages)}
 
-    metadata = Telemetry.produce_metadata(topic, partition, client_id, required_acks)
-    start_measurements = %{message_count: message_count}
-
-    Telemetry.span([:kafka_ex, :produce], Map.merge(metadata, start_measurements), fn ->
-      do_produce_request(topic, partition, messages, opts, state, metadata)
-    end)
+      Telemetry.span([:kafka_ex, :produce], Map.merge(metadata, start_measurements), fn ->
+        do_produce_request(topic, partition, messages, Keyword.put(opts, :acks, acks), state, metadata)
+      end)
+    end
   end
 
   defp do_produce_request(topic, partition, messages, opts, state, metadata) do
@@ -652,6 +666,16 @@ defmodule KafkaEx.Client do
     else
       {:error, error} -> {{:error, error}, metadata}
       error_result -> {error_result, metadata}
+    end
+  end
+
+  # Reject a bad acks value here; unvalidated it reaches Kayrock's int16 encoder and crashes the client.
+  defp resolve_acks(opts) do
+    case Keyword.get(opts, :acks, Keyword.get(opts, :required_acks, -1)) do
+      acks when acks in [-1, 0, 1] -> {:ok, acks}
+      # Java/librdkafka spelling for "all in-sync replicas"; accept it as the -1 the wire carries.
+      acks when acks in [:all, :any] -> {:ok, -1}
+      _ -> {:error, :invalid_acks}
     end
   end
 
@@ -845,6 +869,20 @@ defmodule KafkaEx.Client do
       network_timeout: network_timeout
     }
     |> handle_request_with_retry(state, @coordinator_max_attempts)
+  end
+
+  # acks=0: the broker sends no response, and a resend would duplicate records.
+  defp handle_produce_request(%{acks: 0} = request, node_selector, state) do
+    %NodeSelector{topic: topic, partition: partition} = node_selector
+
+    case network_request(request, node_selector, state) do
+      {{:ok, :no_response}, updated_state} ->
+        {{:ok, RecordMetadata.build(topic: topic, partition: partition, base_offset: nil)}, updated_state}
+
+      {{:error, reason}, updated_state} ->
+        Logger.warning("Fire-and-forget produce to #{topic}/#{partition} failed with #{inspect(reason)}")
+        {{:error, build_transport_error(reason)}, updated_state}
+    end
   end
 
   defp handle_produce_request(request, node_selector, state) do
@@ -1394,6 +1432,9 @@ defmodule KafkaEx.Client do
         {{:error, reason}, broker} ->
           {{:error, reason}, 0, broker_to_telemetry_info(broker)}
 
+        {:ok, broker} ->
+          {{:ok, :no_response}, 0, broker_to_telemetry_info(broker)}
+
         {data, broker} when synchronous ->
           {deserialize(data, client_request), byte_size(data), broker_to_telemetry_info(broker)}
 
@@ -1507,10 +1548,10 @@ defmodule KafkaEx.Client do
     {topic_metadata, %{updated_state | allow_auto_topic_creation: allow_auto_topic_creation}}
   end
 
-  defp close_broker_by_socket(state, socket, reason \\ :remote_closed) do
+  defp close_broker_by_socket(state, socket, reason \\ :remote_closed, detail \\ nil) do
     State.update_brokers(state, fn broker ->
       if Broker.has_socket?(broker, socket) do
-        Logger.debug("#{Broker.to_string(broker)} closed connection")
+        log_connection_close(broker, detail)
         # Socket is already closed (received :tcp_closed/:ssl_closed), just emit telemetry
         NetworkClient.close_socket(broker, socket, reason)
         Broker.put_socket(broker, nil)
@@ -1519,4 +1560,9 @@ defmodule KafkaEx.Client do
       end
     end)
   end
+
+  defp log_connection_close(broker, nil), do: Logger.debug("#{Broker.to_string(broker)} closed connection")
+
+  defp log_connection_close(broker, detail),
+    do: Logger.warning("#{Broker.to_string(broker)} closed connection: #{inspect(detail)}")
 end

--- a/lib/kafka_ex/messages/record_metadata.ex
+++ b/lib/kafka_ex/messages/record_metadata.ex
@@ -11,7 +11,8 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
     * `:topic` - The topic the messages were produced to
     * `:partition` - The partition the messages were produced to
-    * `:base_offset` - The offset assigned to the first message in the batch
+    * `:base_offset` - The offset assigned to the first message in the batch; `nil` when
+      produced with `acks: 0`, where the broker sends no response
     * `:log_append_time` - The timestamp assigned by the broker (v2+, -1 if not available)
     * `:log_start_offset` - The start offset of the log (v5+)
     * `:throttle_time_ms` - Time in ms the request was throttled (v3+)
@@ -29,7 +30,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
   @type t :: %__MODULE__{
           topic: String.t(),
           partition: non_neg_integer(),
-          base_offset: non_neg_integer(),
+          base_offset: non_neg_integer() | nil,
           log_append_time: integer() | nil,
           log_start_offset: non_neg_integer() | nil,
           throttle_time_ms: non_neg_integer() | nil
@@ -42,7 +43,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
     * `:topic` - (required) The topic name
     * `:partition` - (required) The partition number
-    * `:base_offset` - (required) The base offset assigned to the batch
+    * `:base_offset` - (required) The base offset assigned to the batch, `nil` for `acks: 0`
     * `:log_append_time` - The broker-assigned timestamp (-1 if not using LogAppendTime)
     * `:log_start_offset` - The log start offset (v5+)
     * `:throttle_time_ms` - Request throttle time in milliseconds (v3+)
@@ -64,7 +65,7 @@ defmodule KafkaEx.Messages.RecordMetadata do
 
   This is an alias for `base_offset` to match Java API.
   """
-  @spec offset(t()) :: non_neg_integer()
+  @spec offset(t()) :: non_neg_integer() | nil
   def offset(%__MODULE__{base_offset: offset}), do: offset
 
   @doc """

--- a/lib/kafka_ex/network/network_client.ex
+++ b/lib/kafka_ex/network/network_client.ex
@@ -102,7 +102,9 @@ defmodule KafkaEx.Network.NetworkClient do
       {_, reason} ->
         broker_str = inspect_broker(broker.host, broker.port)
         Logger.error("Asynchronously sending data to broker #{broker_str} failed with #{inspect(reason)}")
-        reason
+        # A self-close is silent (no {:tcp_closed} to the owner), so emit the close event here.
+        close_socket(broker, socket, :send_error)
+        {:error, reason}
     end
   end
 

--- a/test/integration/produce/reliability_test.exs
+++ b/test/integration/produce/reliability_test.exs
@@ -17,22 +17,56 @@ defmodule KafkaEx.Integration.Produce.ReliabilityTest do
   end
 
   describe "produce with different acks settings" do
-    test "produce with acks=0 (fire and forget) succeeds", %{client: client} do
+    test "produce with acks=0 (fire and forget) returns no offset", %{client: client} do
       topic_name = generate_random_string()
       _ = create_topic(client, topic_name)
 
+      # A fire-and-forget batch is dropped without a trace while the partition leader is still
+      # being elected, so establish the leader with an acknowledged produce first.
+      {:ok, %RecordMetadata{base_offset: base_offset}} =
+        API.produce(client, topic_name, 0, [%{value: "leader-warmup"}], acks: -1)
+
       messages = [%{value: "acks-0-message"}]
 
-      {:ok, result} = API.produce(client, topic_name, 0, messages, required_acks: 0)
+      {:ok, result} = API.produce(client, topic_name, 0, messages, acks: 0)
+      {:ok, _} = API.produce(client, topic_name, 0, messages, acks: 0)
 
       assert %RecordMetadata{} = result
       assert result.topic == topic_name
       assert result.partition == 0
+      assert result.base_offset == nil
 
-      # Wait for message to arrive and verify via fetch
-      Process.sleep(500)
-      {:ok, latest} = API.latest_offset(client, topic_name, 0)
-      assert latest >= 1
+      # Two async sends followed by a synchronous request on the same socket: proves the
+      # response-less produce leaves no bytes behind to desynchronise the next request.
+      wait_for(
+        fn ->
+          {:ok, latest} = API.latest_offset(client, topic_name, 0)
+          latest >= base_offset + 3
+        end,
+        200,
+        25
+      )
+    end
+
+    test "produce with the deprecated required_acks: 0 alias still fires and forgets", %{client: client} do
+      topic_name = generate_random_string()
+      _ = create_topic(client, topic_name)
+
+      {:ok, %RecordMetadata{base_offset: base_offset}} =
+        API.produce(client, topic_name, 0, [%{value: "leader-warmup"}], acks: -1)
+
+      {:ok, result} = API.produce(client, topic_name, 0, [%{value: "alias-message"}], required_acks: 0)
+
+      assert %RecordMetadata{base_offset: nil} = result
+
+      wait_for(
+        fn ->
+          {:ok, latest} = API.latest_offset(client, topic_name, 0)
+          latest >= base_offset + 2
+        end,
+        200,
+        25
+      )
     end
 
     test "produce with acks=1 (leader only) succeeds", %{client: client} do

--- a/test/kafka_ex/client/client_test.exs
+++ b/test/kafka_ex/client/client_test.exs
@@ -1,13 +1,18 @@
 defmodule KafkaEx.ClientTest do
   use ExUnit.Case, async: false
+  use Mimic
 
   import ExUnit.CaptureLog
   import KafkaEx.TestSupport.ProcessHelpers
 
   alias KafkaEx.Client
+  alias KafkaEx.Client.Error
   alias KafkaEx.Client.State
   alias KafkaEx.Cluster.Broker
   alias KafkaEx.Cluster.ClusterMetadata
+  alias KafkaEx.Cluster.Topic
+  alias KafkaEx.Messages.RecordMetadata
+  alias KafkaEx.Network.NetworkClient
   alias KafkaEx.Network.Socket
 
   # Tiny GenServer that delegates :tcp_closed/:ssl_closed to
@@ -98,6 +103,120 @@ defmodule KafkaEx.ClientTest do
         )
 
       assert match?({:reply, _, _}, result)
+    end
+  end
+
+  # Regression: `:required_acks` never reached the wire (the request builder reads `:acks`), so
+  # `acks: 0` was unreachable — and once reachable it crashed on `byte_size(:ok)` and was retried.
+  describe "handle_call/3 - produce acks" do
+    setup :set_mimic_private
+
+    setup do
+      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false])
+      {:ok, lport} = :inet.port(listen)
+      {:ok, sock} = :gen_tcp.connect(~c"localhost", lport, [:binary, active: false])
+
+      on_exit(fn ->
+        :gen_tcp.close(sock)
+        :gen_tcp.close(listen)
+      end)
+
+      broker = %Broker{node_id: 1, host: "localhost", port: lport, socket: %Socket{socket: sock, ssl: false}}
+
+      state = %State{
+        api_versions: %{0 => {0, 8}},
+        correlation_id: 1,
+        cluster_metadata: %ClusterMetadata{
+          brokers: %{1 => broker},
+          topics: %{"t" => %Topic{name: "t", partition_leaders: %{0 => 1}}}
+        }
+      }
+
+      {:ok, state: state}
+    end
+
+    test "acks: 0 is sent fire-and-forget, exactly once, and returns no offset", %{state: state} do
+      stub_sends(:ok)
+
+      {:reply, reply, state_out} = produce(state, acks: 0)
+
+      assert {:ok, %RecordMetadata{topic: "t", partition: 0, base_offset: nil}} = reply
+      assert state_out.correlation_id == state.correlation_id + 1
+      assert_received :async_sent
+      refute_received :async_sent
+      refute_received :sync_sent
+    end
+
+    test "a failed fire-and-forget send is reported as an error, not a crash, and is sent once", %{state: state} do
+      stub_sends({:error, :closed})
+
+      {:reply, reply, state_out} = produce(state, acks: 0)
+
+      assert {:error, %Error{error: :closed}} = reply
+      assert state_out.correlation_id == state.correlation_id + 1
+      assert_received :async_sent
+      refute_received :async_sent
+    end
+
+    test "an acks value the wire cannot carry is rejected without touching the socket", %{state: state} do
+      stub_sends(:ok)
+
+      for opts <- [[acks: :bogus], [required_acks: 65_536], [acks: nil], [required_acks: 2]] do
+        assert {:reply, {:error, :invalid_acks}, ^state} = produce(state, opts)
+      end
+
+      refute_received :async_sent
+      refute_received :sync_sent
+    end
+
+    test "the Java/librdkafka :all / :any spelling reaches the wire as -1", %{state: state} do
+      stub_sends()
+      attach_produce_start_handler()
+
+      produce(state, acks: :all)
+      assert_received {:produce_start, %{required_acks: -1}}
+
+      produce(state, acks: :any)
+      assert_received {:produce_start, %{required_acks: -1}}
+
+      assert_received :sync_sent
+    end
+
+    test "the deprecated :required_acks is honoured when :acks is absent", %{state: state} do
+      stub_sends(:ok)
+
+      {:reply, reply, _state} = produce(state, required_acks: 0)
+
+      assert {:ok, %RecordMetadata{base_offset: nil}} = reply
+      assert_received :async_sent
+    end
+
+    test "the deprecated :required_acks loses to an explicit :acks", %{state: state} do
+      stub_sends()
+
+      produce(state, required_acks: 0, acks: 1)
+
+      assert_received :sync_sent
+      refute_received :sync_sent
+      refute_received :async_sent
+    end
+
+    test "telemetry reports the acks value that reaches the wire", %{state: state} do
+      stub_sends()
+      attach_produce_start_handler()
+
+      produce(state, acks: 1, required_acks: -1)
+
+      assert_received {:produce_start, %{required_acks: 1}}
+    end
+
+    test "acks defaults to -1 when neither option is given", %{state: state} do
+      stub_sends()
+      attach_produce_start_handler()
+
+      produce(state, [])
+
+      assert_received {:produce_start, %{required_acks: -1}}
     end
   end
 
@@ -343,6 +462,43 @@ defmodule KafkaEx.ClientTest do
     end
   end
 
+  # A broker rejecting an acks=0 produce signals it by resetting the connection, so these
+  # messages are on the normal error path for fire-and-forget, not an exotic case.
+  describe "handle_info/2 - socket errors and unknown messages" do
+    test "{:tcp_error, port, reason} clears the matching broker's socket" do
+      port = open_tcp_port()
+      state = build_state(%{1 => broker_with_port(1, port)})
+
+      assert {:noreply, new_state} = Client.handle_info({:tcp_error, port, :econnreset}, state)
+
+      [broker] = State.brokers(new_state)
+      assert broker.socket == nil
+    end
+
+    test "{:ssl_error, ref, reason} clears the matching broker's socket" do
+      ref = make_ref()
+      state = build_state(%{1 => broker_with_ssl_ref(1, ref)})
+
+      assert {:noreply, new_state} = Client.handle_info({:ssl_error, ref, :closed}, state)
+
+      [broker] = State.brokers(new_state)
+      assert broker.socket == nil
+    end
+
+    test "an unknown message does not kill the client and is logged" do
+      port = open_tcp_port()
+      state = build_state(%{1 => broker_with_port(1, port)})
+
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^state} = Client.handle_info(:something_unexpected, state)
+        end)
+
+      assert log =~ "ignoring unexpected message"
+      assert log =~ ":something_unexpected"
+    end
+  end
+
   describe "telemetry emission on remote close [issue #449]" do
     test "emits [:kafka_ex, :connection, :close] with :remote_closed on :tcp_closed" do
       port = open_tcp_port()
@@ -371,6 +527,35 @@ defmodule KafkaEx.ClientTest do
         assert metadata.host == broker.host
         assert metadata.port == broker.port
         assert metadata.reason == :remote_closed
+      end)
+    end
+
+    test "emits :recv_error on :tcp_error rather than the raw posix reason" do
+      port = open_tcp_port()
+      broker = broker_with_port(1, port)
+      state = build_state(%{1 => broker})
+
+      with_telemetry_handler(fn ->
+        log = capture_log(fn -> {:noreply, _} = Client.handle_info({:tcp_error, port, :econnreset}, state) end)
+
+        assert_receive {:telemetry, [:kafka_ex, :connection, :close], %{count: 1}, metadata}
+        assert metadata.reason == :recv_error
+        assert log =~ ":econnreset"
+      end)
+    end
+
+    test "emits :recv_error on :ssl_error even when the reason is a complex term" do
+      ref = make_ref()
+      broker = broker_with_ssl_ref(1, ref)
+      state = build_state(%{1 => broker})
+      alert = {:tls_alert, {:handshake_failure, ~c"bad certificate"}}
+
+      with_telemetry_handler(fn ->
+        log = capture_log(fn -> {:noreply, _} = Client.handle_info({:ssl_error, ref, alert}, state) end)
+
+        assert_receive {:telemetry, [:kafka_ex, :connection, :close], %{count: 1}, metadata}
+        assert metadata.reason == :recv_error
+        assert log =~ "handshake_failure"
       end)
     end
 
@@ -530,5 +715,36 @@ defmodule KafkaEx.ClientTest do
     after
       0 -> :ok
     end
+  end
+
+  defp produce(state, opts) do
+    Client.handle_call({:produce, "t", 0, [%{value: "v"}], opts}, self(), state)
+  end
+
+  defp stub_sends(async_result \\ :ok) do
+    test_pid = self()
+
+    stub(NetworkClient, :send_async_request, fn _broker, _wire ->
+      send(test_pid, :async_sent)
+      async_result
+    end)
+
+    stub(NetworkClient, :send_sync_request, fn _broker, _wire, _timeout ->
+      send(test_pid, :sync_sent)
+      {:error, :stubbed}
+    end)
+  end
+
+  defp attach_produce_start_handler do
+    handler_id = "produce-acks-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :produce, :start],
+      fn _event, _measurements, metadata, pid -> send(pid, {:produce_start, metadata}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
   end
 end

--- a/test/kafka_ex/network/network_client_test.exs
+++ b/test/kafka_ex/network/network_client_test.exs
@@ -1,5 +1,6 @@
 defmodule KafkaEx.Network.NetworkClientTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
   import KafkaEx.TestHelpers
 
   alias KafkaEx.Network.NetworkClient
@@ -103,6 +104,40 @@ defmodule KafkaEx.Network.NetworkClientTest do
 
       Process.exit(pid, :normal)
       :gen_tcp.close(tcp_socket)
+    end
+
+    test "a failed send returns the reason, closes the socket and emits a :send_error close event" do
+      port = get_free_port(3070)
+      pid = KafkaEx.TestSupport.Server.start(port)
+
+      {:ok, tcp_socket} = :gen_tcp.connect(~c"localhost", port, [:binary, {:active, false}, {:packet, 0}])
+
+      kafka_socket = %KafkaEx.Network.Socket{socket: tcp_socket, ssl: false}
+      broker = %{socket: kafka_socket, host: "localhost", port: port}
+      :ok = :gen_tcp.close(tcp_socket)
+
+      handler_id = "network-client-send-error-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:kafka_ex, :connection, :close],
+          fn _name, measurements, metadata, _ -> send(test_pid, {:telemetry, measurements, metadata}) end,
+          nil
+        )
+
+      try do
+        capture_log(fn ->
+          assert {:error, :closed} == NetworkClient.send_async_request(broker, "test data")
+        end)
+
+        assert {:error, :closed} == :gen_tcp.send(tcp_socket, <<>>)
+        assert_receive {:telemetry, _measurements, %{reason: :send_error, host: "localhost", port: ^port}}
+      after
+        :telemetry.detach(handler_id)
+        Process.exit(pid, :normal)
+      end
     end
   end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -52,6 +52,20 @@ messages = [%{value: "msg1", key: "k1"}, %{value: "msg2", key: "k2"}]
 # CORRECT - With compression
 {:ok, metadata} = KafkaEx.API.produce(client, "topic", 0, messages, compression: :gzip)
 
+# CORRECT - Durability: -1 (default) all in-sync replicas, 1 leader only.
+# -1/0/1 plus :all/:any (Java spelling, treated as -1) are accepted; anything else
+# returns {:error, :invalid_acks}
+{:ok, metadata} = KafkaEx.API.produce(client, "topic", 0, messages, acks: 1)
+
+# CAUTION - acks: 0 is fire-and-forget: {:ok, _} only means "handed to the socket",
+# metadata.base_offset is nil, nothing is retried, and a broker-side rejection shows up
+# as a closed connection, so records can be lost silently. The call still round-trips
+# through the client process, so it is not a latency escape hatch.
+{:ok, %{base_offset: nil}} = KafkaEx.API.produce(client, "topic", 0, messages, acks: 0)
+
+# DEPRECATED - :required_acks is an alias for :acks, removed in 2.0
+KafkaEx.API.produce(client, "topic", 0, messages, required_acks: 1)
+
 # WRONG - Missing client parameter
 KafkaEx.produce("topic", 0, "message")  # This is legacy API, don't use in v1.0 code
 ```


### PR DESCRIPTION
## Summary

The `acks` produce option has been ignored since 1.0. The protocol layer reads `:acks`, but the client only ever passed `:required_acks`, so every produce went out as `acks: -1` regardless of what the caller asked for. This branch resolves `acks` once at the client boundary, makes `acks: 0` (fire-and-forget) actually work instead of crashing, and adds socket-error handling so a failed send or an unexpected message can't take the client process down.

## Changes

**Produce path (`client.ex`)**
- `resolve_acks/1`: validates on the way in — `-1/0/1` pass, `:all`/`:any` map to `-1` (Java/librdkafka spelling), anything else returns `{:error, :invalid_acks}` before touching the socket. Canonicalises to `:acks` in opts so the protocol layer finally receives the right value.
- Dedicated `handle_produce_request(%{acks: 0})`: sent asynchronously, never retried (a retry would duplicate records), returns `RecordMetadata{base_offset: nil}`. A failed send is reported as a transport error, not a crash.
- New `handle_info` clauses for `{:tcp_error}` / `{:ssl_error}` (clear the broker socket) plus a catch-all that logs and ignores unknown messages instead of crashing the client.

**Public contract**
- `RecordMetadata.base_offset` and `offset/1` gain `... | nil` (for `acks: 0`).
- `api.ex` docs `:acks` as canonical, `:required_acks` as a deprecated alias (removed in 2.0), and spells out the fire-and-forget / record-loss semantics.

**Network (`network_client.ex`)**
- A failed `send_async_request` now closes the socket and emits a close event itself (a self-close is silent — no `{:tcp_closed}` reaches the owner) and returns `{:error, reason}` instead of a bare `reason`.

**Tests / docs**
- `client_test.exs`, `network_client_test.exs`: full coverage of the acks paths, including "exactly once" proven via `refute_received`.
- `reliability_test.exs` (integration): acks=0 does not desynchronise the socket; the test warms up the partition leader before firing and forgetting.
- CHANGELOG + usage-rules.

## Worth a closer look

- **This is a breaking change.** A caller passing `required_acks: 0` for durability used to get `acks: -1` (wait for all in-sync replicas, real offset). It now gets true fire-and-forget: `base_offset: nil` and possible silent record loss. Callers pattern-matching on an integer offset will break at runtime. The default is `-1`, so anyone who set nothing is unaffected.
- **Integration tests were not run in review** (tagged `produce`, needs the Docker cluster) — reviewed and they look right, but worth running against a broker before merge.
- **Telemetry payload changed silently**: `[:kafka_ex, :produce, :start]` metadata now carries `required_acks: -1` by default instead of `1` — observable for existing handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
