### PR TITLE
fix(consumer): retry fetch failures instead of taking the group down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
   `PartitionInfo` carries the broker's `error_code`.
 * **`:no_broker` says why in the log.** Unknown topic vs. leaderless partition vs. unknown node are
   now distinguished (logged at debug); the returned error is unchanged.
+* **A moving partition leader no longer takes down the whole consumer group.** `GenConsumer` used to
+  stop on any fetch error but `:offset_out_of_range`, and because `ConsumerGroup` supervises with
+  `max_restarts: 0`, one partition losing its leader killed the whole group. The fetch loop now
+  retries transient errors — leader moves, `:no_broker`, timeouts, and non-atom SSL reasons (mapped
+  to a retryable `:transport_error`) — with jittered backoff (`:fetch_retry_base_delay_ms` to
+  `:fetch_retry_max_delay_ms`) instead of stopping, matching brod, KafkaJS and librdkafka. A
+  partition stuck past `:fetch_unavailable_warn_ms` (default 30s) is surfaced once via a
+  `Logger.error` and a `[:kafka_ex, :consumer, :partition_unavailable]` telemetry event. A failed
+  `:offset_out_of_range` reset backs off instead of raising a `MatchError`.
 
 ## 1.1.1 (2026-07-24)
 

--- a/lib/kafka_ex/client/client.ex
+++ b/lib/kafka_ex/client/client.ex
@@ -994,7 +994,9 @@ defmodule KafkaEx.Client do
   end
 
   defp build_transport_error(reason) when is_atom(reason), do: Error.build(reason, %{})
-  defp build_transport_error(reason), do: Error.build(:unknown, %{transport_reason: reason})
+  # A non-atom reason (SSL {:tls_alert, _}) would collapse to :unknown, which the fetch loop treats
+  # as fatal; tag it retryable instead.
+  defp build_transport_error(reason), do: Error.build(:transport_error, %{transport_reason: reason})
 
   defp handle_request_error(%RequestContext{} = ctx, state, retry_count, error) do
     request_name = ctx.request.__struct__

--- a/lib/kafka_ex/consumer/gen_consumer.ex
+++ b/lib/kafka_ex/consumer/gen_consumer.ex
@@ -91,7 +91,8 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
   * `:commit_interval` is the maximum time (in milliseconds) that a
     `KafkaEx.Consumer.GenConsumer` will delay committing the offset for an acknowledged
-    message.
+    message. The interval is a deadline checked at the end of a fetch cycle, not a
+    timer, so a fetch backoff (see *Fetch failure handling*) stretches it.
 
   * `:commit_threshold` is the maximum number of acknowledged messages that a
     `KafkaEx.Consumer.GenConsumer` will allow to be uncommitted before triggering a
@@ -115,6 +116,33 @@ defmodule KafkaEx.Consumer.GenConsumer do
   For low-volume topics, `:commit_interval` is the dominant factor for how
   often a `KafkaEx.Consumer.GenConsumer` auto-commits. For high-volume topics,
   `:commit_threshold` is the dominant factor.
+
+  ## Fetch failure handling
+
+  A fetch error that `KafkaEx.Support.Retry.fetch_retryable?/1` accepts — a leader
+  move (`:not_leader_for_partition`, `:leader_not_available`), `:no_broker`, a
+  closed socket, a timeout — makes the consumer back off and retry rather than
+  stop. Stopping would take the whole group down, because
+  `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`. Retries are
+  unbounded, matching brod, KafkaJS and librdkafka, with jittered exponential
+  backoff from `:fetch_retry_base_delay_ms` (250) to `:fetch_retry_max_delay_ms`
+  (5000), both settable in the `:kafka_ex` app environment. A warning naming the
+  error and the consecutive failure count is logged while the backoff ramps, then
+  roughly once a minute. Any other fetch error still stops the consumer.
+
+  Retries never give up, so a partition that is not merely mid-leader-move but genuinely stuck (a
+  deleted topic, a leader that never returns) is surfaced once, after
+  `:fetch_unavailable_warn_ms` (default 30000, settable in the `:kafka_ex` app environment) of
+  continuous failure, as a `Logger.error` and a `[:kafka_ex, :consumer, :partition_unavailable]`
+  telemetry event. The consumer keeps retrying; the signal just makes a non-recovering partition
+  alertable without a human reading the logs. This mirrors librdkafka's
+  `topic.metadata.propagation.max.ms`.
+
+  The same backoff covers a failed `:offset_out_of_range` reset, which needs a
+  live leader of its own. It does **not** cover establishing the starting offset
+  at startup: `load_offsets/1` still raises if the committed offset or the reset
+  offset cannot be read, so a consumer that starts while its leader is moving
+  still fails to start.
 
   ## Handler state and interaction
 
