### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # KafkaEx Changelog
 
-## 1.1.2 (unreleased)
+## 1.1.2 (2026-09-09)
 
 ### Changed (Breaking)
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KafkaEx.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kafkaex/kafka_ex"
-  @version "1.1.1"
+  @version "1.1.2"
 
   def project do
     [


### PR DESCRIPTION
Cuts **v1.1.2**. Version bump in `mix.exs` and the CHANGELOG `1.1.2` section dated; no code changes. Ships three fixes already on `master`:

- **#593 — produce `acks` honoured.** `acks`/`required_acks` reaches the broker again (was pinned to `-1` since 1.0); `acks: 0` fire-and-forget works. Breaking: `required_acks: 0` is now genuine fire-and-forget.
- **#595 — leaderless-partition metadata retention.** A partition mid-leader-move is kept in the cluster model instead of dropped, so a key keeps its partition and the partition stays assignable.
- **#596 — consumer fetch retry.** The fetch loop backs off and retries transient/leader-move errors instead of stopping, so a moving leader no longer takes the whole group down; a stuck partition is surfaced via the new `[:kafka_ex, :consumer, :partition_unavailable]` telemetry event.

Together #595 + #596 address the failure mode seen in the MSK 3.7→3.9 rolling-restart incident (2677): kafka_ex 1.1 consumers stayed healthy group members but stopped reading the partitions disturbed by each broker restart, and needed manual pod restarts to recover.

## Diff
- `mix.exs`: `@version "1.1.1"` → `"1.1.2"`
- `CHANGELOG.md`: `## 1.1.2 (unreleased)` → `## 1.1.2 (2026-09-09)`

## Not in this release (known gap)
Consumer **startup** during a leader move is still not resilient: `load_offsets/1` raises if the starting offset can't be read while the leader is moving. The running-consumer path is fixed (#596); the startup path is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