@@ -440,8 +468,12 @@ defmodule KafkaEx.Consumer.GenConsumer do
       :fetch_options,
       :api_versions,
       :group_manager_pid,
+      :fetch_retry_at,
+      :fetch_failing_since,
       # true only when we started the client — a caller-supplied (shared) :client must not be stopped.
-      owns_client: false
+      owns_client: false,
+      fetch_error_count: 0,
+      fetch_unavailable_reported: false
     ]
 
     @type t :: %__MODULE__{
@@ -463,7 +495,11 @@ defmodule KafkaEx.Consumer.GenConsumer do
             fetch_options: Keyword.t(),
             api_versions: map(),
             group_manager_pid: pid() | nil,
-            owns_client: boolean()
+            fetch_retry_at: integer() | nil,
+            fetch_failing_since: integer() | nil,
+            owns_client: boolean(),
+            fetch_error_count: non_neg_integer(),
+            fetch_unavailable_reported: boolean()
           }
   end
 
@@ -475,6 +511,13 @@ defmodule KafkaEx.Consumer.GenConsumer do
   # Uses KafkaEx.Support.Retry for unified retry logic with exponential backoff
   @commit_max_attempts 3
   @commit_base_delay_ms 100
+
+  # Low cap — a leader move is usually sub-second; jittered against a synchronized restart.
+  @fetch_retry_base_delay_ms 250
+  @fetch_retry_max_delay_ms 5_000
+
+  # After this long of continuous failure a partition is clearly stuck, not mid-move; surface it once.
+  @fetch_unavailable_warn_ms 30_000
 
   # Client API
 
@@ -772,15 +815,10 @@ defmodule KafkaEx.Consumer.GenConsumer do
   end
 
   def handle_info(:timeout, %State{} = state) do
-    case consume(state) do
-      {:error, reason} ->
-        {:stop, reason, state}
-
-      {:noreply, new_state} ->
-        {:noreply, new_state, 0}
-
-      {:stop, _reason, _final_state} = stop ->
-        stop
+    # Any inbound message re-arms this at timeout 0, so honour the backoff deadline held in state.
+    case fetch_backoff_remaining(state) do
+      0 -> consume_cycle(state)
+      remaining -> {:noreply, state, remaining}
     end
   end
 
@@ -853,16 +891,105 @@ defmodule KafkaEx.Consumer.GenConsumer do
 
     case KafkaExAPI.fetch(client, topic, partition, offset, fetch_opts) do
       {:ok, fetch_result} ->
-        handle_new_fetch_response(fetch_result, state)
+        handle_new_fetch_response(fetch_result, clear_fetch_errors(state))
 
       {:error, :offset_out_of_range} ->
-        new_state = handle_offset_out_of_range(state)
-        handle_commit(:async_commit, new_state)
+        case handle_offset_out_of_range(clear_fetch_errors(state)) do
+          {:ok, new_state} -> handle_commit(:async_commit, new_state)
+          {:error, reason} -> {:error, reason, state}
+        end
 
       {:error, reason} ->
-        {:error, reason}
+        {:error, reason, state}
     end
   end
+
+  defp consume_cycle(%State{} = state) do
+    case consume(state) do
+      {:error, reason, new_state} ->
+        handle_fetch_error(reason, new_state)
+
+      {:noreply, new_state} ->
+        {:noreply, new_state, 0}
+
+      {:stop, _reason, _final_state} = stop ->
+        stop
+    end
+  end
+
+  defp handle_fetch_error(reason, %State{fetch_error_count: count} = state) do
+    if Retry.fetch_retryable?(reason) do
+      now = :erlang.monotonic_time(:milli_seconds)
+      failing_since = state.fetch_failing_since || now
+      delay = Retry.backoff_delay_jittered(count, fetch_retry_base_delay_ms(), fetch_retry_max_delay_ms())
+
+      if log_fetch_retry?(count) do
+        Logger.warning(
+          "Fetch failed for #{state.topic}/#{state.partition} with #{inspect(reason)}, " <>
+            "retrying in #{delay}ms (consecutive failures: #{count + 1})"
+        )
+      end
+
+      new_state =
+        %State{
+          state
+          | fetch_error_count: count + 1,
+            fetch_retry_at: now + delay,
+            fetch_failing_since: failing_since
+        }
+        |> maybe_report_unavailable(reason, now - failing_since)
+
+      {:noreply, new_state, delay}
+    else
+      {:stop, reason, state}
+    end
+  end
+
+  # Retries never stop, so a genuinely stuck partition would otherwise only show in logs; flag it once.
+  defp maybe_report_unavailable(%State{fetch_unavailable_reported: true} = state, _reason, _elapsed), do: state
+
+  defp maybe_report_unavailable(%State{} = state, reason, elapsed) do
+    if elapsed >= fetch_unavailable_warn_ms() do
+      Logger.error(
+        "Partition #{state.topic}/#{state.partition} has been unavailable for #{elapsed}ms " <>
+          "(#{inspect(reason)}); still retrying"
+      )
+
+      Telemetry.emit_partition_unavailable(state.group, state.topic, state.partition, elapsed, reason)
+      %State{state | fetch_unavailable_reported: true}
+    else
+      state
+    end
+  end
+
+  # Loud while the backoff ramps, then ~once a minute, so a stuck partition stays visible.
+  defp log_fetch_retry?(count), do: count < 5 or rem(count, 12) == 0
+
+  defp fetch_backoff_remaining(%State{fetch_retry_at: nil}), do: 0
+
+  defp fetch_backoff_remaining(%State{fetch_retry_at: retry_at}),
+    do: max(retry_at - :erlang.monotonic_time(:milli_seconds), 0)
+
+  defp clear_fetch_errors(%State{fetch_error_count: 0, fetch_retry_at: nil, fetch_failing_since: nil} = state),
+    do: state
+
+  defp clear_fetch_errors(%State{} = state),
+    do: %{
+      state
+      | fetch_error_count: 0,
+        fetch_retry_at: nil,
+        fetch_failing_since: nil,
+        fetch_unavailable_reported: false
+    }
+
+  defp fetch_retry_base_delay_ms,
+    do: Application.get_env(:kafka_ex, :fetch_retry_base_delay_ms, @fetch_retry_base_delay_ms)
+
+  defp fetch_retry_max_delay_ms,
+    do: Application.get_env(:kafka_ex, :fetch_retry_max_delay_ms, @fetch_retry_max_delay_ms)
+
+  defp fetch_unavailable_warn_ms,
+    do: Application.get_env(:kafka_ex, :fetch_unavailable_warn_ms, @fetch_unavailable_warn_ms)
 
   # The broker returned batches but every record was filtered out (control
   # batches — transaction commit/abort markers). Advance past them to next_offset, otherwise the
@@ -927,29 +1054,30 @@ defmodule KafkaEx.Consumer.GenConsumer do
            auto_offset_reset: auto_offset_reset
          } = state
        ) do
-    offset =
-      case auto_offset_reset do
-        :earliest ->
-          {:ok, offset} = KafkaExAPI.earliest_offset(client, topic, partition)
-          offset
+    # The reset needs a live leader too, so it fails exactly when a leader is
+    # moving. Hand that back rather than letting a MatchError kill the group.
+    case reset_offset(client, topic, partition, auto_offset_reset) do
+      {:ok, offset} ->
+        report_offset_reset(state, auto_offset_reset, offset, :offset_out_of_range)
 
-        :latest ->
-          {:ok, offset} = KafkaExAPI.latest_offset(client, topic, partition)
-          offset
+        {:ok,
+         %State{
+           state
+           | current_offset: offset,
+             committed_offset: offset,
+             acked_offset: offset
+         }}
 
-        :none ->
-          raise "Offset out of range while consuming topic #{topic}, partition #{partition}."
-      end
-
-    report_offset_reset(state, auto_offset_reset, offset, :offset_out_of_range)
-
-    %State{
-      state
-      | current_offset: offset,
-        committed_offset: offset,
-        acked_offset: offset
-    }
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
+
+  defp reset_offset(client, topic, partition, :earliest), do: KafkaExAPI.earliest_offset(client, topic, partition)
+  defp reset_offset(client, topic, partition, :latest), do: KafkaExAPI.latest_offset(client, topic, partition)
+
+  defp reset_offset(_client, topic, partition, :none),
+    do: raise("Offset out of range while consuming topic #{topic}, partition #{partition}.")
 
   defp handle_commit(:sync_commit, %State{} = state), do: commit(state)
 

--- a/lib/kafka_ex/support/retry.ex
+++ b/lib/kafka_ex/support/retry.ex
@@ -44,11 +44,10 @@ defmodule KafkaEx.Support.Retry do
   @default_max_attempts 3
   @default_base_delay_ms 100
   @default_max_delay_ms :infinity
-  # ±20% uniform jitter on each backoff, matching Kafka's KIP-580
-  # (retry.backoff.ms grows exponentially up to retry.backoff.max.ms with ±20%
-  # jitter). Jitter decorrelates retries across many members so they do not
-  # thundering-herd the coordinator/broker after a shared failure.
+  # ±20% jitter (KIP-580) decorrelates retries so members don't thundering-herd after a shared failure.
   @jitter_fraction 0.2
+  # Past this the delay dwarfs any sane cap; clamping keeps the shift cheap.
+  @max_backoff_exponent 32
 
   @doc """
   Calculate exponential backoff delay.
@@ -75,7 +74,8 @@ defmodule KafkaEx.Support.Retry do
   @spec backoff_delay(non_neg_integer(), non_neg_integer(), non_neg_integer() | :infinity) ::
           non_neg_integer()
   def backoff_delay(attempt, base_ms, max_ms \\ @default_max_delay_ms) do
-    delay = trunc(base_ms * :math.pow(2, attempt))
+    # Integer shift, not :math.pow, which overflows to ArithmeticError past attempt 1023.
+    delay = base_ms * Bitwise.bsl(1, min(attempt, @max_backoff_exponent))
 
     case max_ms do
       :infinity -> delay
@@ -99,8 +99,7 @@ defmodule KafkaEx.Support.Retry do
       |> backoff_delay(base_ms, max_ms)
       |> apply_jitter()
 
-    # Keep the result within the cap — jitter is applied after the exponential
-    # cap, so clamp so a delay never exceeds max_ms (KIP-580 jitters within bound).
+    # Jitter is applied after the cap, so clamp to keep the delay within max_ms.
     case max_ms do
       :infinity -> jittered
       cap when is_integer(cap) -> min(jittered, cap)
@@ -115,7 +114,6 @@ defmodule KafkaEx.Support.Retry do
     if spread <= 0 do
       delay
     else
-      # uniform in [delay - spread, delay + spread]
       delay - spread + (:rand.uniform(2 * spread + 1) - 1)
     end
   end
@@ -214,6 +212,8 @@ defmodule KafkaEx.Support.Retry do
   def transient_error?(:no_broker), do: true
   def transient_error?(:econnreset), do: true
   def transient_error?(:not_connected), do: true
+  # Normalised non-atom socket reason (e.g. SSL {:tls_alert, _}); a broken connection is transient.
+  def transient_error?(:transport_error), do: true
   def transient_error?(error), do: coordinator_error?(error)
 
   @doc """
@@ -261,6 +261,17 @@ defmodule KafkaEx.Support.Retry do
   def leadership_error?(:fenced_leader_epoch), do: true
   def leadership_error?(:unknown_topic_or_partition), do: true
   def leadership_error?(_), do: false
+
+  @doc """
+  Retriability for the consumer's fetch loop.
+
+  A leader move leaves the partition unreachable for as long as the new leader
+  takes to open it, so stopping the consumer would take the whole group down with
+  it. brod (`err_op/1` → `reset_connection`), KafkaJS (`retriable` errors restart
+  the consumer) and librdkafka (fast leader query) all back off and retry instead.
+  """
+  @spec fetch_retryable?(error()) :: boolean()
+  def fetch_retryable?(error), do: transient_error?(error) or leadership_error?(error)
 
   @doc """
   Check if error is safe to retry for produce operations.

--- a/lib/kafka_ex/telemetry.ex
+++ b/lib/kafka_ex/telemetry.ex
@@ -222,6 +222,14 @@ defmodule KafkaEx.Telemetry do
     * Measurements: `%{count: 1, crashes_in_window: non_neg_integer()}`
     * Metadata: `%{group_id: binary(), member_id: binary(), reason: term()}`
 
+  * `[:kafka_ex, :consumer, :partition_unavailable]` - Emitted once when a partition has been
+    continuously unavailable to a consumer for longer than `:fetch_unavailable_warn_ms` (default
+    30s). The consumer keeps retrying regardless; this only flags a partition that is not
+    recovering (a persistently missing topic, a leader that never returns). Attach to alert on a
+    stuck partition without waiting for a human to read the logs.
+    * Measurements: `%{unavailable_ms: non_neg_integer()}`
+    * Metadata: `%{group_id: binary(), topic: binary(), partition: non_neg_integer(), reason: atom()}`
+
   ### Metadata Events
 
   * `[:kafka_ex, :metadata, :update, :start]` - Emitted when a metadata request begins
@@ -304,6 +312,7 @@ defmodule KafkaEx.Telemetry do
   @consumer_offset_reset [:kafka_ex, :consumer, :offset_reset]
   @consumer_member_terminated [:kafka_ex, :consumer, :member_terminated]
   @consumer_heartbeat_crash [:kafka_ex, :consumer, :heartbeat_crash]
+  @consumer_partition_unavailable [:kafka_ex, :consumer, :partition_unavailable]
 
   @metadata_update_start [:kafka_ex, :metadata, :update, :start]
   @metadata_update_stop [:kafka_ex, :metadata, :update, :stop]
@@ -332,7 +341,8 @@ defmodule KafkaEx.Telemetry do
                              @consumer_commit_failed,
                              @consumer_offset_reset,
                              @consumer_member_terminated,
-                             @consumer_heartbeat_crash
+                             @consumer_heartbeat_crash,
+                             @consumer_partition_unavailable
                            ]
   @consumer_process_events [@consumer_process_start, @consumer_process_stop, @consumer_process_exception]
   @consumer_events @consumer_commit_events ++ @consumer_group_events ++ @consumer_process_events
@@ -633,6 +643,27 @@ defmodule KafkaEx.Telemetry do
         reset: reset,
         reason: reason
       }
+    )
+  end
+
+  @doc """
+  Emitted once when a partition has been continuously unavailable to a consumer for longer than
+  `:fetch_unavailable_warn_ms` (default 30s). The consumer keeps retrying — this only surfaces a
+  partition that is not recovering (a persistently missing topic, a leader that never returns).
+  `unavailable_ms` is how long the failure streak had lasted; `reason` is the last fetch error.
+  """
+  @spec emit_partition_unavailable(
+          group_id :: binary(),
+          topic :: binary(),
+          partition :: non_neg_integer(),
+          unavailable_ms :: non_neg_integer(),
+          reason :: atom()
+        ) :: :ok
+  def emit_partition_unavailable(group_id, topic, partition, unavailable_ms, reason) do
+    :telemetry.execute(
+      @consumer_partition_unavailable,
+      %{unavailable_ms: unavailable_ms},
+      %{group_id: group_id, topic: topic, partition: partition, reason: reason}
     )
   end
 

--- a/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
+++ b/test/kafka_ex/consumer/gen_consumer_fetch_retry_test.exs
@@ -1,0 +1,177 @@
+defmodule KafkaEx.Consumer.GenConsumerFetchRetryTest do
+  @moduledoc """
+  A transient fetch error must not kill the consumer.
+
+  When a partition's leader moves (broker restart, RF=1 makes the window wide),
+  the client answers `:no_broker`. Stopping on it takes the whole group down with
+  it, because the ConsumerGroup supervisor runs `max_restarts: 0`. brod, KafkaJS
+  and librdkafka all back off and retry instead.
+
+  Driven through the real consume loop and the real `KafkaEx.API.fetch/5` reply
+  path, so the error is unwrapped by `normalize_reply/1` exactly as in production.
+  """
+  use ExUnit.Case, async: false
+
+  import KafkaEx.TestSupport.ProcessHelpers
+
+  alias KafkaEx.Client.Error
+  alias KafkaEx.Consumer.GenConsumer
+  alias KafkaEx.Test.MockClient
+
+  defmodule TestConsumer do
+    use KafkaEx.Consumer.GenConsumer
+    def handle_message_set(_messages, state), do: {:async_commit, state}
+    def handle_call(:ping, _from, state), do: {:reply, :pong, state}
+  end
+
+  setup do
+    Application.put_env(:kafka_ex, :fetch_retry_base_delay_ms, 10)
+    Application.put_env(:kafka_ex, :fetch_retry_max_delay_ms, 40)
+
+    on_exit(fn ->
+      Application.delete_env(:kafka_ex, :fetch_retry_base_delay_ms)
+      Application.delete_env(:kafka_ex, :fetch_retry_max_delay_ms)
+    end)
+
+    :ok
+  end
+
+  defp start_consumer(fetch_response) do
+    {:ok, client} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: 0, error_code: :no_error}]}]},
+        fetch: fetch_response,
+        offset_commit: {:ok, []}
+      })
+
+    Process.unlink(client)
+
+    {:ok, pid} = GenServer.start_link(GenConsumer, {TestConsumer, "g", "t", 0, [client: client]})
+    Process.unlink(pid)
+
+    on_exit(fn ->
+      stop_safely(pid)
+      stop_safely(client)
+    end)
+
+    {client, pid}
+  end
+
+  defp fetch_count(client) do
+    client |> MockClient.get_calls() |> Enum.count(&match?({:fetch, _, _, _, _}, &1))
+  end
+
+  defp wait_until(fun, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() -> :ok
+      System.monotonic_time(:millisecond) >= deadline -> flunk("condition not met before deadline")
+      true -> Process.sleep(10) && do_wait_until(fun, deadline)
+    end
+  end
+
+  test "keeps retrying a transient fetch error instead of stopping" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
+
+  test "a call served during backoff does not strand the consumer" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+    wait_until(fn -> fetch_count(client) >= 2 end)
+
+    before = fetch_count(client)
+    assert GenConsumer.call(pid, :ping) == :pong
+
+    wait_until(fn -> fetch_count(client) > before + 1 end)
+  end
+
+  test "keeps retrying a non-atom transport error (e.g. an SSL alert) instead of stopping" do
+    {client, pid} =
+      start_consumer({:error, Error.build(:transport_error, %{transport_reason: {:tls_alert, :bad_record_mac}})})
+
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
+
+  test "still stops on a fetch error that is not retryable" do
+    {_client, pid} = start_consumer({:error, Error.build(:topic_authorization_failed, %{})})
+    ref = Process.monitor(pid)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :topic_authorization_failed}, 2_000
+  end
+
+  test "surfaces a persistently unavailable partition once via telemetry, without stopping" do
+    Application.put_env(:kafka_ex, :fetch_unavailable_warn_ms, 0)
+    on_exit(fn -> Application.delete_env(:kafka_ex, :fetch_unavailable_warn_ms) end)
+
+    handler_id = "gen-consumer-unavailable-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:kafka_ex, :consumer, :partition_unavailable],
+      fn _name, measurements, metadata, _ -> send(test_pid, {:unavailable, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+
+    assert_receive {:unavailable, %{unavailable_ms: ms}, %{topic: "t", partition: 0, reason: :no_broker}}, 1_000
+    assert is_integer(ms) and ms >= 0
+
+    wait_until(fn -> fetch_count(client) >= 5 end)
+    refute_receive {:unavailable, _, _}, 200
+    assert Process.alive?(pid)
+  end
+
+  test "recovers and resumes consuming once the leader is back" do
+    {client, pid} = start_consumer({:error, Error.build(:no_broker, %{})})
+
+    wait_until(fn -> fetch_count(client) >= 3 end)
+
+    MockClient.put_response(client, :fetch, {:ok, %KafkaEx.Messages.Fetch{topic: "t", partition: 0, records: []}})
+
+    recovered = fetch_count(client)
+    wait_until(fn -> fetch_count(client) > recovered + 2 end)
+    assert Process.alive?(pid)
+  end
+
+  test "backs off instead of crashing when the offset reset cannot reach a leader" do
+    {:ok, client} =
+      MockClient.start_link(%{
+        offset_fetch: {:ok, [%{partition_offsets: [%{offset: 0, error_code: :no_error}]}]},
+        fetch: {:error, Error.build(:offset_out_of_range, %{})},
+        list_offsets: {:error, Error.build(:no_broker, %{})},
+        offset_commit: {:ok, []}
+      })
+
+    Process.unlink(client)
+
+    {:ok, pid} = GenServer.start_link(GenConsumer, {TestConsumer, "g", "t", 0, [client: client]})
+    Process.unlink(pid)
+
+    on_exit(fn ->
+      stop_safely(pid)
+      stop_safely(client)
+    end)
+
+    ref = Process.monitor(pid)
+
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 500
+
+    assert fetch_count(client) >= 3
+  end
+end

--- a/test/kafka_ex/support/retry_test.exs
+++ b/test/kafka_ex/support/retry_test.exs
@@ -226,6 +226,11 @@ defmodule KafkaEx.Support.RetryTest do
       assert Retry.transient_error?(:not_connected)
     end
 
+    test "transport_error (normalised non-atom socket reason) is transient" do
+      assert Retry.transient_error?(:transport_error)
+      assert Retry.fetch_retryable?(:transport_error)
+    end
+
     test "coordinator errors are transient" do
       assert Retry.transient_error?(:coordinator_not_available)
       assert Retry.transient_error?(:not_coordinator)
@@ -536,6 +541,13 @@ defmodule KafkaEx.Support.RetryTest do
     test "does not rejoin on terminal errors" do
       refute Retry.sync_rejoinable?(:fenced_instance_id)
       refute Retry.sync_rejoinable?(:group_authorization_failed)
+    end
+  end
+
+  describe "backoff_delay/3 with an unbounded retry loop" do
+    test "stays at the cap instead of overflowing the exponent" do
+      assert Retry.backoff_delay(2000, 500, 5000) == 5000
+      assert Retry.backoff_delay_jittered(2000, 500, 5000) <= 5000
     end
   end
 end

--- a/test/kafka_ex/telemetry_test.exs
+++ b/test/kafka_ex/telemetry_test.exs
@@ -180,8 +180,9 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_events()
 
       # 3 commit + 12 group (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash + 3 process = 23
-      assert length(events) == 23
+      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash + 1 partition_unavailable
+      # + 3 process = 24
+      assert length(events) == 24
 
       # Commit events
       assert [:kafka_ex, :consumer, :commit, :start] in events
@@ -205,6 +206,7 @@ defmodule KafkaEx.TelemetryTest do
       assert [:kafka_ex, :consumer, :offset_reset] in events
       assert [:kafka_ex, :consumer, :member_terminated] in events
       assert [:kafka_ex, :consumer, :heartbeat_crash] in events
+      assert [:kafka_ex, :consumer, :partition_unavailable] in events
 
       # Process events
       assert [:kafka_ex, :consumer, :process, :start] in events
@@ -218,13 +220,14 @@ defmodule KafkaEx.TelemetryTest do
       events = Telemetry.consumer_group_events()
 
       # 12 group events (join, sync, heartbeat, leave x 3) + 1 rebalance + 1 commit_failed
-      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash = 17
-      assert length(events) == 17
+      # + 1 offset_reset + 1 member_terminated + 1 heartbeat_crash + 1 partition_unavailable = 18
+      assert length(events) == 18
 
       assert [:kafka_ex, :consumer, :commit_failed] in events
       assert [:kafka_ex, :consumer, :offset_reset] in events
       assert [:kafka_ex, :consumer, :member_terminated] in events
       assert [:kafka_ex, :consumer, :heartbeat_crash] in events
+      assert [:kafka_ex, :consumer, :partition_unavailable] in events
 
       # Group lifecycle events
       assert [:kafka_ex, :consumer, :join, :start] in events

--- a/test/support/mock_client.ex
+++ b/test/support/mock_client.ex
@@ -140,6 +140,10 @@ defmodule KafkaEx.Test.MockClient do
     {:reply, Enum.reverse(state.calls), state}
   end
 
+  def handle_call({:put_response, operation, response}, _from, state) do
+    {:reply, :ok, %{state | responses: Map.put(state.responses, operation, response)}}
+  end
+
   defp record_call(state, call) do
     %{state | calls: [call | state.calls]}
   end
@@ -148,6 +152,11 @@ defmodule KafkaEx.Test.MockClient do
   Returns the list of calls made to the mock client in order.
   """
   def get_calls(pid), do: GenServer.call(pid, :get_calls)
+
+  @doc """
+  Swaps the canned reply for one operation, so a test can script recovery.
+  """
+  def put_response(pid, operation, response), do: GenServer.call(pid, {:put_response, operation, response})
 
   @doc """
   Polls until at least `expected_count` calls have been recorded, then returns them.


### PR DESCRIPTION
> **Last of three related fixes.** `master` already carries the produce (#593) and leaderless-metadata (#595) work; this PR is the runtime piece that makes a leader move survivable. The metadata fix keeps a transiently-leaderless partition in the cluster model; this fix makes the consumer back off and retry it instead of stopping.

## Summary

A fetch error used to stop the consumer: `handle_info(:timeout)` returned `{:stop, reason, state}` on any `{:error, reason}`. Because `KafkaEx.Consumer.ConsumerGroup` supervises with `max_restarts: 0`, one transient fetch failure — a leader move, a closed socket, an SSL alert — took the whole group down. This branch makes the consumer's fetch loop back off and retry transient/leadership errors, and only stop on errors that are genuinely fatal.

## Changes

**`gen_consumer.ex` — retry loop**
- `handle_info(:timeout)` now honours a backoff deadline held in state (`fetch_retry_at`) rather than stopping. It has to be a state deadline, not a bare GenServer timeout, because any inbound message re-arms the callback at timeout 0.
- `handle_fetch_error/2`: if `Retry.fetch_retryable?/1` accepts the error, compute a jittered exponential backoff (`:fetch_retry_base_delay_ms` 250 → `:fetch_retry_max_delay_ms` 5000, both app-env settable) and reschedule; otherwise `{:stop, reason, state}`. Retries are unbounded, matching brod / KafkaJS / librdkafka.
- A stuck partition (not mid-move — a deleted topic, a leader that never returns) is surfaced **once**, after `:fetch_unavailable_warn_ms` (default 30000) of continuous failure, as a `Logger.error` plus a `[:kafka_ex, :consumer, :partition_unavailable]` telemetry event. The consumer keeps retrying. Mirrors librdkafka's `topic.metadata.propagation.max.ms`.
- Retry logging is loud for the first few attempts, then ~once a minute.
- `handle_offset_out_of_range` now returns `{:ok, state}` / `{:error, reason}` instead of pattern-matching the reset offset with `=`. The reset needs a live leader too, so it fails exactly during a leader move — this hands the error back to the backoff path instead of crashing with a `MatchError`.

**`retry.ex`**
- New `fetch_retryable?/1` = `transient_error?/1 or leadership_error?/1` — the consumer fetch-loop retriability predicate.
- `transient_error?(:transport_error)` → true.
- `backoff_delay/3` uses an integer bit-shift with a clamped exponent instead of `:math.pow`, which overflows to `ArithmeticError` past attempt 1023 (reachable now that fetch retries are unbounded).

**`client.ex`**
- `build_transport_error/1` maps a non-atom reason (an SSL `{:tls_alert, _}` tuple) to a retryable `:transport_error` instead of `:unknown`, which the fetch loop treated as fatal — this is what took TLS clusters' groups down.

**`telemetry.ex`**
- New `[:kafka_ex, :consumer, :partition_unavailable]` event + `emit_partition_unavailable/5`, added to the consumer-group event list and moduledoc.

**Tests**
- `gen_consumer_fetch_retry_test.exs`: retry-not-stop on `:no_broker` and on an SSL-alert transport error (asserted via process `{:DOWN}` monitoring), a call served mid-backoff not stranding the consumer, still-stop on a non-retryable error, the once-only unavailable telemetry, recovery once the leader returns, and backoff on an unreachable offset reset.
- `retry_test.exs`, `telemetry_test.exs`, `mock_client.ex` updated.

## Worth a closer look

- **Retries are unbounded.** A permanently dead partition retries forever, flagged after 30s via telemetry. Deliberate, matching brod / KafkaJS / librdkafka, documented in the moduledoc — worth a conscious accept.
- **Startup is still not resilient.** `:none` `auto_offset_reset` still raises on offset-out-of-range, and `load_offsets/1` still raises if the starting offset can't be read, so a consumer that *starts* while its leader is moving still fails to start. Only the running consumer is now resilient. Documented as an intentional limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
